### PR TITLE
feat: Automatic data collection name detection

### DIFF
--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -29,6 +29,7 @@ class Settings:
         self._repo_root = Path(__file__).parent.parent
         self._initialized = True
         self._is_template_loaded = False
+        self._is_auto_filled = False
         self._config_found = False
 
     @property
@@ -543,6 +544,13 @@ class Settings:
         if not self._loaded and not self._loading:
             self.load()
 
+    def _is_valid_data_collection_name(self, name: str) -> bool:
+        """Check if the name follows the MultiplEYE data collection format."""
+        # Format: MultiplEYE_[LANGUAGE]_[COUNTRY]_[CITY]_[LAB]_[YEAR]
+        # Example: MultiplEYE_DA_DK_Aalborg_1_2026
+        pattern = r"^MultiplEYE_[A-Z]{2}_[A-Z]{2}_[A-Za-z0-9]+_[A-Za-z0-9]+_\d{4}$"
+        return bool(re.match(pattern, name))
+
     def load(self, path: str | Path | None = None) -> None:
         """Load settings from various sources with defined precedence."""
         self._loading = True
@@ -565,7 +573,13 @@ class Settings:
                 return
 
             # No config found, try to create from template
-            self.create_config_template(cwd_default)
+            cwd_name = Path.cwd().name
+            if self._is_valid_data_collection_name(cwd_name):
+                self.create_config_template(cwd_default, collection_name=cwd_name)
+                self._is_auto_filled = True
+            else:
+                self.create_config_template(cwd_default)
+
             self._is_template_loaded = True
             if cwd_default.exists():
                 self.load_from_yaml(cwd_default)
@@ -575,14 +589,22 @@ class Settings:
         finally:
             self._loading = False
 
-    def create_config_template(self, target_path: Path) -> None:
+    def create_config_template(
+        self, target_path: Path, collection_name: str | None = None
+    ) -> None:
         """Create a configuration template at the target path."""
         template_path = self._repo_root / TEMPLATE_RELATIVE_PATH
         if not template_path.exists():
             return
 
         try:
-            target_path.write_text(template_path.read_text(encoding="utf-8"))
+            content = template_path.read_text(encoding="utf-8")
+            if collection_name:
+                content = content.replace(
+                    'data_collection_name: "REPLACE_WITH_YOUR_COLLECTION_NAME"',
+                    f'data_collection_name: "{collection_name}"',
+                )
+            target_path.write_text(content)
         except OSError:
             # We don't log here to keep load() silent,
             # but we can check if it exists in get_config_status_message
@@ -594,11 +616,24 @@ class Settings:
 
         if self._is_template_loaded:
             if cwd_default.exists():
+                if self._is_auto_filled:
+                    return (
+                        "\n" + "=" * 80 + "\n"
+                        " CONFIGURATION REQUIRED\n" + "=" * 80 + "\n"
+                        "No configuration file was found.\n\n"
+                        f"The data collection name has been detected as '{Path.cwd().name}'\n"
+                        "and the configuration template has been updated for you at:\n"
+                        f"  {cwd_default}\n\n"
+                        "Please open this file, review the settings,\n"
+                        "and then run the pipeline again.\n\n"
+                        f"For more help, see: {TEMPLATE_DOCS_URL}\n" + "=" * 80 + "\n"
+                    )
+
                 return (
                     "\n" + "=" * 80 + "\n"
                     " CONFIGURATION REQUIRED\n" + "=" * 80 + "\n"
                     "No configuration file was found.\n\n"
-                    "I've created a template for you at:\n"
+                    "A template has been created for you at:\n"
                     f"  {cwd_default}\n\n"
                     "Please open this file, set your 'data_collection_name',\n"
                     "and then run the pipeline again.\n\n"

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -17,11 +17,24 @@
 data_collection_name: "REPLACE_WITH_YOUR_COLLECTION_NAME"
 
 # --- COMMON SETTINGS (frequently changed) ---
+# The type of experiment being processed.
 experiment_type: "MultiplEYE" # MultiplEYE or MeRID
+
+# Whether to overwrite existing preprocessed files.
+# If false, already preprocessed sessions are skipped.
+# Note: If some files exist, overwrite once to ensure version consistency.
 overwrite: false
+
+# List of session identifiers to explicitly include. If not empty, only these are processed.
 include_sessions: [] # e.g., ["000_DA_DK_1_ET1"]
+
+# List of session identifiers to explicitly exclude from processing.
 exclude_sessions: []
+
+# Whether to include sessions from the pilot folder.
 include_pilots: false
+
+# The expected sampling rate of the eye tracker in Hertz.
 expected_sampling_rate_hz: 1000
 
 # ----------------------- Internal Usage -----------------------

--- a/tests/unit/preprocessing/test_config.py
+++ b/tests/unit/preprocessing/test_config.py
@@ -141,15 +141,11 @@ def test_settings_load_from_yaml(settings_obj, tmp_path):
     assert settings_obj.EXPECTED_SAMPLING_RATE_HZ == 500
 
 
-def test_settings_validation_no_error_initially(settings_obj):
-    """Test that missing required fields do not raise an error during initial load."""
-    settings_obj._validate()  # Should not raise
-
-
-def test_settings_validation_placeholder_no_error_initially(settings_obj):
-    """Test that placeholder DATA_COLLECTION_NAME does not raise an error during initial load."""
+def test_settings_validation_cases(settings_obj):
+    """Test that missing required fields or placeholders do not raise errors during initial load."""
+    settings_obj._validate()  # Should not raise initially
     settings_obj.DATA_COLLECTION_NAME = "REPLACE_WITH_YOUR_COLLECTION_NAME"
-    settings_obj._validate()  # Should not raise
+    settings_obj._validate()  # Should also not raise initially
 
 
 def test_prepare_language_folder_none_error():
@@ -177,18 +173,18 @@ def test_prepare_language_folder_none_error():
     [
         ("LANGUAGE", "EN"),
         ("COUNTRY", "UK"),
-        ("CITY", "LON"),
-        ("LAB", "LAB1"),
-        ("YEAR", "2025"),
+        ("CITY", "London"),
+        ("LAB", "1"),
+        ("YEAR", "2026"),
     ],
 )
 def test_settings_dynamic_properties(settings_obj, name, expected):
     """Test that dynamic properties are correctly computed."""
