### PR TITLE
feat: Add data collection model

### DIFF
--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import yaml
 
+from .models.dcn import Dcn
+
 TEMPLATE_DOCS_URL = (
     "https://multipleye-cost.github.io/multipleye-preprocessing/guide/configuration/"
 )
@@ -66,18 +68,19 @@ class Settings:
         self.__dict__["OUTPUT_DIR"] = Path(value)
 
     @property
-    def _data_collection_parts(self) -> list[str]:
-        """Split the data collection name into parts."""
-        name = self.DATA_COLLECTION_NAME or ""
-        return name.split("_")
+    def _dcn(self) -> Dcn | None:
+        """Get the Dcn model instance."""
+        name = self.DATA_COLLECTION_NAME
+        if name and Dcn.is_valid(name):
+            return Dcn(name)
+        return None
 
     @property
     def LANGUAGE(self) -> str:
         """The language code from the data collection name."""
         if "LANGUAGE" in self.__dict__:
             return self.__dict__["LANGUAGE"]
-        parts = self._data_collection_parts
-        return parts[1] if len(parts) > 1 else ""
+        return self._dcn.lang if self._dcn else ""
 
     @LANGUAGE.setter
     def LANGUAGE(self, value: str) -> None:
@@ -88,8 +91,7 @@ class Settings:
         """The country code from the data collection name."""
         if "COUNTRY" in self.__dict__:
             return self.__dict__["COUNTRY"]
-        parts = self._data_collection_parts
-        return parts[2] if len(parts) > 2 else ""
+        return self._dcn.country if self._dcn else ""
 
     @COUNTRY.setter
     def COUNTRY(self, value: str) -> None:
@@ -100,8 +102,7 @@ class Settings:
         """The city name from the data collection name."""
         if "CITY" in self.__dict__:
             return self.__dict__["CITY"]
-        parts = self._data_collection_parts
-        return parts[3] if len(parts) > 3 else ""
+        return self._dcn.city if self._dcn else ""
 
     @CITY.setter
     def CITY(self, value: str) -> None:
@@ -112,8 +113,7 @@ class Settings:
         """The lab identifier from the data collection name."""
         if "LAB" in self.__dict__:
             return self.__dict__["LAB"]
-        parts = self._data_collection_parts
-        return parts[4] if len(parts) > 4 else ""
+        return self._dcn.lab if self._dcn else ""
 
     @LAB.setter
     def LAB(self, value: str) -> None:
@@ -124,8 +124,7 @@ class Settings:
         """The year from the data collection name."""
         if "YEAR" in self.__dict__:
             return self.__dict__["YEAR"]
-        parts = self._data_collection_parts
-        return parts[5] if len(parts) > 5 else ""
+        return self._dcn.year if self._dcn else ""
 
     @YEAR.setter
     def YEAR(self, value: str) -> None:
@@ -546,10 +545,7 @@ class Settings:
 
     def _is_valid_data_collection_name(self, name: str) -> bool:
         """Check if the name follows the MultiplEYE data collection format."""
-        # Format: MultiplEYE_[LANGUAGE]_[COUNTRY]_[CITY]_[LAB]_[YEAR]
-        # Example: MultiplEYE_DA_DK_Aalborg_1_2026
-        pattern = r"^MultiplEYE_[A-Z]{2}_[A-Z]{2}_[A-Za-z0-9]+_[A-Za-z0-9]+_\d{4}$"
-        return bool(re.match(pattern, name))
+        return Dcn.is_valid(name)
 
     def load(self, path: str | Path | None = None) -> None:
         """Load settings from various sources with defined precedence."""

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -17,6 +17,7 @@ from polars.exceptions import ComputeError
 from tqdm import tqdm
 
 from ..models.sid import Sid
+from ..models.dcn import Dcn
 from ..config import settings
 from ..utils.conversion import convert_to_time_str
 from ..utils.logging import get_logger
@@ -387,40 +388,19 @@ class MultipleyeDataCollection:
         data_dir = Path(data_dir)
 
         data_folder_name = data_dir.name
