### PR TITLE
chore: add automated CalVer release workflow

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v7.3.0
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
@@ -28,10 +28,10 @@ jobs:
         run: uv run sphinx-build docs/ public -b dirhtml
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Automated CalVer Release
 on:
   schedule:
     - cron: '0 23 * * *'  # Run nightly at 23:00 UTC
-  workflow_dispatch:  # TODO: Remove before merging to main
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Automated CalVer Release
+
+on:
+  schedule:
+    - cron: '0 23 * * *'  # Run nightly at 23:00 UTC
+  workflow_dispatch:  # TODO: Remove before merging to main
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'MultiplEYE-COST'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Get Today's Date
+        id: date
+        run: echo "today=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
+
+      - name: Check if Tag Exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.date.outputs.today }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if Release Already Exists
+        if: steps.check_tag.outputs.exists == 'true'
+        run: |
+          echo "Release v${{ steps.date.outputs.today }} already exists. Skipping."
+
+      - name: Update Version Files
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          python preprocessing/scripts/sync_version.py --set-version ${{ steps.date.outputs.today }}
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .
+          if ! git diff --cached --exit-code; then
+            git commit -m "chore: bump version to ${{ steps.date.outputs.today }}"
+            git push origin ${{ github.ref_name }}
+          fi
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ steps.date.outputs.today }}
+          name: Release ${{ steps.date.outputs.today }}
+          generate_release_notes: true
+          body: |
+            Automated CalVer release for ${{ steps.date.outputs.today }}.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,27 +24,8 @@ repos:
   - repo: local
     hooks:
       - id: update-version
-        name: Update package version in CITATION.cff and docs/conf.py
-        entry: >
-          sh -c 'if command -v pwsh >/dev/null 2>&1 || [ "$0" = "pwsh" ]; then
-              echo "Skipping in PowerShell";
-          else
-              os_type=$(uname) &&
-              if [ "$os_type" = "Darwin" ]; then
-                  version=$(awk -F "\"" "/version =/ {print \$2}" pyproject.toml) &&
-                  sed -i "" "s/^version: .*/version: $version/" CITATION.cff &&
-                  sed -i "" "s/^version = .*/version = \"$version\"/" docs/conf.py &&
-                  sed -i "" "s/^release = .*/release = \"$version\"/" docs/conf.py;
-              elif [ "$os_type" = "Linux" ]; then
-                  version=$(grep -oP "(?<=version = \")[^\"]+" pyproject.toml) &&
-                  sed -i "s/^version: .*/version: $version/" CITATION.cff &&
-                  sed -i "s/^version = .*/version = \"$version\"/" docs/conf.py &&
-                  sed -i "s/^release = .*/release = \"$version\"/" docs/conf.py;
-              else
-                  echo "Unsupported OS type: $os_type";
-                  exit 1;
-              fi
-          fi'
-        language: system
+        name: Sync and Validate Version
+        entry: python preprocessing/scripts/sync_version.py
+        language: python
         files: 'CITATION\.cff|pyproject\.toml|docs/conf\.py'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,30 @@ repos:
       # Run the linter.
       - id: ruff-check
         args: [ --fix ]
+  - repo: local
+    hooks:
+      - id: update-version
+        name: Update package version in CITATION.cff and docs/conf.py
+        entry: >
+          sh -c 'if command -v pwsh >/dev/null 2>&1 || [ "$0" = "pwsh" ]; then
+              echo "Skipping in PowerShell";
+          else
+              os_type=$(uname) &&
+              if [ "$os_type" = "Darwin" ]; then
+                  version=$(awk -F "\"" "/version =/ {print \$2}" pyproject.toml) &&
+                  sed -i "" "s/^version: .*/version: $version/" CITATION.cff &&
+                  sed -i "" "s/^version = .*/version = \"$version\"/" docs/conf.py &&
+                  sed -i "" "s/^release = .*/release = \"$version\"/" docs/conf.py;
+              elif [ "$os_type" = "Linux" ]; then
+                  version=$(grep -oP "(?<=version = \")[^\"]+" pyproject.toml) &&
+                  sed -i "s/^version: .*/version: $version/" CITATION.cff &&
+                  sed -i "s/^version = .*/version = \"$version\"/" docs/conf.py &&
+                  sed -i "s/^release = .*/release = \"$version\"/" docs/conf.py;
+              else
+                  echo "Unsupported OS type: $os_type";
+                  exit 1;
+              fi
+          fi'
+        language: system
+        files: 'CITATION\.cff|pyproject\.toml|docs/conf\.py'
+        pass_filenames: false

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ authors:
 - family-names: "J{\"a}ger"
   given-names: "Lena A."
 title: "The MultiplEYE preprocessing pipeline"
-version: 0.2.0
+version: 2026.05.22
 url: "https://github.com/MultiplEYE-COST/multipleye-preprocessing/"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,4 +16,5 @@ authors:
 - family-names: "J{\"a}ger"
   given-names: "Lena A."
 title: "The MultiplEYE preprocessing pipeline"
