### PR TITLE
chore: Improve logging init

### DIFF
--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -555,18 +555,21 @@ class Settings:
             if path:
                 self.load_from_yaml(path)
                 self._config_found = True
+                self._apply_logging_settings()
                 return
 
             env_path = os.getenv("MULTIPLEYE_CONFIG")
             if env_path:
                 self.load_from_yaml(env_path)
                 self._config_found = True
+                self._apply_logging_settings()
                 return
 
             cwd_default = Path.cwd() / "multipleye_settings_preprocessing.yaml"
             if cwd_default.exists():
                 self.load_from_yaml(cwd_default)
                 self._config_found = True
+                self._apply_logging_settings()
                 return
 
             # No config found, try to create from template
@@ -580,11 +583,29 @@ class Settings:
             self._is_template_loaded = True
             if cwd_default.exists():
                 self.load_from_yaml(cwd_default)
+                self._apply_logging_settings()
 
             return
 
         finally:
             self._loading = False
+
+    def _apply_logging_settings(self) -> None:
+        """Apply logging settings from configuration to the active logger."""
+        # Use the package-level setup_logging to ensure consistent behaviour
+        from .utils.logging import setup_logging, clear_log_file
+
+        log_file = self.DATASET_DIR / "preprocessing_logs.txt"
+        if not self.DATASET_DIR.exists():
+            log_file = None
+        elif not self.APPEND_LOGS:
+            clear_log_file(log_file)
+
+        setup_logging(
+            log_file=log_file,
+            console_level=self.CONSOLE_LOG_LEVEL,
+            file_level=self.FILE_LOG_LEVEL,
+        )
 
     def create_config_template(
         self, target_path: Path, collection_name: str | None = None
@@ -672,7 +693,7 @@ class Settings:
         if not path.exists():
             raise FileNotFoundError(f"Config file not found: {path}")
 
-        logger.info(f"Loading config from: {path}")
+        logger.debug(f"Loading config from: {path}")
 
         with open(path, "r") as f:
             user_configs = yaml.safe_load(f)

--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 import pymovements as pm
 
+# Package-level logger
 logger = logging.getLogger("preprocessing")
+
+# Track if setup_logging has been called before
+_logging_initialized = False
 
 
 def get_logger(name: str | None = None) -> logging.Logger:
@@ -164,7 +168,7 @@ def setup_logging(
     logging.captureWarnings(True)
 
     # Note: We use the package-level logger defined at module level
-    logger.info("MultiplEYE preprocessing package loaded.")
+    logger.debug("MultiplEYE preprocessing package logging setup/updated.")
 
     # Add regex filter to root logger and py.warnings logger
     class RegexFilter(logging.Filter):
@@ -193,9 +197,15 @@ def setup_logging(
 
     # Log versions
     pipeline_version, last_update = get_pipeline_info()
-    logger.info(f"Pipeline version: {pipeline_version}")
-    logger.info(f"Last updated (git): {last_update}")
-    logger.info(f"pymovements version: {pm.__version__}")
+
+    global _logging_initialized
+    version_log_level = logging.INFO if not _logging_initialized else logging.DEBUG
+
+    logger.log(version_log_level, f"Pipeline version: {pipeline_version}")
+    logger.log(version_log_level, f"Last updated (git): {last_update}")
+    logger.log(version_log_level, f"pymovements version: {pm.__version__}")
+
+    _logging_initialized = True
 
     # Initialise a list to store warnings for the summary report
     if not hasattr(logging, "_captured_warnings"):

--- a/tests/unit/utils/test_logging_levels.py
+++ b/tests/unit/utils/test_logging_levels.py
@@ -1,0 +1,47 @@
+import logging
+from unittest.mock import patch
+import preprocessing.utils.logging as logging_utils
+
+
+def test_setup_logging_version_levels():
+    """Test that pipeline info is logged as INFO first, then DEBUG."""
+    # Reset the initialisation flag for testing
+    with patch("preprocessing.utils.logging._logging_initialized", False):
+        # We need to capture what's being logged to a custom handler or mock logger
+        with patch("preprocessing.utils.logging.logger.log") as mock_log:
+            logging_utils.setup_logging()
+
+            # Check if any call was INFO and contained "Pipeline version"
+            info_calls = [
+                call for call in mock_log.call_args_list if call[0][0] == logging.INFO
+            ]
+            assert any("Pipeline version" in call[0][1] for call in info_calls)
+
+            mock_log.reset_mock()
+
+            # Second call should be DEBUG
+            logging_utils.setup_logging()
+
+            debug_calls = [
+                call for call in mock_log.call_args_list if call[0][0] == logging.DEBUG
+            ]
+            assert any("Pipeline version" in call[0][1] for call in debug_calls)
+            assert not any(
+                call[0][0] == logging.INFO for call in mock_log.call_args_list
+            )
+
+
+def test_setup_logging_respects_levels():
+    """Test that setup_logging correctly sets the console level."""
+    # Reset state
+    with patch("preprocessing.utils.logging._logging_initialized", True):
+        # Set to WARNING, should not show INFO/DEBUG
+        logging_utils.setup_logging(console_level=logging.WARNING)
+
+        # Check handler level
+        found_console = False
+        for handler in logging.getLogger().handlers:
+            if isinstance(handler, logging.StreamHandler):
+                assert handler.level == logging.WARNING
+                found_console = True
+        assert found_console


### PR DESCRIPTION
Improve logging initialisation so that version info is logged at INFO level on first `setup_logging` call, but at DEBUG level on subsequent calls. Also apply logging settings (log file, console/file levels) from the YAML config immediately after loading it, ensuring the logger is configured before any processing begins.

## Changes
- [x] Track `_logging_initialized` flag in `preprocessing/utils/logging.py`
- [x] Log pipeline version as INFO on first call, DEBUG on subsequent calls.
  - This way we always see what version users have, but only when first importing the package, not when reloading the configs (internal logic)
- [x] Add `_apply_logging_settings()` to `preprocessing/config.py` to wire up config values to the logger
- [x] Change config loading message from `info` to `debug` (it fires before logging is fully configured; decluttering the user's console)
- [x] Add unit tests for version log level behaviour and console level configuration