### PR TITLE
chore(logs): Improve psych test warnings

### DIFF
--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -288,7 +288,11 @@ def preprocess_stroop(stroop_flanker_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if stroop_flanker_dir.is_absolute() and psym_dir.is_absolute() and stroop_flanker_dir.is_relative_to(psym_dir):
+            if (
+                stroop_flanker_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and stroop_flanker_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(stroop_flanker_dir.relative_to(psym_dir))
             else:
                 display_path = stroop_flanker_dir.name
@@ -296,6 +300,7 @@ def preprocess_stroop(stroop_flanker_dir: Path):
             display_path = stroop_flanker_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         # Filter out common non-file strings
@@ -369,7 +374,11 @@ def preprocess_flanker(stroop_flanker_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if stroop_flanker_dir.is_absolute() and psym_dir.is_absolute() and stroop_flanker_dir.is_relative_to(psym_dir):
+            if (
+                stroop_flanker_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and stroop_flanker_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(stroop_flanker_dir.relative_to(psym_dir))
             else:
                 display_path = stroop_flanker_dir.name
@@ -377,6 +386,7 @@ def preprocess_flanker(stroop_flanker_dir: Path):
             display_path = stroop_flanker_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         if files_checked:
@@ -466,7 +476,11 @@ def preprocess_lwmc(lwmc_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if lwmc_dir.is_absolute() and psym_dir.is_absolute() and lwmc_dir.is_relative_to(psym_dir):
+            if (
+                lwmc_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and lwmc_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(lwmc_dir.relative_to(psym_dir))
             else:
                 display_path = lwmc_dir.name
@@ -474,6 +488,7 @@ def preprocess_lwmc(lwmc_dir: Path):
             display_path = lwmc_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         if files_checked:
@@ -615,7 +630,11 @@ def preprocess_ran(ran_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if ran_dir.is_absolute() and psym_dir.is_absolute() and ran_dir.is_relative_to(psym_dir):
+            if (
+                ran_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and ran_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(ran_dir.relative_to(psym_dir))
             else:
                 display_path = ran_dir.name
@@ -623,6 +642,7 @@ def preprocess_ran(ran_dir: Path):
             display_path = ran_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         if files_checked:
@@ -695,7 +715,11 @@ def preprocess_wikivocab(wv_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if wv_dir.is_absolute() and psym_dir.is_absolute() and wv_dir.is_relative_to(psym_dir):
+            if (
+                wv_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and wv_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(wv_dir.relative_to(psym_dir))
             else:
                 display_path = wv_dir.name
@@ -703,6 +727,7 @@ def preprocess_wikivocab(wv_dir: Path):
             display_path = wv_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         if files_checked:
@@ -744,7 +769,11 @@ def preprocess_wikivocab(wv_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if wv_dir.is_absolute() and psym_dir.is_absolute() and wv_dir.is_relative_to(psym_dir):
+            if (
+                wv_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and wv_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(wv_dir.relative_to(psym_dir))
             else:
                 display_path = wv_dir.name
@@ -752,6 +781,7 @@ def preprocess_wikivocab(wv_dir: Path):
             display_path = wv_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         if files_checked:
@@ -811,7 +841,11 @@ def preprocess_plab(plab_dir: Path):
         # Determine display path for the outer error message
         try:
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if plab_dir.is_absolute() and psym_dir.is_absolute() and plab_dir.is_relative_to(psym_dir):
+            if (
+                plab_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and plab_dir.is_relative_to(psym_dir)
+            ):
                 display_path = str(plab_dir.relative_to(psym_dir))
             else:
                 display_path = plab_dir.name
@@ -819,6 +853,7 @@ def preprocess_plab(plab_dir: Path):
             display_path = plab_dir.name
 
         import re
+
         see_also = ""
         files_checked = re.findall(r"'([^']+)'", str(err))
         if files_checked:
@@ -1002,7 +1037,11 @@ def _find_one_filetype_with_columns(
         else:
             # Fallback: if folder is inside settings.PSYCHOMETRIC_TESTS_DIR, use that
             psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
-            if folder.is_absolute() and psym_dir.is_absolute() and folder.is_relative_to(psym_dir):
+            if (
+                folder.is_absolute()
+                and psym_dir.is_absolute()
+                and folder.is_relative_to(psym_dir)
+            ):
                 display_path = str(folder.relative_to(psym_dir))
             else:
                 display_path = folder.name

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -97,7 +97,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["LWMC_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process LWMC test for {session.stem}: {str(err)}",
+                    f"[{session.name}] LWMC test skipped: {str(err)}",
                     category=UserWarning,
                 )
 
@@ -113,7 +113,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["RAN_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process RAN test for {session.stem}: {str(err)}",
+                    f"[{session.name}] RAN test skipped: {str(err)}",
                     category=UserWarning,
                 )
 
@@ -136,7 +136,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["Stroop_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process Stroop test for {session.stem}: {str(err)}",
+                    f"[{session.name}] Stroop test skipped: {str(err)}",
                     category=UserWarning,
                 )
             try:
@@ -157,13 +157,13 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["Flanker_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process Flanker test for {session.stem}: {str(err)}",
+                    f"[{session.name}] Flanker test skipped: {str(err)}",
                     category=UserWarning,
                 )
                 overview_row["Flanker_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process Flanker test for {session.stem}: {str(err)}",
+                    f"[{session.name}] Flanker test skipped: {str(err)}",
                     category=UserWarning,
                 )
 
@@ -185,7 +185,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["WikiVocab_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process WikiVocab test for {session.stem}: {str(err)}",
+                    f"[{session.name}] WikiVocab test skipped: {str(err)}",
                     category=UserWarning,
                 )
 
@@ -200,7 +200,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["PLAB_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"Failed to process PLAB test for {session.stem}: {str(err)}",
+                    f"[{session.name}] PLAB test skipped: {str(err)}",
                     category=UserWarning,
                 )
 
@@ -278,11 +278,39 @@ def preprocess_stroop(stroop_flanker_dir: Path):
         'Stroop_congruent_num_items', 'Stroop_neutral_rt_mean_sec', 'Stroop_neutral_accuracy',
         and 'Stroop_neutral_num_items'.
     """
-    df = _find_one_filetype_with_columns(
-        stroop_flanker_dir,
-        ["stim_type", "stroop_key.rt", "stroop_key.corr"],
-        allow_nan=True,
-    )
+    try:
+        df = _find_one_filetype_with_columns(
+            stroop_flanker_dir,
+            ["stim_type", "stroop_key.rt", "stroop_key.corr"],
+            allow_nan=True,
+        )
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if stroop_flanker_dir.is_absolute() and psym_dir.is_absolute() and stroop_flanker_dir.is_relative_to(psym_dir):
+                display_path = str(stroop_flanker_dir.relative_to(psym_dir))
+            else:
+                display_path = stroop_flanker_dir.name
+        except (ValueError, AttributeError):
+            display_path = stroop_flanker_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        # Filter out common non-file strings
+        if files_checked:
+            # Only include names that look like CSVs
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"Stroop results missing or incomplete in '{display_path}'. "
+            f"The script couldn't find a valid results file with stimulus and response data. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
     result_df = _reaction_time_accuracy(
         df,
         reaction_time_col="stroop_key.rt",
@@ -331,11 +359,37 @@ def preprocess_flanker(stroop_flanker_dir: Path):
         'Flanker_incongruent_num_items', 'Flanker_congruent_rt_mean', 'Flanker_congruent_accuracy',
         and 'Flanker_congruent_num_items'.
     """
-    df = _find_one_filetype_with_columns(
-        stroop_flanker_dir,
-        ["stim_type", "Flanker_key.rt", "Flanker_key.corr"],
-        allow_nan=True,
-    )
+    try:
+        df = _find_one_filetype_with_columns(
+            stroop_flanker_dir,
+            ["stim_type", "Flanker_key.rt", "Flanker_key.corr"],
+            allow_nan=True,
+        )
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if stroop_flanker_dir.is_absolute() and psym_dir.is_absolute() and stroop_flanker_dir.is_relative_to(psym_dir):
+                display_path = str(stroop_flanker_dir.relative_to(psym_dir))
+            else:
+                display_path = stroop_flanker_dir.name
+        except (ValueError, AttributeError):
+            display_path = stroop_flanker_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        if files_checked:
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"Flanker results missing or incomplete in '{display_path}'. "
+            f"The script couldn't find a valid results file with stimulus and response data. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
     result_df = _reaction_time_accuracy(
         df,
         reaction_time_col="Flanker_key.rt",
@@ -406,7 +460,33 @@ def preprocess_lwmc(lwmc_dir: Path):
         "ss_key_resp_recall.corr",
         "ss_key_resp_recall.rt",  # SS columns
     ]
-    df = _find_one_filetype_with_columns(lwmc_dir, required_cols, allow_nan=True)
+    try:
+        df = _find_one_filetype_with_columns(lwmc_dir, required_cols, allow_nan=True)
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if lwmc_dir.is_absolute() and psym_dir.is_absolute() and lwmc_dir.is_relative_to(psym_dir):
+                display_path = str(lwmc_dir.relative_to(psym_dir))
+            else:
+                display_path = lwmc_dir.name
+        except (ValueError, AttributeError):
+            display_path = lwmc_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        if files_checked:
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"LWMC (Working Memory Capacity) results missing or incomplete in '{display_path}'. "
+            f"The script couldn't find a valid results file with recall and timing data. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
 
     # Create a trial identifier using the inter-trial text onset markers
     # Each non-NaN in base_text_intertrial.started indicates a new trial boundary.
@@ -527,9 +607,34 @@ def preprocess_ran(ran_dir: Path):
     ValueError
         If not exactly one .csv file is found in the directory.
     """
-    df = _find_one_filetype_with_columns(
-        ran_dir, ["Trial", "Reading_Time"], allow_nan=False
-    )
+    try:
+        df = _find_one_filetype_with_columns(
+            ran_dir, ["Trial", "Reading_Time"], allow_nan=False
+        )
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if ran_dir.is_absolute() and psym_dir.is_absolute() and ran_dir.is_relative_to(psym_dir):
+                display_path = str(ran_dir.relative_to(psym_dir))
+            else:
+                display_path = ran_dir.name
+        except (ValueError, AttributeError):
+            display_path = ran_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        if files_checked:
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"RAN (Rapid Naming) results missing or incomplete in '{display_path}'. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
 
     # Extract practice and experimental trial reaction times
     practice_rt = df[df["Trial"] == 1]["Reading_Time"]
@@ -582,9 +687,34 @@ def preprocess_wikivocab(wv_dir: Path):
         - WikiVocab_pseudo_correct: Fraction of correct pseudo words
         - WikiVocab_real_correct: Fraction of correct real words
     """
-    df = _find_one_filetype_with_columns(
-        wv_dir, ["correct_answer", "real_answer", "RT"], allow_nan=False
-    )
+    try:
+        df = _find_one_filetype_with_columns(
+            wv_dir, ["correct_answer", "real_answer", "RT"], allow_nan=False
+        )
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if wv_dir.is_absolute() and psym_dir.is_absolute() and wv_dir.is_relative_to(psym_dir):
+                display_path = str(wv_dir.relative_to(psym_dir))
+            else:
+                display_path = wv_dir.name
+        except (ValueError, AttributeError):
+            display_path = wv_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        if files_checked:
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"WikiVocab results missing or incomplete in '{display_path}'. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
     df["correctness"] = df["correct_answer"] == df["real_answer"]
 
     # Calculate additional metrics
@@ -606,9 +736,34 @@ def preprocess_wikivocab(wv_dir: Path):
     # Calculate incorrect_correct score
     incorrect_correct = (real_correct + pseudo_correct) / 2
 
-    rt_acc = _reaction_time_accuracy(
-        df, reaction_time_col="RT", correctness_col="correctness"
-    )
+    try:
+        rt_acc = _reaction_time_accuracy(
+            df, reaction_time_col="RT", correctness_col="correctness"
+        )
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if wv_dir.is_absolute() and psym_dir.is_absolute() and wv_dir.is_relative_to(psym_dir):
+                display_path = str(wv_dir.relative_to(psym_dir))
+            else:
+                display_path = wv_dir.name
+        except (ValueError, AttributeError):
+            display_path = wv_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        if files_checked:
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"WikiVocab results missing or incomplete in '{display_path}'. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
 
     return {
         "WikiVocab_rt_mean_sec": rt_acc[0],
@@ -648,9 +803,35 @@ def preprocess_plab(plab_dir: Path):
         Dictionary with keys 'PLAB_rt_mean_sec', 'PLAB_accuracy', and 'PLAB_num_items'.
 
     """
-    df = _find_one_filetype_with_columns(
-        plab_dir, ["rt", "correctness"], allow_nan=True
-    )
+    try:
+        df = _find_one_filetype_with_columns(
+            plab_dir, ["rt", "correctness"], allow_nan=True
+        )
+    except ValueError as err:
+        # Determine display path for the outer error message
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if plab_dir.is_absolute() and psym_dir.is_absolute() and plab_dir.is_relative_to(psym_dir):
+                display_path = str(plab_dir.relative_to(psym_dir))
+            else:
+                display_path = plab_dir.name
+        except (ValueError, AttributeError):
+            display_path = plab_dir.name
+
+        import re
+        see_also = ""
+        files_checked = re.findall(r"'([^']+)'", str(err))
+        if files_checked:
+            csv_files = [f for f in files_checked if f.endswith(".csv")]
+            if csv_files:
+                see_also = f" See '{display_path}/" + "', '".join(csv_files) + "'."
+
+        raise ValueError(
+            f"PLAB results missing or incomplete in '{display_path}'. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
+            f"\nDetail: {err}"
+        ) from err
+
     rt_mean, accuracy, num_items = _reaction_time_accuracy(
         df, reaction_time_col="rt", correctness_col="correctness"
     )
@@ -781,7 +962,7 @@ def __validate_rt_acc_inputs(
 
 
 def _find_one_filetype_with_columns(
-    folder: Path, columns: list[str], allow_nan=False
+    folder: Path, columns: list[str], allow_nan=False, base_path: Path | None = None
 ) -> DataFrame:
     """Find a single CSV file containing specific columns and return it as DataFrame.
 
@@ -797,6 +978,8 @@ def _find_one_filetype_with_columns(
         List of column names that must be present in the CSV.
     allow_nan : bool, optional
         If True, allows NaN values in the ``columns`` asked for. Default is False.
+    base_path : Path, optional
+        If provided, the folder path in error messages will be relative to this path.
 
     Returns
     -------
@@ -811,28 +994,64 @@ def _find_one_filetype_with_columns(
         If NaN values are found in required columns and ``allow_nan`` is False.
     """
     csvs = list(folder.glob("*.csv"))
+
+    # Determine the folder path to show in error messages
+    try:
+        if base_path and folder.is_absolute() and base_path.is_absolute():
+            display_path = str(folder.relative_to(base_path))
+        else:
+            # Fallback: if folder is inside settings.PSYCHOMETRIC_TESTS_DIR, use that
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if folder.is_absolute() and psym_dir.is_absolute() and folder.is_relative_to(psym_dir):
+                display_path = str(folder.relative_to(psym_dir))
+            else:
+                display_path = folder.name
+    except (ValueError, AttributeError, RuntimeError):
+        display_path = folder.name
+
     if not csvs:
-        raise ValueError(f"No .csv files found in {folder}")
+        raise ValueError(f"No CSV files were found in '{display_path}'.")
 
     valid_csvs = []
+    missing_cols_info = {}
     for csv in csvs:
         # Only read the header to check columns
         try:
-            if all(col in read_csv(csv, nrows=0).columns for col in columns):
+            cols_found = read_csv(csv, nrows=0).columns
+            missing = [col for col in columns if col not in cols_found]
+            if not missing:
                 valid_csvs.append(csv)
-        except UserWarning:
+            else:
+                missing_cols_info[csv.name] = missing
+        except Exception:
             continue
 
     if not valid_csvs:
-        raise ValueError(f"No .csv files with columns {columns} found in {folder}")
-    if len(valid_csvs) > 1:
+        details = ""
+        if missing_cols_info:
+            details = "\nChecked: " + ", ".join(
+                f"'{f}'" for f in missing_cols_info.keys()
+            )
         raise ValueError(
-            f"Multiple .csv files with columns {columns} found in {folder}"
+            f"No CSV files with the required columns {columns} were found in '{display_path}'.{details}"
+        )
+
+    if len(valid_csvs) > 1:
+        valid_csvs_sorted = sorted([f.name for f in valid_csvs])
+        raise ValueError(
+            f"Multiple CSV files with the required columns {columns} were found in '{display_path}': "
+            f"{valid_csvs_sorted}. Please ensure only one valid results file is present."
         )
 
     df = read_csv(valid_csvs[0], usecols=columns)
-    if not allow_nan and df.isna().any().any():
+    if df.empty:
         raise ValueError(
-            f"NaN values found in required columns {columns} in {valid_csvs[0]}"
+            f"The data file '{valid_csvs[0].name}' was found but contains no data rows."
+        )
+
+    if not allow_nan and df.isna().any().any():
+        nan_cols = df.columns[df.isna().any()].tolist()
+        raise ValueError(
+            f"Required columns {nan_cols} in '{valid_csvs[0].name}' contain missing values (NaN)."
         )
     return df

--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -105,7 +105,25 @@ def setup_logging(
         logging.CRITICAL: "\033[1;41m",  # Bold on red background
     }
 
-    class ColorFormatter(logging.Formatter):
+    class ShortPathFormatter(logging.Formatter):
+        """Formatter that shortens absolute paths in the message to project-relative ones."""
+
+        def format(self, record: logging.LogRecord) -> str:
+            if record.name == "py.warnings":
+                # Shorten full paths to project-relative paths or filename
+                msg = record.getMessage()
+                project_root = str(Path(__file__).parent.parent.parent)
+                if project_root in msg:
+                    msg = msg.replace(project_root, "").lstrip("/")
+
+                # Remove trailing warnings.warn(...) and newline
+                if "\n  warnings.warn(" in msg:
+                    msg = msg.split("\n  warnings.warn(")[0]
+
+                record.msg = msg
+            return super().format(record)
+
+    class ColorFormatter(ShortPathFormatter):
         def format(self, record: logging.LogRecord) -> str:
             color = COLORS.get(record.levelno, "")
             # Emphasise captured warnings specifically
@@ -125,13 +143,13 @@ def setup_logging(
     console_handler.setFormatter(ColorFormatter(base_format))
     handlers.append(console_handler)
 
-    # File handler (plain formatter)
+    # File handler (plain formatter with short paths)
     if log_file:
         log_file = Path(log_file)
         log_file.parent.mkdir(parents=True, exist_ok=True)
         file_handler = logging.FileHandler(log_file, encoding="utf-8")
         file_handler.setLevel(resolved_file_level)
-        file_handler.setFormatter(logging.Formatter(base_format))
+        file_handler.setFormatter(ShortPathFormatter(base_format))
         handlers.append(file_handler)
 
     logging.basicConfig(

--- a/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from numpy import float64
 
+from preprocessing.config import settings
 from preprocessing.psychometric_tests.preprocess_psychometric_tests import (
     _reaction_time_accuracy,
     _find_one_filetype_with_columns,
@@ -270,32 +271,32 @@ def test__reaction_time_accuracy_grouped_missing_column(group_by_col, expect_err
             [],
             ["a"],
             False,
-            "No .csv files found",
+            "No CSV files were found",
             None,
         ),
-        # CSV present but missing columns -> ValueError starting with "No CSV files with columns"
+        # CSV present but missing columns -> ValueError with details
         (
             [("bad.csv", "x,y\n", "1,2\n")],
             ["a"],
             False,
-            "No .csv files with columns",
+            r"No CSV files with the required columns \['a'\] were found in 'session'.\n'bad.csv' is missing \['a'\]",
             None,
         ),
-        # Multiple CSVs that both match -> ValueError starting with "Multiple CSV files with columns"
+        # Multiple CSVs that both match -> ValueError with file names
         (
             [("a1.csv", "u,v\n", "1,2\n"), ("a2.csv", "u,v,w\n", "3,4,5\n")],
             ["u", "v"],
             False,
-            "Multiple .csv files with columns",
+            r"Multiple CSV files with the required columns \['u', 'v'\] were found in 'session': \['a1.csv', 'a2.csv'\]",
             None,
         ),
-        # Header-only CSV that has the required columns -> returns empty DataFrame with those columns
+        # Header-only CSV that has the required columns -> ValueError (no data rows)
         (
             [("empty.csv", "m,n\n", "")],
             ["m", "n"],
             False,
+            "was found but contains no data rows",
             None,
-            lambda df: list(df.columns) == ["m", "n"] and df.shape == (0, 2),
         ),
         # Multiple CSVs that partially match, only one exactly -> returns DataFrame
         (
@@ -318,7 +319,7 @@ def test__reaction_time_accuracy_grouped_missing_column(group_by_col, expect_err
             [("nan.csv", "a,b\n", "1,NaN\n")],
             ["a", "b"],
             False,
-            "NaN values found in required columns",
+            "Required columns .* contain missing values",
             None,
         ),
     ],
@@ -326,12 +327,16 @@ def test__reaction_time_accuracy_grouped_missing_column(group_by_col, expect_err
 def test__find_one_filetype_with_columns(
     tmp_path: Path,
     make_text_file,
+    monkeypatch,
     files,
     required_cols,
     allow_nan,
     expect_error_msg,
     check,
 ):
+    # Mock settings.PSYCHOMETRIC_TESTS_DIR to tmp_path
+    monkeypatch.setattr(settings, "PSYCHOMETRIC_TESTS_DIR", tmp_path)
+
     # Prepare folder with CSVs
     folder = tmp_path / "session"
     folder.mkdir()
@@ -431,8 +436,8 @@ def test_preprocess_stroop_errors(
 ):
     folder = tmp_path / "p1" / "SF"
     make_text_file(folder / "data.csv", header=header, body=body)
-    if error_msg.startswith("No .csv files with columns"):
-        with pytest.raises(ValueError, match="No .csv files with columns"):
+    if "No CSV files with columns" in error_msg or "No .csv files with columns" in error_msg or "Stroop results missing" in error_msg:
+        with pytest.raises(ValueError, match="Stroop results missing"):
             preprocess_stroop(folder)
     else:
         with pytest.raises(ValueError, match=error_msg):
@@ -492,8 +497,8 @@ def test_preprocess_flanker_errors(
 ):
     folder = tmp_path / "p2" / "SF"
     make_text_file(folder / "data.csv", header=header, body=body)
-    if error_msg.startswith("No .csv files with columns"):
-        with pytest.raises(ValueError, match="No .csv files with columns"):
+    if "No CSV files with columns" in error_msg or "No .csv files with columns" in error_msg or "Flanker results missing" in error_msg:
+        with pytest.raises(ValueError, match="Flanker results missing"):
             preprocess_flanker(folder)
     else:
         with pytest.raises(ValueError, match=error_msg):
@@ -521,7 +526,7 @@ def test_preprocess_plab_basic(tmp_path: Path, make_text_file, rows, expected):
 @pytest.mark.parametrize(
     "header, body, error_msg",
     [
-        ("rt,corr\n", "100,1\n", "No .csv files with columns"),
+        ("rt,corr\n", "100,1\n", "No CSV files with the required columns"),
         (
             "rt,correctness\n",
             ",1\n",
@@ -539,8 +544,8 @@ def test_preprocess_plab_errors(
 ):
     folder = tmp_path / "p3" / "PLAB"
     make_text_file(folder / "plab.csv", header=header, body=body)
-    if error_msg.startswith("No .csv files with columns"):
-        with pytest.raises(ValueError, match="No .csv files with columns"):
+    if "No CSV files with the required columns" in error_msg or "PLAB results missing" in error_msg:
+        with pytest.raises(ValueError, match="PLAB results missing"):
             preprocess_plab(folder)
     else:
         with pytest.raises(ValueError, match=error_msg):
@@ -561,10 +566,10 @@ def test_preprocess_ran_basic(tmp_path: Path, make_text_file):
 @pytest.mark.parametrize(
     "header, body, error_msg",
     [
-        ("Trial,RT\n", "1,2\n", "No .csv files with columns"),
+        ("Trial,RT\n", "1,2\n", "No CSV files with the required columns"),
         ("Trial,Reading_Time\n", "1,\n", "NaN values found in required columns"),
         # Multiple files with required columns
-        ("Trial,Reading_Time\n", "1,2\n", "Multiple .csv files with columns"),
+        ("Trial,Reading_Time\n", "1,2\n", "Multiple CSV files with the required columns"),
     ],
 )
 def test_preprocess_ran_errors(tmp_path: Path, make_text_file, header, body, error_msg):
@@ -573,8 +578,13 @@ def test_preprocess_ran_errors(tmp_path: Path, make_text_file, header, body, err
     make_text_file(folder / "ran1.csv", header=header, body=body)
     if error_msg.startswith("Multiple"):
         make_text_file(folder / "ran2.csv", header=header, body=body)
-    with pytest.raises(ValueError, match=error_msg):
-        preprocess_ran(folder)
+    # The wrapper adds more context, so we match the wrapper's prefix
+    if "No CSV files with the required columns" in error_msg or "RAN results missing" in error_msg or "Multiple CSV files with the required columns" in error_msg or "NaN values found" in error_msg:
+        with pytest.raises(ValueError, match=r"RAN \(Rapid Naming\) results missing"):
+            preprocess_ran(folder)
+    else:
+        with pytest.raises(ValueError, match=error_msg):
+            preprocess_ran(folder)
 
 
 @pytest.mark.parametrize(
@@ -658,11 +668,14 @@ def test_preprocess_wikivocab_errors(
     folder = tmp_path / "p5" / "WV"
     make_text_file(folder / "wv.csv", header=header, body=body)
     if (
-        error_msg.startswith("No .csv files with columns")
-        or error_msg.startswith("NaN values found")
-        or error_msg.startswith("Reaction time column contains")
+        "No CSV files with the required columns" in error_msg
+        or "WikiVocab results missing" in error_msg
+        or "NaN values found" in error_msg
+        or "Required columns" in error_msg
+        or "Reaction time column contains" in error_msg
     ):
-        with pytest.raises(ValueError, match=error_msg):
+        # The wrapper adds more context, so we match the wrapper's prefix
+        with pytest.raises(ValueError, match="WikiVocab results missing"):
             preprocess_wikivocab(folder)
     else:
         # In this case, CSV loads but reaction time accuracy validation triggers

--- a/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
@@ -279,7 +279,7 @@ def test__reaction_time_accuracy_grouped_missing_column(group_by_col, expect_err
             [("bad.csv", "x,y\n", "1,2\n")],
             ["a"],
             False,
-            r"No CSV files with the required columns \['a'\] were found in 'session'.\n'bad.csv' is missing \['a'\]",
+            r"No CSV files with the required columns \['a'\] were found in 'session'.\nChecked: 'bad.csv'",
             None,
         ),
         # Multiple CSVs that both match -> ValueError with file names
@@ -436,7 +436,11 @@ def test_preprocess_stroop_errors(
 ):
     folder = tmp_path / "p1" / "SF"
     make_text_file(folder / "data.csv", header=header, body=body)
-    if "No CSV files with columns" in error_msg or "No .csv files with columns" in error_msg or "Stroop results missing" in error_msg:
+    if (
+        "No CSV files with columns" in error_msg
+        or "No .csv files with columns" in error_msg
+        or "Stroop results missing" in error_msg
+    ):
         with pytest.raises(ValueError, match="Stroop results missing"):
             preprocess_stroop(folder)
     else:
@@ -497,7 +501,11 @@ def test_preprocess_flanker_errors(
 ):
     folder = tmp_path / "p2" / "SF"
     make_text_file(folder / "data.csv", header=header, body=body)
-    if "No CSV files with columns" in error_msg or "No .csv files with columns" in error_msg or "Flanker results missing" in error_msg:
+    if (
+        "No CSV files with columns" in error_msg
+        or "No .csv files with columns" in error_msg
+        or "Flanker results missing" in error_msg
+    ):
         with pytest.raises(ValueError, match="Flanker results missing"):
             preprocess_flanker(folder)
     else:
@@ -544,7 +552,10 @@ def test_preprocess_plab_errors(
 ):
     folder = tmp_path / "p3" / "PLAB"
     make_text_file(folder / "plab.csv", header=header, body=body)
-    if "No CSV files with the required columns" in error_msg or "PLAB results missing" in error_msg:
+    if (
+        "No CSV files with the required columns" in error_msg
+        or "PLAB results missing" in error_msg
+    ):
         with pytest.raises(ValueError, match="PLAB results missing"):
             preprocess_plab(folder)
     else:
@@ -569,7 +580,11 @@ def test_preprocess_ran_basic(tmp_path: Path, make_text_file):
         ("Trial,RT\n", "1,2\n", "No CSV files with the required columns"),
         ("Trial,Reading_Time\n", "1,\n", "NaN values found in required columns"),
         # Multiple files with required columns
-        ("Trial,Reading_Time\n", "1,2\n", "Multiple CSV files with the required columns"),
+        (
+            "Trial,Reading_Time\n",
+            "1,2\n",
+            "Multiple CSV files with the required columns",
+        ),
     ],
 )
 def test_preprocess_ran_errors(tmp_path: Path, make_text_file, header, body, error_msg):
@@ -579,7 +594,12 @@ def test_preprocess_ran_errors(tmp_path: Path, make_text_file, header, body, err
     if error_msg.startswith("Multiple"):
         make_text_file(folder / "ran2.csv", header=header, body=body)
     # The wrapper adds more context, so we match the wrapper's prefix
-    if "No CSV files with the required columns" in error_msg or "RAN results missing" in error_msg or "Multiple CSV files with the required columns" in error_msg or "NaN values found" in error_msg:
+    if (
+        "No CSV files with the required columns" in error_msg
+        or "RAN results missing" in error_msg
+        or "Multiple CSV files with the required columns" in error_msg
+        or "NaN values found" in error_msg
+    ):
         with pytest.raises(ValueError, match=r"RAN \(Rapid Naming\) results missing"):
             preprocess_ran(folder)
     else:


### PR DESCRIPTION
This PR improves the error messages of the psychometric tests.

Before:
> 2026-04-13 12:02:20,319 - py.warnings - PYWARN:WARNING - ~/code/multipleye-preprocessing/preprocessing/psychometric_tests/preprocess_psychometric_tests.py:138: UserWarning: Failed to process Stroop test for 001_SQ_CH_1_PT2: No .csv files with columns ['stim_type', 'stroop_key.rt', 'stroop_key.corr'] found in ~/code/multipleye-preprocessing/data/MultiplEYE_SQ_CH_Zurich_1_2025/psychometric-tests-sessions/001_SQ_CH_1_PT2/Stroop_Flanker
>   warnings.warn(

  
After:
> 2026-04-13 18:17:45,432 - py.warnings - PYWARN:WARNING - preprocessing/psychometric_tests/preprocess_psychometric_tests.py:138: UserWarning: [001_SQ_CH_1_PT2] Stroop test skipped: Stroop results missing or incomplete in '001_SQ_CH_1_PT2/Stroop_Flanker'. The script couldn't find a valid results file with stimulus and response data. Please check if the experiment was interrupted or if the data was recorded correctly. See '001_SQ_CH_1_PT2/Stroop_Flanker/SQCH1_001_PT2_2025-09-08_12-35-53.csv'.                                                                                                                  
> Detail: No CSV files with the required columns ['stim_type', 'stroop_key.rt', 'stroop_key.corr'] were found in '001_SQ_CH_1_PT2/Stroop_Flanker'.                                                                                                                                                                
> Checked: 'SQCH1_001_PT2_2025-09-08_12-35-53.csv'
