### PR TITLE
ci: Build pages workflow for documentation

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v7.3.0
       with:
         enable-cache: true
         cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
+
+      - name: Build documentation
+        run: sphinx-build docs/ public -b dirhtml
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ lint = [
 ]
 docs = [
     "myst-nb>=1.3.0",
+    "sphinx>=8.0.0",
     "sphinx-autobuild>=2025.8.25",
     "sphinx-book-theme>=1.1.4",
     "sphinx-copybutton>=0.5.2",


### PR DESCRIPTION
With the added workflow, the pages would be built on main and ba accessible on `https://thedebbister.github.io/multipleye-preprocessing`. Should this be added in this repo, or somewhere else?