### PR TITLE
chore: Refactor session list validation and filtering logic

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,15 +41,32 @@ sure that all files are generated again, and the error should not occur anymore 
 choosing overwrite.
 :::
 
+:::{dropdown} ValueError: Both 'included_sessions' and 'excluded_sessions' are provided and not
+empty.
 
----
+This error occurs when you have both `include_sessions` and `exclude_sessions` defined in your
+configuration file (i.e. `multipleye_settings_preprocessing.yaml`). The pipeline only supports
+using one type of filter at a time to avoid ambiguity.
 
+**What to do:**
+
+- **Decide on a Filter Type:** Determine if you want to use a whitelist (only process specific
+  sessions)
+  or a blacklist (skip specific sessions).
+- **Update Configuration:**
+    - If you want to process **only specific sessions**, fill `include_sessions` and leave
+      `exclude_sessions` empty (i.e. `exclude_sessions: []`).
+    - If you want to **skip specific sessions**, fill `exclude_sessions` and leave
+      `include_sessions` empty (i.e. `include_sessions: []`).
+    - If you want to process **all sessions**, leave both lists empty.
+
+:::
 
 (errors_restructuring)=
 
 ## Psychometric Tests Restructuring Errors
 
-::::{dropdown} !!! MISSING DATA !!!: Participant [ID] is marked for [Test] in participant
+:::{dropdown} !!! MISSING DATA !!!: Participant [ID] is marked for [Test] in participant
 configuration ([Config]), but the data folder does not exist at: [Path].
 
 This warning occurs during the restructuring of psychometric tests when a test is marked as `True`
@@ -69,9 +86,10 @@ source directory.
 - **Update Configuration:** If the test was not supposed to be run for this participant (e.g., it
   was skipped intentionally), you can update the participant's YAML configuration file by setting
   the corresponding test flag to `false` to silence this warning.
-  ::::
 
-::::{dropdown} Participant [ID] has data for [Test], but it is marked as False (or missing) in
+:::
+
+:::{dropdown} Participant [ID] has data for [Test], but it is marked as False (or missing) in
 participant config ([Config]). Copying anyway.
 
 This warning indicates that the script found a data folder for a specific test, but that test is
@@ -92,15 +110,14 @@ configuration.
   the participant's YAML configuration file by setting the corresponding test flag to `true`.
 - **Verify Consistency:** If the test should not have been run, you might want to investigate why
   data exists for it. However, the data will still be processed if it exists.
-  ::::
 
----
+:::
 
 (errors_calculation)=
 
 ## Psychometric Tests Calculation Warnings
 
-:::::{dropdown} [Participant ID] [Test] test skipped: [Error Message]
+:::{dropdown} [Participant ID] [Test] test skipped: [Error Message]
 
 This warning occurs when the script attempts to calculate summary metrics for a psychometric test,
 but the data is missing, incomplete, or malformed.
@@ -124,7 +141,8 @@ The warning includes additional context based on the participant's YAML configur
 - **Update Configuration:** If the test failed but was not intended to be used anyway, you can set
   the flag to `false` in the participant's YAML configuration. This will clarify the intent,
   although the technical skip warning may still appear if the data folder exists.
-  :::::
+
+:::
 
 ---
 

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -235,20 +235,14 @@ class MultipleyeDataCollection:
                 if item.is_dir():
                     if re.match(session_folder_regex, item.name, re.IGNORECASE):
                         found_sessions.append(item.name)
-                        if (
-                            (
-                                self.excluded_sessions
-                                and item.name not in self.excluded_sessions
-                            )
-                            or (
-                                self.included_sessions
-                                and item.name in self.included_sessions
-                            )
-                            or (
-                                not self.excluded_sessions
-                                and not self.included_sessions
-                            )
-                        ):
+                        # Determine if the session should be included based on filters
+                        keep = True
+                        if self.included_sessions:
+                            keep = item.name in self.included_sessions
+                        elif self.excluded_sessions:
+                            keep = item.name not in self.excluded_sessions
+
+                        if keep:
                             session_file = list(
                                 Path(item.path).glob("*" + session_file_suffix)
                             )