-        _, stimulus_language, country, city, lab_number, year = data_folder_name.split(
-            "_"
-        )
-        if not data_folder_name.startswith("MultiplEYE"):
+
+        try:
+            dcn = Dcn(data_folder_name)
+        except (ValueError, TypeError) as e:
             raise ValueError(
-                f"Data collection name {data_folder_name} does not start with "
-                f"'MultiplEYE'. "
-                f"Please check the folder name."
-            )
-        if not year.isdigit() or len(year) != 4:
-            raise ValueError(
-                f"Year {year} of the data collection name is not a valid year. "
-                f"It should be a 4 digit number."
-            )
-        if not lab_number.isdigit() or len(lab_number) != 1:
-            raise ValueError(
-                f"Lab number {lab_number} of the data collection name is not a "
-                f"valid lab number. It should be a 1 digit number."
-            )
-        if len(country) != 2 or not country.isalpha():
-            raise ValueError(
-                f"Country {country} of the data collection name is not a "
-                f"valid country code. It should be a 2 letter code."
-            )
-        if len(city) < 2 or not city.isalpha():
-            raise ValueError(
-                f"City {city} of the data collection name is not a valid city name. "
-                f"It should be a string with at least 2 letters."
-            )
-        if not stimulus_language.isalpha() or len(stimulus_language) != 2:
-            raise ValueError(
-                f"Stimulus language {stimulus_language} of the data collection name is "
-                f"not a valid language code. It should be a 2 letter code."
-            )
+                f"Invalid data collection name: {data_folder_name}. {e}"
+            ) from e
+
+        stimulus_language = dcn.lang
+        country = dcn.country
+        city = dcn.city
+        lab_number = dcn.lab
+        year = dcn.year
 
         session_folder_regex = (
             r"\d\d\d" + f"_{stimulus_language}_{country}_{lab_number}" + r"_ET\d"

--- a/preprocessing/models/__init__.py
+++ b/preprocessing/models/__init__.py
@@ -1,0 +1,4 @@
+from .sid import Sid
+from .dcn import Dcn
+
+__all__ = ["Sid", "Dcn"]

--- a/preprocessing/models/dcn.py
+++ b/preprocessing/models/dcn.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass, field
+from typing import Optional
+import re
+
+__all__ = ["Dcn"]
+
+
+@dataclass
+class Dcn:
+    prefix: str = field(init=False)
+    lang: str = field(init=False)
+    country: str = field(init=False)
+    city: str = field(init=False)
+    lab: str = field(init=False)
+    year: str = field(init=False)
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        *,
+        lang: Optional[str] = None,
+        country: Optional[str] = None,
+        city: Optional[str] = None,
+        lab: Optional[str] = None,
+        year: Optional[str] = None,
+    ):
+        if name is not None and any(
+            v is not None for v in [lang, country, city, lab, year]
+        ):
+            raise ValueError(
+                "Pass either 'name' string or individual components, not both."
+            )
+
+        if name is not None:
+            if not isinstance(name, str):
+                raise TypeError(f"Name must be a string, got {type(name).__name__}")
+            parts = name.split("_")
+            if len(parts) != 6:
+                raise ValueError(
+                    f"Invalid data collection name format: '{name}'. Expected 6 parts separated by '_'."
+                )
+
+            self.prefix = parts[0]
+            self.lang = parts[1]
+            self.country = parts[2]
+            self.city = parts[3]
+            self.lab = parts[4]
+            self.year = parts[5]
+        else:
+            if any(v is None for v in [lang, country, city, lab, year]):
+                raise ValueError(
+                    "All components (lang, country, city, lab, year) must be provided if 'name' is not."
+                )
+
+            self.prefix = "MultiplEYE"
+            self.lang = lang
+            self.country = country
+            self.city = city
+            self.lab = lab
+            self.year = year
+
+        self._validate()
+
+    def _validate(self):
+        if self.prefix != "MultiplEYE":
+            raise ValueError(f"Invalid prefix: '{self.prefix}'. Must be 'MultiplEYE'.")
+        if not re.match(r"^[A-Z]{2}$", self.lang):
+            raise ValueError(
+                f"Invalid language code: '{self.lang}'. Must be 2 uppercase letters."
+            )
+        if not re.match(r"^[A-Z]{2}$", self.country):
+            raise ValueError(
+                f"Invalid country code: '{self.country}'. Must be 2 uppercase letters."
+            )
+        if not re.match(r"^[A-Za-z0-9]+$", self.city):
+            raise ValueError(f"Invalid city: '{self.city}'. Must be alphanumeric.")
+        if not re.match(r"^[A-Za-z0-9]+$", self.lab):
+            raise ValueError(f"Invalid lab: '{self.lab}'. Must be alphanumeric.")
+        if not re.match(r"^\d{4}$", self.year):
+            raise ValueError(f"Invalid year: '{self.year}'. Must be 4 digits.")
+
+    def __str__(self) -> str:
+        return f"{self.prefix}_{self.lang}_{self.country}_{self.city}_{self.lab}_{self.year}"
+
+    @staticmethod
+    def is_valid(name: str) -> bool:
+        """Checks if a string is a valid Dcn-compliant identifier."""
+        if not isinstance(name, str):
+            return False
+        try:
+            Dcn(name)
+            return True
+        except (ValueError, TypeError):
+            return False

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 import re
 
+__all__ = ["Sid"]
+
 
 @dataclass
 class Sid:

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from ..models.dcn import Dcn
 from ..utils.data_path_utils import check_data_collection_exists
 from ..utils.logging import get_logger
 from ..scripts.restructure_psycho_tests import fix_psycho_tests_structure
@@ -27,7 +28,12 @@ def prepare_language_folder(data_collection_name: str | None = None):
             "as an argument or load a configuration via settings.load()."
         )
 
-    _, lang, country, city, lab_no, year = data_collection_name.split("_")
+    dcn = Dcn(data_collection_name)
+    lang = dcn.lang
+    country = dcn.country
+    lab_no = dcn.lab
+    # city and year are not used
+
     logger = get_logger(__name__)
 
     # Check if the data collection folder exists

