### PR TITLE
chore!: Rename `run_multipleye_preprocessing` to `run_preprocessing`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,24 @@
 # MultiplEYE Preprocessing
 
 > [!IMPORTANT]
-> This repository is **actively maintained and evolving**. Features, configurations, and behaviors may
-> change as we improve the codebase. Please:
+> This repository is **actively maintained and evolving**.
+> Features, configurations, and behaviors may change as we improve the codebase. Please:
 > - Keep the repository up-to-date to receive the latest changes, fixes, and improvements
 > - Report issues if you encounter unexpected behavior
 > - Refer to the documentation for the latest information on how to use the pipeline
-> - Check the [troubleshooting guide](https://multipleye-cost.github.io/multipleye-preprocessing/troubleshooting/) if you encounter any issues
+> - Check the
+> - [troubleshooting guide](https://multipleye-cost.github.io/multipleye-preprocessing/troubleshooting/)
+    if you encounter any issues
 
 This repository contains the preprocessing pipeline for eye-tracking data and psychometric test
 scoring from the MultiplEYE project.
 
-If you are running the pipeline and encounter any issues, please check the [troubleshooting guide](https://multipleye-cost.github.io/multipleye-preprocessing/troubleshooting/).
+If you are running the pipeline and encounter any issues, please check
+the [troubleshooting guide](https://multipleye-cost.github.io/multipleye-preprocessing/troubleshooting/).
 
 > [!NOTE]
-> This repository processes data recorded
-> with [MultiplEYE-psychometric-tests](https://github.com/MultiplEYE-COST/MultiplEYE-psychometric-tests).
+> This repository processes data recorded with
+> [MultiplEYE-psychometric-tests](https://github.com/MultiplEYE-COST/MultiplEYE-psychometric-tests).
 
 ## What You Can Do With This Repository
 
@@ -29,7 +32,7 @@ Process raw eye-tracking data (EyeLink `.edf` files) through a complete preproce
 
 ```bash
 # Configure your settings in multipleye_settings_preprocessing.yaml
-run_multipleye_preprocessing
+run_preprocessing
 ```
 
 This pipeline handles:
@@ -61,8 +64,8 @@ This calculates scores for:
 - **WikiVocab**
 
 > [!IMPORTANT]
-> The psychometric tests require data to be structured correctly. See
-> the [Psychometric Tests documentation](https://multipleye-cost.github.io/multipleye-preprocessing/guide/psychometric_tests/)
+> The psychometric tests require data to be structured correctly. See the
+> [Psychometric Tests documentation](https://multipleye-cost.github.io/multipleye-preprocessing/guide/psychometric_tests/)
 > for details on the expected data format.
 
 ---
@@ -97,7 +100,7 @@ source .venv/bin/activate  # Unix/Mac
 |--------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
 | [Getting Started](https://multipleye-cost.github.io/multipleye-preprocessing/getting_started/)                     | Installation, requirements, and running the pipeline |
 | [Preprocessing](https://multipleye-cost.github.io/multipleye-preprocessing/guide/preprocessing/)                   | Detailed preprocessing pipeline documentation        |
-| [Reading Measures](https://multipleye-cost.github.io/multipleye-preprocessing/guide/reading_measures/)            | Reading measures from preprocessed eye-tracking data |
+| [Reading Measures](https://multipleye-cost.github.io/multipleye-preprocessing/guide/reading_measures/)             | Reading measures from preprocessed eye-tracking data |
 | [Psychometric Tests](https://multipleye-cost.github.io/multipleye-preprocessing/guide/psychometric_tests/)         | Test descriptions and scoring details                |
 | [Configuration](https://multipleye-cost.github.io/multipleye-preprocessing/guide/configuration/)                   | Configuration file options                           |
 | [Technical Architecture](https://multipleye-cost.github.io/multipleye-preprocessing/guide/technical_architecture/) | Code structure and design                            |
@@ -107,10 +110,10 @@ source .venv/bin/activate  # Unix/Mac
 ## Quick Start
 
 1. Update settings in `multipleye_settings_preprocessing.yaml`
-2. Run preprocessing: `run_multipleye_preprocessing`
+2. Run preprocessing: `run_preprocessing`
 3. Score psychometric tests: `preprocess_psychometric_tests`
 
 > [!CAUTION]
-> EyeLink-specific: You must install the EyeLink Developers Kit to convert `.edf` files. See
-> the [installation guide](https://multipleye-cost.github.io/multipleye-preprocessing/getting_started/)
+> EyeLink-specific: You must install the EyeLink Developers Kit to convert `.edf` files. See the
+> [installation guide](https://multipleye-cost.github.io/multipleye-preprocessing/getting_started/)
 > for details.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -149,13 +149,13 @@ To run the MultiplEye preprocessing pipeline (if you used `uv` for installation 
 environment):
 
 ```bash
-run_multipleye_preprocessing
+run_preprocessing
 ```
 
 You can always check the available options for each script by using the `--help` flag:
 
 ```bash
-run_multipleye_preprocessing --help
+run_preprocessing --help
 ```
 
 Processing the {ref}`psychometric_tests` is not part of the preprocessing pipeline.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -38,7 +38,8 @@ The main settings include:
 
 ### Psychometric Test Settings
 
-- `PSYCHOMETRIC_TESTS_DIR`: Directory containing psychometric test sessions (configured per data collection)
+- `PSYCHOMETRIC_TESTS_DIR`: Directory containing psychometric test sessions (configured per data
+  collection)
 
 ### Processing Parameters
 
@@ -63,7 +64,7 @@ settings.load_from_yaml("path/to/your_config.yaml")
 When running the preprocessing script:
 
 ```bash
-python -m preprocessing.scripts.run_multipleye_preprocessing --config_path your_config.yaml
+python -m preprocessing.scripts.run_preprocessing --config_path your_config.yaml
 ```
 
 ## Internal Constants

--- a/docs/guide/preprocessing.md
+++ b/docs/guide/preprocessing.md
@@ -39,13 +39,13 @@ structure specification, see the {ref}`multiplEYE_data_structure` section.
 
 ```bash
 # A. Run full preprocessing pipeline (uses default config file)
-run_multipleye_preprocessing
+run_preprocessing
 
 # B. Or specify a custom config file
-run_multipleye_preprocessing --config_path path/to/your_config.yaml
+run_preprocessing --config_path path/to/your_config.yaml
 
 # C. Or directly run with uv
-uv run run_multipleye_preprocessing
+uv run run_preprocessing
 ```
 
 ### Output Files

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -11,7 +11,7 @@ from preprocessing import settings
 from preprocessing.scripts.prepare_language_folder import prepare_language_folder
 
 
-def run_multipleye_preprocessing(config_path: str | None = None):
+def run_preprocessing(config_path: str | None = None):
     settings.load(config_path)
     logger = get_logger(__name__)
 
@@ -271,7 +271,7 @@ def main():
         help="Path to the preprocessing configuration YAML file.",
     )
     args = parser.parse_args()
-    run_multipleye_preprocessing(args.config_path)
+    run_preprocessing(args.config_path)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,4 @@ restructure_psychometric_tests = "preprocessing.scripts.restructure_psycho_tests
 prepare_language_folder = "preprocessing.scripts.prepare_language_folder:main"
 preprocess_psychometric_tests = "preprocessing.scripts.psychometric_tests:process_all_psychometric_test_sessions"
 # Pipelines
-run_multipleye_preprocessing = "preprocessing.scripts.run_multipleye_preprocessing:main"
-run_merid_preprocessing = "preprocessing.scripts.run_merid_preprocessing:main"
-run_multipleye_sanity_checks = "preprocessing.scripts.run_multipleye_sanity_checks:main"
-run_merid_sanity_checks = "preprocessing.scripts.run_merid_sanity_checks:main"
+run_preprocessing = "preprocessing.scripts.run_preprocessing:main"

--- a/tests/unit/scripts/test_run_multipleye_preprocessing.py
+++ b/tests/unit/scripts/test_run_multipleye_preprocessing.py
@@ -1,4 +1,4 @@
-"""Unit tests for run_multipleye_preprocessing script."""
+"""Unit tests for run_preprocessing script."""
 
 from pathlib import Path
 
@@ -13,7 +13,7 @@ def test_reading_measures_check_uses_session_save_name():
     When session_idf = "001_ET_EE_1_ET1_restart_1" and session_save_name = "001_ET_EE_1_ET1",
     the check should use session_save_name to match what save uses.
     """
-    source_file = Path("preprocessing/scripts/run_multipleye_preprocessing.py")
+    source_file = Path("preprocessing/scripts/run_preprocessing.py")
     source_code = source_file.read_text()
 
     lines = source_code.split("\n")


### PR DESCRIPTION
*Breaking change!*

- Now the script is called by `run_preprocessing`, not `run_multipleye_preprocessing` anymore
- remove unused, broken entries

Use `uv sync` to update these entry points.

Closes #79