@@ -377,13 +371,16 @@ class MultipleyeDataCollection:
         MultipleyeDataCollection object
         """
 
-        if excluded_sessions is None:
-            excluded_sessions = []
-        elif included_sessions is None:
-            included_sessions = []
-        else:
+        excluded_sessions = excluded_sessions or []
+        included_sessions = included_sessions or []
+
+        if excluded_sessions and included_sessions:
             raise ValueError(
-                "Either excluded_sessions or included_sessions can be provided, not both."
+                "Both 'included_sessions' and 'excluded_sessions' are provided and not empty. "
+                "The pipeline only supports using one type of filter at a time to avoid ambiguity. "
+                "Please check your configuration and ensure that either 'include_sessions' is used "
+                "to process only specific sessions, or 'exclude_sessions' is used to skip specific sessions, "
+                "but not both."
             )
         data_dir = Path(data_dir)
 

--- a/tests/unit/preprocessing/data_collection/test_session_lists.py
+++ b/tests/unit/preprocessing/data_collection/test_session_lists.py
@@ -1,0 +1,127 @@
+import pytest
+import pandas as pd
+from preprocessing.data_collection.multipleye_data_collection import (
+    MultipleyeDataCollection,
+)
+
+
+@pytest.fixture
+def mock_lab_config(monkeypatch):
+    """Fixture to mock MultipleyeDataCollection.load_lab_config."""
+
+    class MockLabConfig:
+        def __init__(self):
+            self.name_eye_tracker = "EyeLink 1000 Plus"
+            self.psychometric_tests = {}
+
+    monkeypatch.setattr(
+        MultipleyeDataCollection,
+        "load_lab_config",
+        lambda *args, **kwargs: MockLabConfig(),
+    )
+
+
+@pytest.fixture
+def dummy_data_dir(tmp_path):
+    """Fixture to create a dummy data collection folder structure."""
+    collection_name = "MultiplEYE_EN_UK_London_1_2025"
+    data_dir = tmp_path / collection_name
+    data_dir.mkdir()
+
+    et_sessions_dir = data_dir / "eye-tracking-sessions"
+    et_sessions_dir.mkdir()
+    (data_dir / "psychometric-tests").mkdir()
+    stimuli_dir = data_dir / f"stimuli_{collection_name}"
+    stimuli_dir.mkdir()
+    config_dir = stimuli_dir / "config"
+    config_dir.mkdir()
+
+    # Create dummy stimulus order versions file
+    df = pd.DataFrame({"participant_id": [1, 2, 3], "version_number": [1, 1, 1]})
+    df.to_csv(config_dir / "stimulus_order_versions_EN_UK_1.csv", index=False)
+
+    # Create dummy session folders
+    for s_id in ["001_EN_UK_1_ET1", "002_EN_UK_1_ET1", "003_EN_UK_1_ET1"]:
+        s_path = et_sessions_dir / s_id
+        s_path.mkdir()
+        (s_path / "data.edf").touch()
+
+    return data_dir
+
+
+@pytest.mark.parametrize(
+    "included, excluded",
+    [
+        (["001_EN_UK_1_ET1"], []),  # Only included
+        (["001_EN_UK_1_ET1"], {}),
+        ([], ["003_EN_UK_1_ET1"]),  # Only excluded
+        ({}, ["003_EN_UK_1_ET1"]),
+        ([], {"003_EN_UK_1_ET1"}),
+        ([], []),  # Both empty
+        (["001_EN_UK_1_ET1"], None),  # Excluded None
+        (None, ["003_EN_UK_1_ET1"]),  # Included None
+        (None, None),  # Both None
+    ],
+)
+def test_create_from_data_folder_valid_session_lists(
+    dummy_data_dir, mock_lab_config, included, excluded
+):
+    """Test that valid session lists (at most one non-empty) work correctly."""
+    dc = MultipleyeDataCollection.create_from_data_folder(
+        dummy_data_dir, included_sessions=included, excluded_sessions=excluded
+    )
+
+    included_sessions = included or []
+    excluded_sessions = excluded or []
+
+    if included_sessions:
+        assert set(dc.sessions.keys()) == set(included_sessions)
+    elif excluded_sessions:
+        expected = {"001_EN_UK_1_ET1", "002_EN_UK_1_ET1", "003_EN_UK_1_ET1"} - set(
+            excluded_sessions
+        )
+        assert set(dc.sessions.keys()) == expected
+    else:
+        assert set(dc.sessions.keys()) == {
+            "001_EN_UK_1_ET1",
+            "002_EN_UK_1_ET1",
+            "003_EN_UK_1_ET1",
+        }
+
+
+def test_create_from_data_folder_both_not_empty_error(dummy_data_dir, mock_lab_config):
+    """Test that providing both included and excluded sessions raises a detailed ValueError."""
+    included = ["001_EN_UK_1_ET1"]
+    excluded = ["003_EN_UK_1_ET1"]
+
+    expected_msg = (
+        "Both 'included_sessions' and 'excluded_sessions' are provided and not empty"
+    )
+    with pytest.raises(ValueError, match=expected_msg):
+        MultipleyeDataCollection.create_from_data_folder(
+            dummy_data_dir, included_sessions=included, excluded_sessions=excluded
+        )
+
+
+@pytest.mark.parametrize(
+    "included, excluded, expected_count",
+    [
+        (["001_EN_UK_1_ET1", "002_EN_UK_1_ET1"], [], 2),
+        ([], ["001_EN_UK_1_ET1"], 2),
+        (["non_existent"], [], 0),  # Will raise ValueError because no sessions found
+    ],
+)
+def test_filtering_logic_regression(
+    dummy_data_dir, mock_lab_config, included, excluded, expected_count
+):
+    """Regression test for the filtering logic in add_recorded_sessions."""
+    if expected_count == 0:
+        with pytest.raises(ValueError, match="No sessions found"):
+            MultipleyeDataCollection.create_from_data_folder(
+                dummy_data_dir, included_sessions=included, excluded_sessions=excluded
+            )
+    else:
+        dc = MultipleyeDataCollection.create_from_data_folder(
+            dummy_data_dir, included_sessions=included, excluded_sessions=excluded
+        )
+        assert len(dc.sessions) == expected_count


### PR DESCRIPTION
- add troubleshooting item for the session filtering error
- improve error message for session filtering logic to enforce exclusive use of `included_sessions` or `excluded_sessions`.
- Add unit tests to validate session inclusion/exclusion scenarios and better cover edge cases.

This change ensures consistent behavior when filtering sessions by strictly enforcing that only one type of filter (inclusion or exclusion) is active at a time.

- [x] Updated `create_from_data_folder` to raise a `ValueError` if both `included_sessions` and `excluded_sessions` are non-empty. Now also allow empty lists or sets, not just `None`. This is needed for the new template config default setting.
- [x] Improved `add_recorded_sessions` filtering logic to be more readable and correctly respect the "include only" list when specified.
- [x] support for empty lists and `None` values to prevent initialization errors.
- [x] Add unit tests to verify the new validation rules.

This approach is most intuitive for the user experience: the user either defines exactly what they want (inclusion) or what they don't want (exclusion). If both are given, the error explains.