--- a/preprocessing/utils/add_custom_uoa_to_aois.py
+++ b/preprocessing/utils/add_custom_uoa_to_aois.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from ..models.dcn import Dcn
 from preprocessing import config
 
 
@@ -24,7 +25,11 @@ def rename_aoi_header(data_collection_name: str) -> None:
     :param data_collection_name:
     """
 
-    _, language, country, city, lab, year = data_collection_name.split("_")
+    dcn = Dcn(data_collection_name)
+    language = dcn.lang
+    country = dcn.country
+    lab = dcn.lab
+    # city and year are not used
 
     aoi_dir_path = (
         config.DEFAULT_STIMULI_DIR

--- a/tests/unit/preprocessing/models/test_dcn.py
+++ b/tests/unit/preprocessing/models/test_dcn.py
@@ -1,0 +1,92 @@
+import pytest
+from preprocessing.models.dcn import Dcn
+
+
+@pytest.mark.parametrize(
+    "name_str, expected_lang, expected_country, expected_city, expected_lab, expected_year",
+    [
+        ("MultiplEYE_EN_UK_London_1_2026", "EN", "UK", "London", "1", "2026"),
+        ("MultiplEYE_DA_DK_Aalborg_1_2026", "DA", "DK", "Aalborg", "1", "2026"),
+        ("MultiplEYE_DE_DE_Berlin_LAB2_2025", "DE", "DE", "Berlin", "LAB2", "2025"),
+    ],
+)
+def test_data_collection_name_init_from_str(
+    name_str,
+    expected_lang,
+    expected_country,
+    expected_city,
+    expected_lab,
+    expected_year,
+):
+    dcn = Dcn(name_str)
+    assert dcn.prefix == "MultiplEYE"
+    assert dcn.lang == expected_lang
+    assert dcn.country == expected_country
+    assert dcn.city == expected_city
+    assert dcn.lab == expected_lab
+    assert dcn.year == expected_year
+    assert str(dcn) == name_str
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_str",
+    [
+        (
+            {
+                "lang": "EN",
+                "country": "UK",
+                "city": "London",
+                "lab": "1",
+                "year": "2026",
+            },
+            "MultiplEYE_EN_UK_London_1_2026",
+        ),
+    ],
+)
+def test_data_collection_name_init_from_components(kwargs, expected_str):
+    dcn = Dcn(**kwargs)
+    assert str(dcn) == expected_str
+    assert dcn.lang == kwargs["lang"]
+    assert dcn.country == kwargs["country"]
+    assert dcn.city == kwargs["city"]
+    assert dcn.lab == kwargs["lab"]
+    assert dcn.year == kwargs["year"]
+
+
+def test_data_collection_name_init_raises_both():
+    with pytest.raises(
+        ValueError,
+        match="Pass either 'name' string or individual components, not both.",
+    ):
+        Dcn("MultiplEYE_EN_UK_London_1_2026", lang="EN")
+
+
+def test_data_collection_name_init_raises_missing_components():
+    with pytest.raises(ValueError, match="All components .* must be provided"):
+        Dcn(lang="EN", country="UK")
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "MultiplEYE_E_UK_London_1_2026",  # lang too short
+        "MultiplEYE_ENG_UK_London_1_2026",  # lang too long
+        "MultiplEYE_EN_U_London_1_2026",  # country too short
+        "MultiplEYE_EN_UKK_London_1_2026",  # country too long
+        "MultiplEYE_EN_UK_London_1_26",  # year too short
+        "MultiplEYE_EN_UK_London_1_20266",  # year too long
+        "MultiplEYE_en_UK_London_1_2026",  # lowercase lang
+        "MultiplEYE_EN_uk_London_1_2026",  # lowercase country
+        "OtherPrefix_EN_UK_London_1_2026",  # wrong prefix
+        "MultiplEYE_EN_UK_London_1",  # missing parts
+    ],
+)
+def test_data_collection_name_init_raises_invalid_format(invalid_name):
+    with pytest.raises(ValueError):
+        Dcn(invalid_name)
+
+
+def test_data_collection_name_is_valid():
+    assert Dcn.is_valid("MultiplEYE_EN_UK_London_1_2026") is True
+    assert Dcn.is_valid("invalid") is False
+    assert Dcn.is_valid(None) is False


### PR DESCRIPTION
Implemented a dedicated `Dcn` (Data Collection Name) model to centralise validation and parsing of the `MultiplEYE_LANG_COUNTRY_CITY_LAB_YEAR` format, consistent with the existing `Sid` model.

### Changes
- Add `preprocessing/models/dcn.py` with the `Dcn` model for data collection name validation and component parsing.
- Let `Settings` in `preprocessing/config.py` use `Dcn` for dynamic properties like `LANGUAGE`, `COUNTRY`, and `LAB`.
- Updated `MultipleyeDataCollection` and utility scripts (`prepare_language_folder.py`, `add_custom_uoa_to_aois.py`) to use the model instead of manual string splitting.
- Test in `tests/unit/preprocessing/models/test_dcn.py` and update existing config tests.

Closes #86

#### Depends on 

- [x] #87