### PR TITLE
fix: Allow Aalborg data preprocessing by removing it from blocked placeholders

### DIFF
--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -618,10 +618,7 @@ class Settings:
 
         # Check for placeholders
         val = self.__dict__.get("DATA_COLLECTION_NAME")
-        if (
-            val == "REPLACE_WITH_YOUR_COLLECTION_NAME"
-            or val == "MultiplEYE_DA_DK_Aalborg_1_2026"
-        ):
+        if val == "REPLACE_WITH_YOUR_COLLECTION_NAME":
             return (
                 "\n" + "=" * 80 + "\n"
                 " INVALID CONFIGURATION\n" + "=" * 80 + "\n"


### PR DESCRIPTION
This PR fixes a bug where the Aalborg data collection identifier was hardcoded as an "invalid" placeholder in the configuration logic, preventing the pipeline from processing actual Aalborg data.

- Updated `get_config_status_message` in `preprocessing/config.py` to stop blocking the Aalborg collection name. It now only blocks the primary placeholder `REPLACE_WITH_YOUR_COLLECTION_NAME`.
- The Aalborg collection name and participant ID as commented-out examples in `templates_and_notes/multipleye_settings_preprocessing.template.yaml` serve as helpful formatting guides without interfering with the pipeline's execution. We keep them.