### PR TITLE
feat: corrected the trial id detection in preprocessing notebook

### DIFF
--- a/preprocessing.ipynb
+++ b/preprocessing.ipynb
@@ -516,10 +516,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we pick just one trial of our session as an example\n",
-    "trial = 4\n",
-    "trial_label = \"trial_\" + str(trial)\n",
-    "aois = sess.stimuli[trial].text_stimulus.aois"
+    "# we pick just one stimulus of our session as an example\n",
+    "stimulus = 4\n",
+    "trial_label = sess.stimuli[stimulus].trial_id\n",
+    "aois = sess.stimuli[stimulus].text_stimulus.aois"
    ]
   },
   {


### PR DESCRIPTION
In the last version, the trial ID was defined incorrectly within the reading measures section. This caused faulty results.
The definition was like this
```
# we pick just one trial of our session as an example
trial = 4
trial_label = "trial_" + str(trial)
aois = sess.stimuli[trial].text_stimulus.aois
```

I corrected this process to use the internal pipeline logic:
```
# we pick just one stimulus of our session as an example
stimulus = 4
trial_label = sess.stimuli[stimulus].trial_id
aois = sess.stimuli[stimulus].text_stimulus.aois
```

That affects:
```
aois_clean = repair_word_labels(aois)
all_tokens = all_tokens_from_aois(aois_clean, trial=trial_label)
```
