### PR TITLE
chore: loosen dependencies from `~=` to `>=`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "matplotlib>=3.8.4",
-    "numpy~=1.26.4",
-    "pandas~=2.2.2",
+    "numpy>=1.26.4",
+    "pandas>=2.2.2",
     "pillow==10.4.0",
     "polars>=1.28.1",
     "pymovements",
-    "tqdm~=4.66.4",
+    "tqdm>=4.66.4",
     "openpyxl>=3.0.0",
     "ipykernel>=7.1.0",
     "jupyterlab",


### PR DESCRIPTION
Loosening the upper version bound allows numpy resolve to `2.x.x` and not to max out at `1.26.4`. This is the same for other packages. Users need to do a `uv sync --upgrade` (or `uv sync --upgrade --all-groups --dev`) to upgrade to the newest available versions.

The few tests we have pass, but I have not dedicatedly ran the preprocessing.