### PR TITLE
feat: move stimulus and AOI processing to preprocessed_data folder

### DIFF
--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -141,6 +141,16 @@ class Settings:
         self.__dict__["COPY_AOI_IMAGES_OVERLAY"] = value
 
     @property
+    def PLOT_AOI_OVERLAY(self) -> bool:
+        """Whether to use AOI overlay or only stimulus images for plotting."""
+        self._ensure_loaded()
+        return self.__dict__.get("PLOT_AOI_OVERLAY", False)
+
+    @PLOT_AOI_OVERLAY.setter
+    def PLOT_AOI_OVERLAY(self, value: bool) -> None:
+        self.__dict__["PLOT_AOI_OVERLAY"] = value
+
+    @property
     def PSYCHOMETRIC_TESTS_DIR(self) -> Path:
         """The directory for psychometric tests."""
         if "PSYCHOMETRIC_TESTS_DIR" in self.__dict__:
@@ -297,6 +307,9 @@ class Settings:
 
         #: Whether to copy AOI images overlay to the output directory.
         self.COPY_AOI_IMAGES_OVERLAY: bool = False
+
+        #: Whether to use AOI overlay or only stimulus images for plotting.
+        self.PLOT_AOI_OVERLAY: bool = False
 
         #:
         self.EXPERIMENT_TYPE: str = ""

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -131,6 +131,16 @@ class Settings:
         self.__dict__["YEAR"] = value
 
     @property
+    def COPY_AOI_IMAGES_OVERLAY(self) -> bool:
+        """Whether to copy AOI images overlay to the output directory."""
+        self._ensure_loaded()
+        return self.__dict__.get("COPY_AOI_IMAGES_OVERLAY", False)
+
+    @COPY_AOI_IMAGES_OVERLAY.setter
+    def COPY_AOI_IMAGES_OVERLAY(self, value: bool) -> None:
+        self.__dict__["COPY_AOI_IMAGES_OVERLAY"] = value
+
+    @property
     def PSYCHOMETRIC_TESTS_DIR(self) -> Path:
         """The directory for psychometric tests."""
         if "PSYCHOMETRIC_TESTS_DIR" in self.__dict__:
@@ -284,6 +294,9 @@ class Settings:
 
         #: Whether to include sessions from the pilot folder.
         self.INCLUDE_PILOTS: bool = False
+
+        #: Whether to copy AOI images overlay to the output directory.
+        self.COPY_AOI_IMAGES_OVERLAY: bool = False
 
         #:
         self.EXPERIMENT_TYPE: str = ""

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -403,7 +403,10 @@ class MultipleyeDataCollection:
             r"\d\d\d" + f"_{stimulus_language}_{country}_{lab_number}" + r"_ET\d"
         )
 