-    settings_obj.DATA_COLLECTION_NAME = "ME_EN_UK_LON_LAB1_2025"
+    settings_obj.DATA_COLLECTION_NAME = "MultiplEYE_EN_UK_London_1_2026"
     settings_obj._loaded = True  # Prevent auto-loading legacy config
 
     assert getattr(settings_obj, name) == expected
-    assert "ME_EN_UK_LON_LAB1_2025" in str(settings_obj.DATASET_DIR)
+    assert "MultiplEYE_EN_UK_London_1_2026" in str(settings_obj.DATASET_DIR)
 
 
 def test_settings_precedence_env_var(tmp_path, monkeypatch):
@@ -232,6 +228,53 @@ def test_settings_copies_template_silently(tmp_path, monkeypatch, caplog):
     msg = s.get_config_status_message()
     assert "CONFIGURATION REQUIRED" in msg
     assert str(copied_path) in msg
+
+
+@pytest.mark.parametrize(
+    "folder_name, expected_auto_filled, expected_msg_part",
+    [
+        (
+            "MultiplEYE_DA_DK_Aalborg_1_2026",
+            True,
+            "The data collection name has been detected as 'MultiplEYE_DA_DK_Aalborg_1_2026'",
+        ),
+        (
+            "Invalid_Folder_Name",
+            False,
+            "A template has been created for you at:",
+        ),
+    ],
+)
+def test_settings_template_auto_fill_behavior(
+    tmp_path, monkeypatch, folder_name, expected_auto_filled, expected_msg_part
+):
+    """Test template generation behavior based on folder name compliance."""
+    from preprocessing.config import Settings
+
+    case_dir = tmp_path / folder_name
+    case_dir.mkdir()
+
+    monkeypatch.chdir(case_dir)
+    monkeypatch.delenv("MULTIPLEYE_CONFIG", raising=False)
+
+    s = Settings()
+    s.load()
+
+    assert s._is_template_loaded
+    assert s._is_auto_filled == expected_auto_filled
+
+    copied_path = case_dir / "multipleye_settings_preprocessing.yaml"
+    assert copied_path.exists()
+    content = copied_path.read_text(encoding="utf-8")
+
+    if expected_auto_filled:
+        assert f'data_collection_name: "{folder_name}"' in content
+    else:
+        assert 'data_collection_name: "REPLACE_WITH_YOUR_COLLECTION_NAME"' in content
+
+    msg = s.get_config_status_message()
+    assert "CONFIGURATION REQUIRED" in msg
+    assert expected_msg_part in msg
 
 
 def test_settings_placeholder_status_message(settings_obj):


### PR DESCRIPTION
This PR implements automatic detection and configuration of the `data_collection_name` based on the current working directory name. If a user runs the pipeline in a folder that follows the standard naming convention (`MultiplEYE_LANG_COUNTRY_CITY_LAB_YEAR`) and no configuration file exists, the system now automatically populates the generated template with the detected name.

#### Changes
- [x] regex-based validation for data collection names in `Settings`.
- [x] Modified the configuration loading logic to detect valid folder names and auto-fill the YAML template.
- [x] Updated status messages for clear instructions when auto-detection occurs. (neutral/passive voice)
- [x] Added unit tests in `tests/unit/preprocessing/test_config.py`

#### Follow-up
There will be a follow-up PR to improve the Data Collection format handling by introducing a dedicated model class (similar to the `Sid` model) to centralise validation and parsing logic. See #86.

#### Depends on 

- [x] #85 
