### PR TITLE
feat: Log `edf2asc` version during logging setup

### DIFF
--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -68,6 +68,35 @@ def get_pipeline_info() -> tuple[str, str]:
     return version, last_update
 
 
+def get_edf2asc_version() -> str:
+    """Get the version of the edf2asc executable.
+
+    Returns
+    -------
+    str
+        edf2asc version or "unknown".
+    """
+    try:
+        output = subprocess.run(
+            ["edf2asc", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+        # Find the line starting with "EDF2ASC version"
+        for line in output.splitlines():
+            if "EDF2ASC version" in line:
+                return line.strip()
+        # Fallback if the string is not found but command succeeded
+        return (
+            output.splitlines()[1].strip()
+            if len(output.splitlines()) > 1
+            else "unknown"
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
 def setup_logging(
     log_file: Path | str | None = None,
     console_level: int | str | None = None,
@@ -204,6 +233,7 @@ def setup_logging(
     logger.log(version_log_level, f"Pipeline version: {pipeline_version}")
     logger.log(version_log_level, f"Last updated (git): {last_update}")
     logger.log(version_log_level, f"pymovements version: {pm.__version__}")
+    logger.log(version_log_level, f"edf2asc version: {get_edf2asc_version()}")
 
     _logging_initialized = True
 

--- a/tests/unit/utils/test_edf2asc_logging.py
+++ b/tests/unit/utils/test_edf2asc_logging.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch, MagicMock
+from preprocessing.utils.logging import get_edf2asc_version
+
+
+def test_get_edf2asc_version_success():
+    """Test get_edf2asc_version when edf2asc is available and returns version info."""
+    mock_output = "EDF2ASC version 4.2.1197.0 MacOS X standalone Sep 27 2024\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=mock_output, returncode=0)
+        version = get_edf2asc_version()
+        assert version == "EDF2ASC version 4.2.1197.0 MacOS X standalone Sep 27 2024"
+        mock_run.assert_called_once_with(
+            ["edf2asc", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+def test_get_edf2asc_version_not_found():
+    """Test get_edf2asc_version when edf2asc is not found (CI scenario)."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = FileNotFoundError
+        version = get_edf2asc_version()
+        assert version == "unknown"
+
+
+def test_get_edf2asc_version_error_exit_code():
+    """Test get_edf2asc_version when edf2asc returns a non-zero exit code (like on MacOS)."""
+    # The current implementation uses subprocess.run(..., check=False).stdout
+    # So it doesn't care about the exit code if stdout is captured.
+    mock_output = "EDF2ASC version 4.2.1197.0 MacOS X standalone Sep 27 2024\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=mock_output, returncode=255)
+        version = get_edf2asc_version()
+        assert version == "EDF2ASC version 4.2.1197.0 MacOS X standalone Sep 27 2024"
+
+
+def test_get_edf2asc_version_unexpected_output():
+    """Test get_edf2asc_version when the output doesn't contain 'EDF2ASC version'."""
+    mock_output = "Some other tool v1.0\nLine 2: data\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=mock_output, returncode=0)
+        version = get_edf2asc_version()
+        # Fallback logic: return output.splitlines()[1].strip() if len > 1
+        assert version == "Line 2: data"
+
+
+def test_get_edf2asc_version_empty_output():
+    """Test get_edf2asc_version when the output is empty."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        version = get_edf2asc_version()
+        assert version == "unknown"


### PR DESCRIPTION
This PR adds the logging of the `edf2asc` version when the preprocessing package is initialised. This improves traceability and reproducibility by documenting the exact version of the external Eyelink conversion tool used in the pipeline.

The implementation is robust to:
- [x] When `edf2asc` is not installed it defaults to "unknown".
- [x] MacOS environments where `edf2asc --version` returns a non-zero exit code (255) despite succeeding.
- [ ] Windows is not tested yet

It should looks something like this:

```txt
2026-06-10 08:26:50,201 - preprocessing - INFO - Pipeline version: 2026.6.9
2026-06-10 08:26:50,201 - preprocessing - INFO - Last updated (git): v2026.06.09-23-g01e71a8 (2026-06-09 16:43:15 +0200)
2026-06-10 08:26:50,201 - preprocessing - INFO - pymovements version: 0.27.0+post0.29f61aed.dirty
2026-06-10 08:26:50,277 - preprocessing - INFO - edf2asc version: EDF2ASC version 4.2.1197.0 MacOS X   standalone Sep 27 2024
```

#### Changes
- Added `get_edf2asc_version()` to `preprocessing/utils/logging.py`.
- Updated `setup_logging()` to include the `edf2asc` version in the initial version log block.
- Created `tests/unit/utils/test_edf2asc_logging.py`

Tests pass locally.

Closes #96