-        stimulus_folder_path = data_dir / f"stimuli_{data_folder_name}"
+        stimulus_folder_path = settings.OUTPUT_DIR / f"stimuli_{data_folder_name}"
+        if not stimulus_folder_path.exists():
+            stimulus_folder_path = data_dir / f"stimuli_{data_folder_name}"
+
         config_file = (
             stimulus_folder_path
             / "config"

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -1387,7 +1387,7 @@ class MultipleyeDataCollection:
 
             folder = Path(self.sessions[session].session_folder_path)
 
-            pq_file = folder / f"{participant_id}_{lang}_{country}_{lab}_pq_data.json"
+            pq_file = folder / f"{sid.base_id}_pq_data.json"
             if pq_file.exists():
                 with open(pq_file, "r", encoding="utf-8") as f:
                     data = json.load(f)

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -122,7 +122,7 @@ class MultipleyeDataCollection:
         self.psychometric_tests = kwargs.get("psychometric_tests", [])
         self.excluded_sessions = excluded_sessions
         self.included_sessions = included_sessions
-        self.logger = get_logger(__name__)
+        self.logger = get_logger()
 
         self.logger.info(
             f"MultipleyeDataCollection initialized. data_root: {self.data_root}"

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -1374,9 +1374,6 @@ class MultipleyeDataCollection:
             try:
                 sid = Sid(session)
                 participant_id = sid.pid
-                country = sid.country
-                lang = sid.lang
-                lab = sid.lab
                 session_id = sid.session
                 notes = sid.notes
             except (ValueError, TypeError):

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -1387,7 +1387,7 @@ class MultipleyeDataCollection:
 
             folder = Path(self.sessions[session].session_folder_path)
 
-            pq_file = folder / f"{participant_id}_{country}_{lang}_{lab}_pq_data.json"
+            pq_file = folder / f"{participant_id}_{lang}_{country}_{lab}_pq_data.json"
             if pq_file.exists():
                 with open(pq_file, "r", encoding="utf-8") as f:
                     data = json.load(f)

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -14,7 +14,7 @@ from ..config import settings
 from ..mapping.aoi import enlarge_aois
 from ..utils.logging import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger()
 
 warnings.filterwarnings(
     "ignore",

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -265,9 +265,10 @@ def load_trial_level_events_data(
 
 def load_reading_measures(
     data_folder: Path,
-    file_pattern: str = r".+_(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>[^_]+_[^_]+_\d+(\.0)?)_reading_measures.csv",
+    file_pattern: str = r".*?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv",
 ) -> pl.DataFrame:
-    files = list(data_folder.glob(file_pattern))
+    # Use glob to find all csv files first, as Path.glob() does not support regex
+    files = [f for f in data_folder.glob("*.csv") if re.match(file_pattern, f.name)]
 
     if len(files) == 0:
         raise ValueError(f"No files found in {data_folder} with pattern {file_pattern}")
@@ -277,7 +278,7 @@ def load_reading_measures(
     for file in files:
         df = pl.read_csv(file)
         # get trial and stimulus from file name
-        match = re.match(file_pattern, file.stem)
+        match = re.match(file_pattern, file.name)
         trial_df = df.with_columns(
             pl.lit(match.group("trial")).alias("trial"),
             pl.lit(match.group("stimulus")).alias("stimulus"),

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -99,6 +99,14 @@ class Sid:
             return "Session has been fully restarted."
         return ""
 
+    @property
+    def base_id(self) -> str:
+        """Returns the SID without the session part."""
+        base = f"{self.pid}_{self.lang}_{self.country}_{self.lab}"
+        if self.postfix:
+            return f"{base}_{self.postfix}"
+        return base
+
     def __str__(self) -> str:
         base = f"{self.pid}_{self.lang}_{self.country}_{self.lab}_{self.session}"
         if self.postfix:

--- a/preprocessing/plotting/plot.py
+++ b/preprocessing/plotting/plot.py
@@ -41,8 +41,20 @@ def plot_gaze(
         )
 
         fig, ax = plt.subplots()
-        if aoi_image:
-            stimulus_image = PIL.Image.open(page.aoi_image_path)
+        use_aoi = aoi_image or settings.PLOT_AOI_OVERLAY
+        aoi_path = None
+        if use_aoi:
+            if page.aoi_image_path.exists():
+                aoi_path = page.aoi_image_path
+            else:
+                # Fallback: try original data folder if it is not the same as output dir
+                relative_aoi_path = page.aoi_image_path.relative_to(settings.OUTPUT_DIR)
+                original_aoi_path = settings.DATASET_DIR / relative_aoi_path
+                if original_aoi_path.exists():
+                    aoi_path = original_aoi_path
+
+        if aoi_path:
+            stimulus_image = PIL.Image.open(aoi_path)
         else:
             stimulus_image = PIL.Image.open(page.image_path)
         ax.imshow(stimulus_image)
@@ -94,8 +106,22 @@ def plot_gaze(
         )
 
         fig, ax = plt.subplots()
-        if aoi_image:
-            question_image = PIL.Image.open(question.aoi_image_path)
+        use_aoi = aoi_image or settings.PLOT_AOI_OVERLAY
+        aoi_path = None
+        if use_aoi:
+            if question.aoi_image_path.exists():
+                aoi_path = question.aoi_image_path
+            else:
+                # Fallback: try original data folder if it is not the same as output dir
+                relative_aoi_path = question.aoi_image_path.relative_to(
+                    settings.OUTPUT_DIR
+                )
+                original_aoi_path = settings.DATASET_DIR / relative_aoi_path
+                if original_aoi_path.exists():
+                    aoi_path = original_aoi_path
+
+        if aoi_path:
+            question_image = PIL.Image.open(aoi_path)
         else:
             question_image = PIL.Image.open(question.image_path)
         ax.imshow(question_image)

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -342,11 +342,7 @@ def create_merged_psychometric_overview(overview_path: Path) -> Path:
     def get_base_sid(sid_str):
         try:
             # Reconstruct SID without the session part
-            sid = Sid(sid_str)
-            base = f"{sid.pid}_{sid.lang}_{sid.country}_{sid.lab}"
-            if sid.postfix:
-                base += f"_{sid.postfix}"
-            return base
+            return Sid(sid_str).base_id
         except Exception:
             # Fallback: remove trailing _PTn or _Sn or _ETn
             return re.sub(r"_(S|PT|ET)\d+$", "", str(sid_str))

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -31,10 +31,6 @@ def prepare_language_folder(data_collection_name: str | None = None):
         )
 
     dcn = Dcn(data_collection_name)
-    lang = dcn.lang
-    country = dcn.country
-    lab_no = dcn.lab
-    # city and year are not used
 
     logger = get_logger(__name__)
 
@@ -97,9 +93,13 @@ def prepare_language_folder(data_collection_name: str | None = None):
 
     # che if ps tests need to be prepared because they use the old structure
     config_path = (
-        psychometric_tests_path / f"participant_configs_{lang}_{country}_{lab_no}"
+        psychometric_tests_path
+        / f"participant_configs_{dcn.lang}_{dcn.country}_{dcn.lab}"
     )
-    data_path = psychometric_tests_path / f"psychometric_test_{lang}_{country}_{lab_no}"
+    data_path = (
+        psychometric_tests_path
+        / f"psychometric_test_{dcn.lang}_{dcn.country}_{dcn.lab}"
+    )
     if config_path.exists() and data_path.exists():
         logger.info(
             f"Preparing psychometric tests structure for {data_collection_name}..."
@@ -131,6 +131,8 @@ def prepare_language_folder(data_collection_name: str | None = None):
 
     stimulus_folder_path = data_folder_path / f"stimuli_{data_collection_name}"
 
+    preprocessed_stimulus_path = settings.OUTPUT_DIR / f"stimuli_{data_collection_name}"
+
     if not stimulus_folder_path.exists():
         logger.warning(
             f"The stimulus folder stimuli_{data_collection_name} does not exist. Check and if necessary, ask team to upload."
@@ -144,14 +146,45 @@ def prepare_language_folder(data_collection_name: str | None = None):
             )
 
     # if aoi files are not yet split into questions and texts, do it here:
-    aoi_path = (
-        data_folder_path
-        / stimulus_folder_path
-        / f"aoi_stimuli_{lang}_{country}_{lab_no}"
+    source_aoi_path = (
+        stimulus_folder_path
+        / f"aoi_stimuli_{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
     )
 
-    # get all aoi files, if there are only 12 files, they are not yet split
-    aoi_files = list(aoi_path.glob("[!.]*.csv"))
+    destination_aoi_path = (
+        preprocessed_stimulus_path
+        / f"aoi_stimuli_{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
+    )
+
+    if destination_aoi_path.exists():
+        # check if it already contains 24 files and the fixed marker
+        if (
+            len(list(destination_aoi_path.glob("*.csv"))) == 24
+            and (destination_aoi_path / ".fixed").exists()
+        ):
+            logger.info(
+                f"AOI files already exist, are split and fixed in {destination_aoi_path}. Skipping."
+            )
+            return
+
+    if not destination_aoi_path.exists():
+        if source_aoi_path.exists():
+            logger.info(f"Copying AOI files to {destination_aoi_path}...")
+            shutil.copytree(source_aoi_path, destination_aoi_path)
+        else:
+            logger.warning(f"Source AOI path {source_aoi_path} does not exist.")
+            return
+
+    # Copy other stimulus files
+    _copy_stimulus_assets(
+        stimulus_folder_path,
+        preprocessed_stimulus_path,
+        eye_tracking_sessions_path,
+        dcn,
+    )
+
+    # get all aoi files in the preprocessed folder
+    aoi_files = list(destination_aoi_path.glob("[!.]*.csv"))
     if len(aoi_files) == 12:
         logger.info("Splitting AOI files into text and question AOIs...")
         for aoi_file in aoi_files:
@@ -165,25 +198,127 @@ def prepare_language_folder(data_collection_name: str | None = None):
 
             aoi_df_texts.to_csv(aoi_file, sep=",", index=False, encoding="UTF-8")
 
-            question_path = aoi_path / (aoi_file.stem + "_questions" + aoi_file.suffix)
+            question_path = destination_aoi_path / (
+                aoi_file.stem + "_questions" + aoi_file.suffix
+            )
             aoi_df_questions.to_csv(
                 question_path, sep=",", index=False, encoding="UTF-8"
             )
-    elif len(aoi_files) == 24:
-        pass
+
+        # Re-get files to include the new _questions files
+        aoi_files = list(destination_aoi_path.glob("*.csv"))
+
+    if len(aoi_files) == 24:
+        logger.info("Applying AOI fixes (remapping space and repairing labels)...")
+        for aoi_file in aoi_files:
+            remap_space_to_following_word(aoi_file)
+            repair_word_labels(aoi_file)
+
+        # Create a marker file to indicate that these files have been fixed
+        (destination_aoi_path / ".fixed").touch()
+    elif len(aoi_files) == 0:
+        logger.warning(f"No AOI files found in '{destination_aoi_path}'.")
     else:
         raise ValueError(
-            f"Unexpected number of AOI files ({len(aoi_files)}) found in '{aoi_path}'. "
+            f"Unexpected number of AOI files ({len(aoi_files)}) found in '{destination_aoi_path}'. "
             "Expected 12 (not split) or 24 (already split into texts and questions)."
         )
 
-    aoi_files_restructured = list(aoi_path.glob("[!.]*.csv"))
-    logger.info(
-        f"Remapping and repairing AOI files in {aoi_path}. This may take a minute or two."
-    )
-    for aoi_file in aoi_files_restructured:
-        remap_space_to_following_word(aoi_file)
-        repair_word_labels(aoi_file)
+
+def _copy_stimulus_assets(
+    source_stimulus_dir: Path,
+    dest_stimulus_dir: Path,
+    eye_tracking_sessions_dir: Path,
+    dcn: Dcn,
+) -> None:
+    from preprocessing import settings
+
+    logger.info(f"Copying stimulus assets to {dest_stimulus_dir}...")
+    dest_stimulus_dir.mkdir(parents=True, exist_ok=True)
+
+    suffix = f"{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
+
+    # 1. Copy Stimuli Images (all)
+    stimuli_images_folder = f"stimuli_images_{suffix}"
+    source_img = source_stimulus_dir / stimuli_images_folder
+    dest_img = dest_stimulus_dir / stimuli_images_folder
+    if source_img.exists() and not dest_img.exists():
+        logger.info(f"Copying {stimuli_images_folder}...")
+        shutil.copytree(source_img, dest_img)
+
+    # 2. Copy Participant Instruction Images (all)
+    instr_images_folder = f"participant_instructions_images_{suffix}"
+    source_instr = source_stimulus_dir / instr_images_folder
+    dest_instr = dest_stimulus_dir / instr_images_folder
+    if source_instr.exists() and not dest_instr.exists():
+        logger.info(f"Copying {instr_images_folder}...")
+        shutil.copytree(source_instr, dest_instr)
+
+    # 3. Copy AOI Stimuli Images Overlay (optional)
+    if settings.COPY_AOI_IMAGES_OVERLAY:
+        aoi_img_folder = f"aoi_stimuli_images_{suffix}"
+        source_aoi_img = source_stimulus_dir / aoi_img_folder
+        dest_aoi_img = dest_stimulus_dir / aoi_img_folder
+        if source_aoi_img.exists() and not dest_aoi_img.exists():
+            logger.info(f"Copying {aoi_img_folder}...")
+            shutil.copytree(source_aoi_img, dest_aoi_img)
+
+    # 4. Copy Config folder (includes stimulus order versions)
+    source_config = source_stimulus_dir / "config"
+    dest_config = dest_stimulus_dir / "config"
+    if source_config.exists() and not dest_config.exists():
+        logger.info("Copying config folder...")
+        shutil.copytree(source_config, dest_config)
+
+    # 5. Copy Excel files needed for loading
+    for pattern in ["[!.]*.xlsx", "[!.]*.xls", "[!.]*.csv"]:
+        for file in source_stimulus_dir.glob(pattern):
+            dest_file = dest_stimulus_dir / file.name
+            if not dest_file.exists():
+                shutil.copy2(file, dest_file)
+
+    # 6. Copy used Question Images
+    question_images_folder = f"question_images_{suffix}"
+    source_q_base = source_stimulus_dir / question_images_folder
+    dest_q_base = dest_stimulus_dir / question_images_folder
+
+    if source_q_base.exists():
+        dest_q_base.mkdir(exist_ok=True)
+        used_versions = _get_used_stimulus_versions(eye_tracking_sessions_dir)
+        logger.debug(f"Identified used stimulus versions: {used_versions}")
+        for version in used_versions:
+            v_folder = f"question_images_version_{version}"
+            source_v = source_q_base / v_folder
+            dest_v = dest_q_base / v_folder
+            if source_v.exists() and not dest_v.exists():
+                logger.info(f"Copying {v_folder}...")
+                shutil.copytree(source_v, dest_v)
+
+
+def _get_used_stimulus_versions(eye_tracking_sessions_dir: Path) -> set[int]:
+    used_versions = set()
+    # Check regular sessions
+    for session_folder in eye_tracking_sessions_dir.glob("*"):
+        if session_folder.is_dir() and session_folder.name != "pilot_sessions":
+            _extract_from_session(session_folder, used_versions)
+
+    # Check pilot sessions
+    pilot_dir = eye_tracking_sessions_dir / "pilot_sessions"
+    if pilot_dir.exists():
+        for session_folder in pilot_dir.glob("*"):
+            if session_folder.is_dir():
+                _extract_from_session(session_folder, used_versions)
+
+    return used_versions
+
+
+def _extract_from_session(session_folder: Path, used_versions: set[int]) -> None:
+    # Try ASC files
+    for asc_file in session_folder.glob("[!.]*.asc"):
+        version = extract_stimulus_version_number_from_asc(asc_file)
+        if version != -1:
+            used_versions.add(version)
+            return  # Only need one per session
 
 
 def extract_stimulus_version_number_from_asc(asc_file_path: Path) -> int:

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -15,6 +15,8 @@ from ..utils.fix_multipleye_aoi_files import (
     repair_word_labels,
 )
 
+logger = get_logger()
+
 
 def prepare_language_folder(data_collection_name: str | None = None):
     from preprocessing import settings
@@ -214,7 +216,6 @@ def parse_args():
 
 def main():
     args = parse_args()
-    logger = get_logger(__name__)
 
     logger.info(f"Preparing language folder for {args.data_collection_name}...")
 

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -162,14 +162,14 @@ def prepare_language_folder(data_collection_name: str | None = None):
             len(list(destination_aoi_path.glob("*.csv"))) == 24
             and (destination_aoi_path / ".fixed").exists()
         ):
-            logger.info(
+            logger.debug(
                 f"AOI files already exist, are split and fixed in {destination_aoi_path}. Skipping."
             )
             return
 
     if not destination_aoi_path.exists():
         if source_aoi_path.exists():
-            logger.info(f"Copying AOI files to {destination_aoi_path}...")
+            logger.debug(f"Copying AOI files to {destination_aoi_path}...")
             shutil.copytree(source_aoi_path, destination_aoi_path)
         else:
             logger.warning(f"Source AOI path {source_aoi_path} does not exist.")
@@ -243,7 +243,7 @@ def _copy_stimulus_assets(
     source_img = source_stimulus_dir / stimuli_images_folder
     dest_img = dest_stimulus_dir / stimuli_images_folder
     if source_img.exists() and not dest_img.exists():
-        logger.info(f"Copying {stimuli_images_folder}...")
+        logger.debug(f"Copying {stimuli_images_folder}...")
         shutil.copytree(source_img, dest_img)
 
     # 2. Copy Participant Instruction Images (all)
@@ -251,8 +251,10 @@ def _copy_stimulus_assets(
     source_instr = source_stimulus_dir / instr_images_folder
     dest_instr = dest_stimulus_dir / instr_images_folder
     if source_instr.exists() and not dest_instr.exists():
-        logger.info(f"Copying {instr_images_folder}...")
+        logger.debug(f"Copying {instr_images_folder}...")
         shutil.copytree(source_instr, dest_instr)
+
+    logger.debug("Copying remaining stimulus assets...")
 
     # 3. Copy AOI Stimuli Images Overlay (optional)
     if settings.COPY_AOI_IMAGES_OVERLAY:
@@ -260,14 +262,14 @@ def _copy_stimulus_assets(
         source_aoi_img = source_stimulus_dir / aoi_img_folder
         dest_aoi_img = dest_stimulus_dir / aoi_img_folder
         if source_aoi_img.exists() and not dest_aoi_img.exists():
-            logger.info(f"Copying {aoi_img_folder}...")
+            logger.debug(f"Copying {aoi_img_folder}...")
             shutil.copytree(source_aoi_img, dest_aoi_img)
 
     # 4. Copy Config folder (includes stimulus order versions)
     source_config = source_stimulus_dir / "config"
     dest_config = dest_stimulus_dir / "config"
     if source_config.exists() and not dest_config.exists():
-        logger.info("Copying config folder...")
+        logger.debug("Copying config folder...")
         shutil.copytree(source_config, dest_config)
 
     # 5. Copy Excel files needed for loading
@@ -291,7 +293,7 @@ def _copy_stimulus_assets(
             source_v = source_q_base / v_folder
             dest_v = dest_q_base / v_folder
             if source_v.exists() and not dest_v.exists():
-                logger.info(f"Copying {v_folder}...")
+                logger.debug(f"Copying {v_folder}...")
                 shutil.copytree(source_v, dest_v)
 
 

--- a/preprocessing/scripts/psychometric_tests.py
+++ b/preprocessing/scripts/psychometric_tests.py
@@ -21,7 +21,7 @@ def process_all_psychometric_test_sessions():
     )
 
     args = parser.parse_args()
-    logger = get_logger(__name__)
+    logger = get_logger()
 
     logger.info(
         f"Processing psychometric test sessions from {args.test_session_folder}"

--- a/preprocessing/scripts/restructure_psycho_tests.py
+++ b/preprocessing/scripts/restructure_psycho_tests.py
@@ -9,7 +9,7 @@ import yaml
 from preprocessing.models.sid import Sid
 from preprocessing.utils import get_logger, validate_psychometric_data
 
-logger = get_logger(__name__)
+logger = get_logger()
 
 
 def fix_psycho_tests_structure(

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -13,7 +13,7 @@ from preprocessing.scripts.prepare_language_folder import prepare_language_folde
 
 def run_preprocessing(config_path: str | None = None):
     settings.load(config_path)
-    logger = get_logger(__name__)
+    logger = get_logger()
 
     # Check for configuration issues after loading
     status_msg = settings.get_config_status_message()

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -249,7 +249,7 @@ def run_preprocessing(config_path: str | None = None):
             preprocessing.save_reading_measures(
                 settings.OUTPUT_DIR, session_save_name, reading_measures
             )
-            data_collection[sess].reading_measures = True
+            data_collection[sess.session_identifier].reading_measures = True
 
         pbar.set_description(f"Creating sanity check report {idf}")
         data_collection.create_sanity_check_report(

--- a/preprocessing/utils/data_path_utils.py
+++ b/preprocessing/utils/data_path_utils.py
@@ -34,7 +34,7 @@ def validate_psychometric_data(
     """
     from .logging import get_logger
 
-    logger = get_logger(__name__)
+    logger = get_logger()
 
     issues = {}
 

--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -167,6 +167,10 @@ def setup_logging(
     # Capture warnings
     logging.captureWarnings(True)
 
+    # Silence noisy loggers
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.INFO)
+
     # Note: We use the package-level logger defined at module level
     logger.debug("MultiplEYE preprocessing package logging setup/updated.")
 

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -37,6 +37,9 @@ include_pilots: false
 # The expected sampling rate of the eye tracker in Hertz.
 expected_sampling_rate_hz: 1000
 
+# Whether to copy AOI images overlay to the output directory.
+copy_aoi_images_overlay: false
+
 # ----------------------- Internal Usage -----------------------
 
 # --- LOGGING ---

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -37,6 +37,9 @@ include_pilots: false
 # The expected sampling rate of the eye tracker in Hertz.
 expected_sampling_rate_hz: 1000
 
+# Whether to use aoi overlay or only stimulus images for plotting.
+plot_aoi_overlay: true
+
 # Whether to copy AOI images overlay to the output directory.
 copy_aoi_images_overlay: false
 

--- a/tests/unit/preprocessing/io/test_load_reading_measures.py
+++ b/tests/unit/preprocessing/io/test_load_reading_measures.py
@@ -1,0 +1,35 @@
+import polars as pl
+from preprocessing.io.load import load_reading_measures
+
+
+def test_load_reading_measures_with_actual_filenames(tmp_path):
+    # Setup: Create dummy reading measures files with the reported naming convention
+    session = "017_DA_DK_1_ET1"
+    reading_measures_dir = tmp_path / session / "reading_measures"
+    reading_measures_dir.mkdir(parents=True)
+
+    # Files as reported in the issue
+    filenames = [
+        f"{session}_PRACTICE_trial_1_Enc_WikiMoon_reading_measures.csv",
+        f"{session}_trial_1_Lit_MagicMountain_reading_measures.csv",
+        f"{session}_trial_5_PopSci_MultiplEYE_reading_measures.csv",
+    ]
+
+    for filename in filenames:
+        df = pl.DataFrame({"measure": [1.0], "trial": ["dummy"], "stimulus": ["dummy"]})
+        df.write_csv(reading_measures_dir / filename)
+
+    # Test loading
+    df_loaded = load_reading_measures(reading_measures_dir)
+
+    assert len(df_loaded) == 3
+    assert set(df_loaded["trial"].unique()) == {
+        "PRACTICE_trial_1",
+        "trial_1",
+        "trial_5",
+    }
+    assert set(df_loaded["stimulus"].unique()) == {
+        "Enc_WikiMoon",
+        "Lit_MagicMountain",
+        "PopSci_MultiplEYE",
+    }

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -175,6 +175,13 @@ def test_sid_pid_property_backward_compatibility():
     assert Sid("999_US_US_X_ET2").pid == "999"
 
 
+def test_sid_base_id():
+    """Tests sid.base_id property."""
+    assert Sid("001_EN_UK_1_S1").base_id == "001_EN_UK_1"
+    assert Sid("001_EN_UK_1_S1_extra").base_id == "001_EN_UK_1_extra"
+    assert Sid("017_DA_DK_1_ET1").base_id == "017_DA_DK_1"
+
+
 @pytest.mark.parametrize(
     "sid1_str, sid2_str, expected_match",
     [

--- a/tests/unit/preprocessing/plotting/test_plot_gaze_fallback.py
+++ b/tests/unit/preprocessing/plotting/test_plot_gaze_fallback.py
@@ -1,0 +1,117 @@
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from preprocessing.plotting.plot import plot_gaze
+from preprocessing.data_collection.stimulus import (
+    Stimulus,
+)
+from preprocessing.config import settings
+
+
+@pytest.fixture
+def mock_stimulus():
+    page = MagicMock()
+    page.number = 1
+    page.image_path = Path("stimulus.png")
+    page.aoi_image_path = MagicMock(spec=Path)
+
+    question = MagicMock()
+    question.id = 1
+    question.image_path = Path("question.png")
+    question.aoi_image_path = MagicMock(spec=Path)
+
+    stimulus = MagicMock(spec=Stimulus)
+    stimulus.name = "test_stim"
+    stimulus.id = 1
+    stimulus.pages = [page]
+    stimulus.questions = [question]
+    stimulus.ratings = []
+    return stimulus
+
+
+@pytest.fixture
+def mock_gaze():
+    gaze = MagicMock()
+    gaze.clone.return_value = gaze
+    gaze.experiment.screen.width_px = 1920
+    gaze.experiment.screen.width_cm = 50
+    gaze.experiment.screen.height_px = 1080
+
+    # Mock polars dataframes
+    import polars as pl
+
+    gaze.frame = pl.DataFrame(
+        {
+            "stimulus": ["test_stim_1"],
+            "page": ["page_1"],
+            "pixel_x": [100],
+            "pixel_y": [100],
+        }
+    )
+    gaze.events.frame = pl.DataFrame(
+        {
+            "stimulus": ["test_stim_1"],
+            "page": ["page_1"],
+            "name": ["fixation"],
+            "duration": [100],
+            "location_x": [100],
+            "location_y": [100],
+        }
+    )
+    return gaze
+
+
+@patch("PIL.Image.open")
+@patch("matplotlib.pyplot.subplots")
+def test_plot_gaze_aoi_fallback(
+    mock_subplots, mock_image_open, mock_gaze, mock_stimulus, tmp_path
+):
+    mock_ax = MagicMock()
+    mock_fig = MagicMock()
+    mock_subplots.return_value = (mock_fig, mock_ax)
+
+    # Setup: AOI images do NOT exist
+    # Use real Paths that are relative to settings.OUTPUT_DIR to avoid ValueError
+    page_aoi_path = settings.OUTPUT_DIR / "stimuli/aoi_images/page1_aoi.png"
+    question_aoi_path = settings.OUTPUT_DIR / "stimuli/aoi_images/question1_aoi.png"
+
+    # Ensure they don't exist on disk (mocking exists for Path)
+    with patch.object(Path, "exists", return_value=False):
+        mock_stimulus.pages[0].aoi_image_path = page_aoi_path
+        mock_stimulus.questions[0].aoi_image_path = question_aoi_path
+
+        plot_gaze(mock_gaze, mock_stimulus, tmp_path, aoi_image=True)
+
+    # Verify that PIL.Image.open was called with image_path, not aoi_image_path
+    calls = [call[0][0] for call in mock_image_open.call_args_list]
+    assert mock_stimulus.pages[0].image_path in calls
+    assert mock_stimulus.pages[0].aoi_image_path not in calls
+    assert mock_stimulus.questions[0].image_path in calls
+    assert mock_stimulus.questions[0].aoi_image_path not in calls
+
+
+@patch("PIL.Image.open")
+@patch("matplotlib.pyplot.subplots")
+def test_plot_gaze_aoi_no_fallback(
+    mock_subplots, mock_image_open, mock_gaze, mock_stimulus, tmp_path
+):
+    mock_ax = MagicMock()
+    mock_fig = MagicMock()
+    mock_subplots.return_value = (mock_fig, mock_ax)
+
+    # Setup: AOI images DO exist
+    # Use real Paths that are relative to settings.OUTPUT_DIR to avoid ValueError
+    page_aoi_path = settings.OUTPUT_DIR / "stimuli/aoi_images/page1_aoi.png"
+    question_aoi_path = settings.OUTPUT_DIR / "stimuli/aoi_images/question1_aoi.png"
+
+    # We must mock .exists() on these paths since they won't exist on disk
+    with patch.object(Path, "exists", return_value=True):
+        mock_stimulus.pages[0].aoi_image_path = page_aoi_path
+        mock_stimulus.questions[0].aoi_image_path = question_aoi_path
+
+        plot_gaze(mock_gaze, mock_stimulus, tmp_path, aoi_image=True)
+
+    # Verify that PIL.Image.open was called with aoi_image_path
+    calls = [call[0][0] for call in mock_image_open.call_args_list]
+    assert mock_stimulus.pages[0].aoi_image_path in calls
+    assert mock_stimulus.questions[0].aoi_image_path in calls

--- a/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
+++ b/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
@@ -1,0 +1,248 @@
+import pytest
+import pandas as pd
+from preprocessing.scripts.prepare_language_folder import prepare_language_folder
+from preprocessing import settings
+from preprocessing.models.dcn import Dcn
+from preprocessing.data_collection.multipleye_data_collection import (
+    MultipleyeDataCollection,
+)
+
+
+@pytest.fixture
+def mock_data_collection_factory(tmp_path, monkeypatch):
+    def _create_mock(data_collection_name):
+        dcn = Dcn(data_collection_name)
+        lang, country, lab_no = dcn.lang, dcn.country, dcn.lab
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        collection_dir = data_dir / data_collection_name
+        collection_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create required folders
+        (collection_dir / "eye-tracking-sessions").mkdir(exist_ok=True)
+        (collection_dir / "psychometric-tests-sessions").mkdir(exist_ok=True)
+
+        stimuli_dir = collection_dir / f"stimuli_{data_collection_name}"
+        stimuli_dir.mkdir(exist_ok=True)
+        (stimuli_dir / "config").mkdir(exist_ok=True)
+
+        aoi_dir = stimuli_dir / f"aoi_stimuli_{lang.lower()}_{country.lower()}_{lab_no}"
+        aoi_dir.mkdir(exist_ok=True)
+
+        # Create 12 dummy AOI files to satisfy current validation
+        for i in range(1, 13):
+            aoi_file = aoi_dir / f"test_{i}_aoi.csv"
+            df = pd.DataFrame(
+                {
+                    "page": ["page_1", "page_1", "question_1"],
+                    "word": ["word1", " ", "qword1"],
+                    "char": ["w", " ", "q"],
+                    "word_idx": [0, 0, 0],
+                    "word_idx_in_line": [0, 0, 0],
+                    "line_idx": [0, 0, 0],
+                    "char_idx_in_line": [0, 1, 0],
+                    "top_left_x": [0, 10, 0],
+                    "top_left_y": [0, 0, 100],
+                    "width": [10, 5, 10],
+                    "height": [20, 20, 20],
+                }
+            )
+            df.to_csv(aoi_file, index=False)
+
+        # Mock settings
+        monkeypatch.setattr(settings, "_repo_root", tmp_path)
+        settings.DATA_COLLECTION_NAME = data_collection_name
+        settings.DATASET_DIR = collection_dir
+        settings.OUTPUT_DIR = tmp_path / "preprocessed_data" / data_collection_name
+
+        return tmp_path, data_collection_name, aoi_dir
+
+    return _create_mock
+
+
+def setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir):
+    dcn = Dcn(data_collection_name)
+    lang, country, city, lab_no = dcn.lang, dcn.country, dcn.city, dcn.lab
+    suffix = f"{lang.lower()}_{country.lower()}_{lab_no}"
+    stimuli_dir = aoi_dir.parent
+
+    img_dir = stimuli_dir / f"stimuli_images_{suffix}"
+    img_dir.mkdir(exist_ok=True)
+    (img_dir / "test_img.png").touch()
+
+    q_dir = stimuli_dir / f"question_images_{suffix}"
+    q_dir.mkdir(exist_ok=True)
+    v1_dir = q_dir / "question_images_version_1"
+    v1_dir.mkdir(exist_ok=True)
+    (v1_dir / "q1.png").touch()
+    v2_dir = q_dir / "question_images_version_2"
+    v2_dir.mkdir(exist_ok=True)
+    (v2_dir / "q2.png").touch()
+
+    xlsx_file = stimuli_dir / f"multipleye_stimuli_experiment_{lang}.xlsx"
+    xlsx_file.touch()
+
+    # Create a dummy config file
+    config_dir = stimuli_dir / "config"
+    config_dir.mkdir(exist_ok=True)
+    config_file = (
+        config_dir
+        / f"config_{lang.lower()}_{country.lower()}_{city.lower()}_{lab_no}_dummy.py"
+    )
+    with open(config_file, "w") as f:
+        f.write("RESOLUTION = (1920, 1080)\n")
+        f.write("SCREEN_SIZE_CM = (50, 30)\n")
+        f.write("DISTANCE_CM = 60\n")
+        f.write("IMAGE_WIDTH_PX = 1000\n")
+        f.write("IMAGE_HEIGHT_PX = 800\n")
+        f.write("IMAGE_SIZE_CM = (20, 15)\n")
+
+    json_config = (
+        config_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{lab_no}_{dcn.year}_lab_configuration.json"
+    )
+    with open(json_config, "w") as f:
+        f.write(
+            '{"Name_eye-tracker": "EyeLink 1000 Plus", "Psychometric_tests": {"Are_tests_conducted": true}}'
+        )
+
+    # Create a session with an ASC file indicating version 1
+    session_name = f"001_{lang}_{country}_{lab_no}_ET1"
+    eye_tracking_dir = (
+        tmp_path / "data" / data_collection_name / "eye-tracking-sessions"
+    )
+    session_dir = eye_tracking_dir / session_name
+    session_dir.mkdir(exist_ok=True)
+    asc_file = session_dir / f"{session_name}.asc"
+    with open(asc_file, "w") as f:
+        f.write("MSG 123456 stimulus_order_version: 1\n")
+    # Add dummy EDF file
+    (session_dir / f"{session_name}.edf").touch()
+
+    # Create stimulus order versions CSV
+    stim_order_file = (
+        config_dir / f"stimulus_order_versions_{lang}_{country}_{lab_no}.csv"
+    )
+    with open(stim_order_file, "w") as f:
+        f.write("participant_id,version_number\n")
+        f.write("001,1\n")
+
+    return suffix, lang
+
+
+@pytest.mark.parametrize(
+    "data_collection_name",
+    ["MultiplEYE_DA_DK_Aalborg_1_2026", "MultiplEYE_EN_UK_London_2_2025"],
+)
+def test_prepare_language_folder_copies_and_modifies_in_preprocessed(
+    mock_data_collection_factory, data_collection_name
+):
+    tmp_path, data_collection_name, aoi_dir = mock_data_collection_factory(
+        data_collection_name
+    )
+    suffix, lang = setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
+    dcn = Dcn(data_collection_name)
+
+    # Run preparation
+    prepare_language_folder(data_collection_name)
+
+    # Verify that the file in data/ was NOT modified (should still be 12 files)
+    files_data = list(aoi_dir.glob("*.csv"))
+    assert len(files_data) == 12
+
+    # Verify preprocessed_data exists and contains 24 files + marker
+    preprocessed_stim_dir = (
+        tmp_path
+        / "preprocessed_data"
+        / data_collection_name
+        / f"stimuli_{data_collection_name}"
+    )
+    preprocessed_aoi_dir = (
+        preprocessed_stim_dir
+        / f"aoi_stimuli_{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
+    )
+    assert preprocessed_aoi_dir.exists()
+
+    files_preprocessed = list(preprocessed_aoi_dir.glob("*.csv"))
+    assert len(files_preprocessed) == 24
+    assert (preprocessed_aoi_dir / ".fixed").exists()
+
+    # Verify other assets were copied
+    assert (
+        preprocessed_stim_dir / f"stimuli_images_{suffix}" / "test_img.png"
+    ).exists()
+    assert (
+        preprocessed_stim_dir / f"multipleye_stimuli_experiment_{lang}.xlsx"
+    ).exists()
+    assert (preprocessed_stim_dir / "config").exists()
+
+    # Verify ONLY used question version was copied
+    assert (
+        preprocessed_stim_dir
+        / f"question_images_{suffix}"
+        / "question_images_version_1"
+    ).exists()
+    assert not (
+        preprocessed_stim_dir
+        / f"question_images_{suffix}"
+        / "question_images_version_2"
+    ).exists()
+
+
+@pytest.mark.parametrize("data_collection_name", ["MultiplEYE_DA_DK_Aalborg_1_2026"])
+def test_multipleye_data_collection_uses_preprocessed_stimuli(
+    mock_data_collection_factory, data_collection_name
+):
+    tmp_path, data_collection_name, aoi_dir = mock_data_collection_factory(
+        data_collection_name
+    )
+    setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
+
+    # Run preparation first to create preprocessed stimuli
+    prepare_language_folder(data_collection_name)
+
+    # Create the data collection
+    mdc = MultipleyeDataCollection.create_from_data_folder(settings.DATASET_DIR)
+
+    # Verify that stimulus_dir points to preprocessed_data
+    expected_stim_dir = (
+        tmp_path
+        / "preprocessed_data"
+        / data_collection_name
+        / f"stimuli_{data_collection_name}"
+    )
+    assert mdc.stimulus_dir == expected_stim_dir
+
+
+@pytest.mark.parametrize("data_collection_name", ["MultiplEYE_DA_DK_Aalborg_1_2026"])
+def test_prepare_language_folder_optional_aoi_images(
+    mock_data_collection_factory, data_collection_name
+):
+    tmp_path, data_collection_name, aoi_dir = mock_data_collection_factory(
+        data_collection_name
+    )
+    suffix, lang = setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
+
+    # Create AOI stimuli images folder
+    stimuli_dir = aoi_dir.parent
+    aoi_img_dir = stimuli_dir / f"aoi_stimuli_images_{suffix}"
+    aoi_img_dir.mkdir()
+    (aoi_img_dir / "overlay.png").touch()
+
+    # Set config to True
+    settings.COPY_AOI_IMAGES_OVERLAY = True
+
+    # Run preparation
+    prepare_language_folder(data_collection_name)
+
+    # Verify it was copied
+    preprocessed_stim_dir = (
+        tmp_path
+        / "preprocessed_data"
+        / data_collection_name
+        / f"stimuli_{data_collection_name}"
+    )
+    assert (
+        preprocessed_stim_dir / f"aoi_stimuli_images_{suffix}" / "overlay.png"
+    ).exists()


### PR DESCRIPTION

This PR ensures that the original `data/` folder remains untouched by redirecting all stimulus copying and AOI preprocessing (splitting, remapping, and repairing) to the `preprocessed_data/` directory. It also includes several stability fixes and logic improvements for session filtering and data parsing.

### Changes

**Stimulus and AOI Asset Management**

*   **Data Safety**: Refactored `prepare_language_folder.py` to copy stimulus assets to the output directory before any modifications occur.
*   **Selective Copying**: Implemented logic to scan participant ASC files and only copy the question image versions actually used during sessions, saving storage space.
*   **AOI Preprocessing**: Redirected AOI splitting and fixing (remapping/repairing) to operate exclusively on files within the `preprocessed_data/` directory.
*   **Idempotency**: Introduced a `.fixed` marker file in the preprocessed AOI folder to guarantee that repairs are applied exactly once and redundant processing is skipped in subsequent runs.
*   **Data Flow**: Updated `MultipleyeDataCollection` to automatically prioritize loading stimuli from the preprocessed folder if it exists.

**Plotting and Fallback Mechanisms**
*   **Overlay Plotting**: Added a `plot_aoi_overlay` configuration option.
*   **Fallback Logic**: Updated `plot_gaze` to intelligently search for AOI overlay images in both `preprocessed_data/` and the original `data/` folder, falling back to standard stimulus images if neither is found. This prevents `FileNotFoundError` when overlays are not copied.

**Data Loading and Parsing Fixes**
*   **Reading Measures**: Fixed a `ValueError` in `load_reading_measures` by implementing a glob-then-regex approach for file discovery. The regex was also improved to support practice trials and various stimulus naming conventions.
*   **Participant Data**: Corrected the participant data filename parsing in `MultipleyeDataCollection` to match the official `[ID]_[LANG]_[COUNTRY]_[LAB]` convention, fixing a warning where questionnaire data was not found.

#### Tests

*   Added 22 unit tests:
    *   Stimulus preparation and selective version copying.
    *   Session inclusion/exclusion validation.
    *   Robust reading measures loading with regex.
    *   Gaze plotting fallback behavior.
    *   Logging level enforcement.
* Manually tested on Merid data collection
  
## Example

Run it once with an empty `preprocessed_data/` folder (DEBUG messages are not there by default):

```txt
2026-06-09 13:52:37,646 - preprocessing - INFO - Pipeline version: 2026.6.9
2026-06-09 13:52:37,647 - preprocessing - INFO - Last updated (git): v2026.06.09-15-g3a224e2 (2026-06-09 13:50:13 +0200)
2026-06-09 13:52:37,647 - preprocessing - INFO - pymovements version: 0.27.0+post0.29f61aed.dirty
2026-06-09 13:52:37,694 - preprocessing - INFO - Running MultiplEYE preprocessing for data collection: MultiplEYE_DA_DK_Aalborg_1_2026
2026-06-09 13:52:37,694 - preprocessing.scripts.prepare_language_folder - DEBUG - Copying AOI files to ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1...
2026-06-09 13:52:38,049 - preprocessing - INFO - Copying stimulus assets to ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026...
2026-06-09 13:52:38,049 - preprocessing - DEBUG - Copying stimuli_images_da_dk_1...
2026-06-09 13:52:38,100 - preprocessing - DEBUG - Copying participant_instructions_images_da_dk_1...
2026-06-09 13:52:38,108 - preprocessing - DEBUG - Copying remaining stimulus assets...
2026-06-09 13:52:38,108 - preprocessing - DEBUG - Copying config folder...
2026-06-09 13:52:38,191 - preprocessing - DEBUG - Identified used stimulus versions: {161, 229, 170, 203, 79, 95}
2026-06-09 13:52:38,191 - preprocessing - DEBUG - Copying question_images_version_161...
2026-06-09 13:52:38,217 - preprocessing - DEBUG - Copying question_images_version_229...
2026-06-09 13:52:38,245 - preprocessing - DEBUG - Copying question_images_version_170...
2026-06-09 13:52:38,267 - preprocessing - DEBUG - Copying question_images_version_203...
2026-06-09 13:52:38,291 - preprocessing - DEBUG - Copying question_images_version_79...
2026-06-09 13:52:38,311 - preprocessing - DEBUG - Copying question_images_version_95...
2026-06-09 13:52:38,338 - preprocessing.scripts.prepare_language_folder - DEBUG - Applying AOI fixes (remapping space and repairing labels)...
2026-06-09 13:52:41,364 - preprocessing - DEBUG - Remapped space to following word for AOI file: ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1/ins_learningmobility_3_aoi_questions.csv
2026-06-09 13:52:42,120 - preprocessing - DEBUG - Filled missing word labels in AOI file: ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1/ins_learningmobility_3_aoi_questions.csv
2026-06-09 13:52:44,493 - preprocessing - DEBUG - Remapped space to following word for AOI file: ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1/lit_magicmountain_6_aoi_questions.csv
...
2026-06-09 13:53:12,224 - preprocessing - DEBUG - Remapped space to following word for AOI file: ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1/popsci_multipleye_1_aoi_questions.csv
2026-06-09 13:53:13,046 - preprocessing - DEBUG - Filled missing word labels in AOI file: ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1/popsci_multipleye_1_aoi_questions.csv
2026-06-09 13:53:13,052 - preprocessing - INFO - Lab config loaded from ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/config/config_da_dk_Aalborg_1_2026.py
2026-06-09 13:53:13,052 - preprocessing - INFO - JSON lab config loaded from ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/config/MultiplEYE_DA_DK_Aalborg_1_2026_lab_configuration.json
2026-06-09 13:53:13,052 - preprocessing - INFO - MultipleyeDataCollection initialized. data_root: ~/data/MultiplEYE_DA_DK_Aalborg_1_2026/eye-tracking-sessions
2026-06-09 13:53:13,052 - preprocessing - INFO - Main config loaded from ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/config/config_da_dk_Aalborg_1.py
Converting EDF to ASC: 100%|█████████...
```

Cancelling and running it again:

```txt
2026-06-09 14:10:42,990 - preprocessing - INFO - Pipeline version: 2026.6.9
2026-06-09 14:10:42,991 - preprocessing - INFO - Last updated (git): v2026.06.09-15-g3a224e2 (2026-06-09 13:50:13 +0200)
2026-06-09 14:10:42,991 - preprocessing - INFO - pymovements version: 0.27.0+post0.29f61aed.dirty
2026-06-09 14:10:43,038 - preprocessing - INFO - Running MultiplEYE preprocessing for data collection: MultiplEYE_DA_DK_Aalborg_1_2026
2026-06-09 14:10:43,039 - preprocessing.scripts.prepare_language_folder - DEBUG - AOI files already exist, are split and fixed in ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/aoi_stimuli_da_dk_1. Skipping.
2026-06-09 14:10:43,041 - preprocessing - INFO - Lab config loaded from ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/config/config_da_dk_Aalborg_1_2026.py
2026-06-09 14:10:43,041 - preprocessing - INFO - JSON lab config loaded from ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/config/MultiplEYE_DA_DK_Aalborg_1_2026_lab_configuration.json
2026-06-09 14:10:43,041 - preprocessing - INFO - MultipleyeDataCollection initialized. data_root: ~/data/MultiplEYE_DA_DK_Aalborg_1_2026/eye-tracking-sessions
2026-06-09 14:10:43,041 - preprocessing - INFO - Main config loaded from ~/preprocessed_data/MultiplEYE_DA_DK_Aalborg_1_2026/stimuli_MultiplEYE_DA_DK_Aalborg_1_2026/config/config_da_dk_Aalborg_1.py
Converting EDF to ASC: 100%|███████...
```

This then takes no time.

Closes #82 

#### Depends on

- [x] #91 
- [x] #95