### PR TITLE
tests: Psychometric tests changes

### DIFF
--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -415,7 +415,7 @@ def preprocess_lwmc(lwmc_dir: Path):
     # Each non-NaN in base_text_intertrial.started indicates a new trial boundary.
     df["trial_id"] = df["base_text_intertrial.started"].notna().cumsum()
 
-    df = df[not df["is_practice"]].copy()  # remove all practice trials
+    df = df[~df["is_practice"]].copy()  # remove all practice trials
     if df.empty:
         raise ValueError("No non-practice trials found in WMC CSV")
 

--- a/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
@@ -597,7 +597,6 @@ def test_preprocess_ran_errors(tmp_path: Path, make_text_file, header, body, err
                 "WikiVocab_incorrect_correct_score": 0.5,
                 "WikiVocab_pseudo_correct": 0.5,
                 "WikiVocab_real_correct": 0.5,
-                "WikiVocab_overall_correct": 0.5,
             },
         ),
         (
@@ -615,7 +614,6 @@ def test_preprocess_ran_errors(tmp_path: Path, make_text_file, header, body, err
                 "WikiVocab_incorrect_correct_score": math.nan,
                 "WikiVocab_pseudo_correct": 0.5,
                 "WikiVocab_real_correct": math.nan,
-                "WikiVocab_overall_correct": 0.5,
             },
         ),
     ],


### PR DESCRIPTION
Tests were broken with missing changes back in e53f4cfc4819e4fc4cdc68c2186fc4195f9e406a.