### PR TITLE
answers in logfiles are now attribute to correct stimulus

### DIFF
--- a/multipleye_settings_preprocessing.yaml
+++ b/multipleye_settings_preprocessing.yaml
@@ -1,7 +1,8 @@
-data_collection_name: "MultiplEYE_LV_LV_Riga_1_2025"
+data_collection_name: "MultiplEYE_SQ_CH_Zurich_1_2025"
 
 # pick either include or exclude sessions, if none is specified, all sessions are included
 include_sessions:
+  - 006_SQ_CH_1_ET1
 
 
 exclude_sessions:
@@ -14,3 +15,6 @@ expected_sampling_rate_hz: 1000  # Hz
 
 # NOT YET IN USE; IGNORE. if any sessions do not use the standard stimulus version, specify so here
 session_to_stimuli:
+  - "session":
+
+default_stimulus_version:

--- a/preprocessing/checks/et_quality_checks.py
+++ b/preprocessing/checks/et_quality_checks.py
@@ -64,7 +64,6 @@ def check_comprehension_question_answers(
             & (pl.col("stimulus_number") == f"{stimulus.id}")
         )
         answers = stimulus_frame.filter(pl.col("message").str.contains("FINAL ANSWER"))
-        print(answers)
         correct_answers = stimulus_frame.filter(pl.col("message").str.contains("True"))
         overall_correct_answers += len(correct_answers)
         overall_answers += len(answers)

--- a/preprocessing/checks/et_quality_checks.py
+++ b/preprocessing/checks/et_quality_checks.py
@@ -55,15 +55,16 @@ def check_comprehension_question_answers(
     overall_correct_answers = 0
     overall_answers = 0
     for stimulus in stimuli:
-        if stimulus.type == "practice":
-            continue
-
         # get the trial number for the stimulus as rating screens don't have an entry in the stimulus_number column
         trial_id = logfile.filter((pl.col("stimulus_number") == f"{stimulus.id}")).item(
             0, "trial_number"
         )
-        stimulus_frame = logfile.filter((pl.col("trial_number") == f"{trial_id}"))
+        stimulus_frame = logfile.filter(
+            (pl.col("trial_number") == f"{trial_id}")
+            & (pl.col("stimulus_number") == f"{stimulus.id}")
+        )
         answers = stimulus_frame.filter(pl.col("message").str.contains("FINAL ANSWER"))
+        print(answers)
         correct_answers = stimulus_frame.filter(pl.col("message").str.contains("True"))
         overall_correct_answers += len(correct_answers)
         overall_answers += len(answers)

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -15,14 +15,13 @@ def save_raw_data(directory: Path, session: str, data: pm.Gaze) -> None:
 
     new_data = data.clone()
 
-    try:
-        new_data.unnest()
-    except Warning:
-        pass
-
     trials = new_data.split(by="trial", as_dict=False)
 
     for trial in trials:
+        try:
+            trial.unnest()
+        except Warning:
+            pass
         df = trial.frame
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]

--- a/preprocessing/scripts/run_multipleye_preprocessing.py
+++ b/preprocessing/scripts/run_multipleye_preprocessing.py
@@ -112,7 +112,7 @@ def run_multipleye_preprocessing(config_path: str):
 
             preprocessing.save_events_data(
                 "fixation",
-                fixation_data_folder,
+                constants.OUTPUT_DIR,
                 session_save_name,
                 "trial",
                 ["trial", "stimulus"],
@@ -122,7 +122,7 @@ def run_multipleye_preprocessing(config_path: str):
 
             preprocessing.save_events_data(
                 "saccade",
-                saccade_data_folder,
+                constants.OUTPUT_DIR,
                 session_save_name,
                 "trial",
                 ["trial", "stimulus"],

--- a/templates_and_notes/high-level-TODOs
+++ b/templates_and_notes/high-level-TODOs
@@ -7,3 +7,7 @@ sanity checks:
   -
 - TESTS!!!
 	- the ones that are there atm were just a first draft
+
+
+- integrate loading of the stimuli into the session object at init
+- make sure naming is correct


### PR DESCRIPTION
Previously, the practice trial answers were accidentally added to one of the core trials. This hase been fixed. The sanity check report now lists all answers separately for practice and normal trials. 