### PR TITLE
chore: use metadata instead of add_columns when calling from_asc()

### DIFF
--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -83,7 +83,7 @@ def load_gaze_data(
             {"pattern": r"stop_recording_", "column": "practice", "value": None},
         ],
         trial_columns=trial_cols,
-        add_columns={"session": session_idf},
+        metadata={"session": session_idf},
     )
 
     # Filter out data outside of trials


### PR DESCRIPTION
I think it's better to use the new `metadata` argument and field for the session identifier as the column will be filled with just a constant value.

The change will probably also have consequences in the remaining pipeline that I didn't check yet.