+version: 0.2.0
 url: "https://github.com/MultiplEYE-COST/multipleye-preprocessing/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ from datetime import datetime
 project = "MultiplEYE Preprocessing pEYEpline"
 copyright = f"2024–{datetime.now().year}, Deborah N. Jakobi et al"
 author = "Deborah N. Jakobi et al."
-release = "0.2.0"
+release = "2026.05.22"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ from datetime import datetime
 project = "MultiplEYE Preprocessing pEYEpline"
 copyright = f"2024–{datetime.now().year}, Deborah N. Jakobi et al"
 author = "Deborah N. Jakobi et al."
-release = "0.0.0"
+release = "0.2.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,9 +89,9 @@ This project has been partially funded by:
    :maxdepth: 2
    :glob:
 
-    getting_started
-    guide/index
-    faq
-    troubleshooting
-    bibliography
+   getting_started
+   guide/index
+   faq
+   troubleshooting
+   bibliography
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-(troubleshooting)=
+(troubleshooting_anchor)=
 
 # Troubleshooting
 

--- a/preprocessing/scripts/sync_version.py
+++ b/preprocessing/scripts/sync_version.py
@@ -1,0 +1,89 @@
+import sys
+import re
+import argparse
+from pathlib import Path
+
+# Paths to files and the regex to find the version string in each
+FILES_TO_UPDATE = {
+    "pyproject.toml": (r'(version\s*=\s*")([^"]+)(")', r"\1{version}\3"),
+    "CITATION.cff": (r"(^version:\s*)(.*)", r"\1{version}"),
+    "docs/conf.py": (r'(release\s*=\s*")([^"]+)(")', r"\1{version}\3"),
+}
+
+
+def get_current_version():
+    """Extracts the version string from pyproject.toml."""
+    path = Path("pyproject.toml")
+    if not path.exists():
+        return None
+    content = path.read_text()
+    match = re.search(FILES_TO_UPDATE["pyproject.toml"][0], content)
+    return match.group(2) if match else None
+
+
+def update_files(new_version: str):
+    """Updates the version string in all configured files."""
+    for file_name, (pattern, replacement_template) in FILES_TO_UPDATE.items():
+        path = Path(file_name)
+        if not path.exists():
+            print(f"Warning: {file_name} not found. Skipping.")
+            continue
+
+        content = path.read_text()
+
+        def replace_func(match):
+            # match.group(1) is the prefix (e.g., 'version = "')
+            # match.group(3) is the suffix (e.g., '"') if it exists
+            prefix = match.group(1)
+            try:
+                suffix = match.group(3)
+            except IndexError:
+                suffix = ""
+            return f"{prefix}{new_version}{suffix}"
+
+        new_content = re.sub(pattern, replace_func, content, flags=re.MULTILINE)
+
+        if content != new_content:
+            path.write_text(new_content)
+            print(f"Updated {file_name} to {new_version}")
+
+
+def validate_format(version: str):
+    """Validates that the version follows the YYYY.MM.DD format."""
+    if not re.match(r"^\d{4}\.\d{2}\.\d{2}$", version):
+        print(f"Error: Version '{version}' does not match CalVer format YYYY.MM.DD")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Synchronize version strings across project files."
+    )
+    parser.add_argument(
+        "--set-version", help="Update all files to this specific version"
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate current version format in pyproject.toml",
+    )
+
+    args = parser.parse_args()
+    current = get_current_version()
+
+    if args.set_version:
+        validate_format(args.set_version)
+        update_files(args.set_version)
+    elif args.validate:
+        if not current:
+            print("Error: Could not find version in pyproject.toml")
+            sys.exit(1)
+        validate_format(current)
+        print(f"Version {current} is valid.")
+    else:
+        # Default behavior: Sync all files based on whatever is in pyproject.toml
+        if current:
+            update_files(current)
+        else:
+            print("Error: Could not find version in pyproject.toml")
+            sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MultiplEYE-preprocessing"
-version = "0.2.0"
+version = "2026.05.22"
 description = "Pipeline for Multipleye data preprocessing"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
The pipeline now automatically publishes releases with the current date (e.g., v2026.05.22) every night if there have been code changes that day. This means:

- No manual work required to create releases
- Version numbers reflect the exact day of release
- The version is automatically updated in documentation, citation files, and package metadata
- Changelog is auto-generated from commit messages

This follows best practices for research software versioning and makes it easy to cite specific versions in papers.

This was tested here: https://github.com/MultiplEYE-COST/multipleye-preprocessing/actions/runs/26287929134
It reated the automatic release: https://github.com/MultiplEYE-COST/multipleye-preprocessing/releases/tag/v2026.05.22

---

This PR adds automated daily CalVer releases using the format YYYY.MM.DD.
Changes:
- [x] Added GitHub Actions workflow that runs nightly at 23:00 UTC, on `main` branch.
- [x] Added `sync_version.py` script to synchronize version strings across `pyproject.toml`, `CITATION.cff`, and `docs/conf.py`
- [x] Added pre-commit hook for automatic version synchronization
- [x] Updated GitHub Actions to latest versions (setup-uv, configure-pages, upload-pages-artifact, deploy-pages)

The workflow creates a release only if one for the current date does not already exist, ensuring no duplicate releases.