### PR TITLE
feat: Add "EyeLink 1000+" to supported eyetrackers

### DIFF
--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -478,6 +478,7 @@ class Settings:
         self.EYETRACKER_NAMES = {
             "eyelink": [
                 "EyeLink 1000 Plus",
+                "EyeLink 1000+",
                 "EyeLink II",
                 "EyeLink 1000",
                 "EyeLink Portable Duo",


### PR DESCRIPTION
This adds "EyeLink 1000+" to the known eyetrackers. Before only writing it as "EyeLink 1000 Plus" was allowed, among other EyeLink models.