### PR TITLE
feat: Comprehension Question Answers Implementation

### DIFF
--- a/preprocessing/answers/__init__.py
+++ b/preprocessing/answers/__init__.py
@@ -1,0 +1,8 @@
+"""Utilities to parse and store answers to comprehension questions.
+
+Provide focused helpers to:
+- read the per-trial question order (11/12/21/22/31/32) from the session CSV,
+- construct canonical question identifiers (e.g., 10111 or 20221),
+- collect a per-session table with one row per asked question (6 per trial),
+- write/read that table from CSV.
+"""

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+import polars as pl
+
+from .parser import parse_question_order, construct_question_id
+from .io import write_answers
+
+
+def _normalize_trial_key(k) -> int:
+    """Accept 'trial_7' or 7 or '7' and return int(7).
+
+    TODO: Check if one is standard - if so, remove
+    """
+    if isinstance(k, int):
+        return k
+    s = str(k)
+    if s.startswith("trial_"):
+        s = s.split("_", 1)[1]
+    return int(s)
+
+
+def collect_session_answers(
+        question_order_csv: Path,
+        stimuli_trial_map: Mapping[str | int, str],
+        out_path: Path | None = None,
+) -> pl.DataFrame:
+    """Assemble per-session question rows from order CSV and a trial->stimulus map.
+
+    Parameters
+    ----------
+    question_order_csv: Path
+        Path to the session's question_order_versions.csv.
+    stimuli_trial_map: Mapping
+        Maps trial identifiers to stimulus names, e.g., {'trial_1': 'Arg_PISACowsMilk_10', ...}.
+        Keys may be 'trial_#', '#', or integers, to be normalized.  TODO: verify
+    out_path: Path | None
+        If provided, the resulting table is written to this CSV path.
+        If None, defaults to `<session_dir>/results/answers.csv`, where
+        `<session_dir>` is the parent folder of the `logfiles` directory
+        containing the provided CSV. TODO: Change default folder - might use config.py
+
+    Returns
+    -------
+    pl.DataFrame with columns:
+      - trial (string, e.g., 'trial_1')
+      - stimulus (string)
+      - slot (string, e.g., 'local_question_1')
+      - order_code (int: 11,12,21,22,31,32)
+      - question_id (string)
+      - preliminary_dir, preliminary_ts, final_dir, final_ts (TODO: currently unused, needed?)
+    """
+    order_df = parse_question_order(question_order_csv)  # Adds 'trial' column to CSV
+
+    # Normalize mapping to int trial index -> stimulus
+    norm_map = {_normalize_trial_key(k): v for k, v in stimuli_trial_map.items()}
+    # Long format per trial with 6 question slots
+    slots = [
+        "local_question_1", "local_question_2",
+        "bridging_question_1", "bridging_question_2",
+        "global_question_1", "global_question_2",
+    ]
+
+    missing = [c for c in slots if c not in order_df.columns]
+    if missing:
+        raise ValueError(f"Missing columns in question order csv: {missing}")
+
+    # Build long format
+    per_slot_frames = []
+    for slot in slots:
+        df_slot = order_df.select(
+            pl.col("trial"),
+            pl.lit(slot).alias("slot"),
+            pl.col(slot).alias("order_code"),
+        )
+        per_slot_frames.append(df_slot)
+
+    long_df = pl.concat(per_slot_frames).with_columns(
+        pl.col("trial").cast(pl.Int64),
+        pl.col("order_code").cast(pl.Int64),
+    )
+
+    # Add stimulus name and construct canonical question_id
+    def _stim_for_trial(trial_idx: int) -> str:
+        if trial_idx not in norm_map:
+            raise KeyError(f"No stimulus mapping for trial {trial_idx}")
+        return norm_map[trial_idx]
+
+    long_df = long_df.with_columns(
+        pl.col("trial").map_elements(_stim_for_trial, return_dtype=pl.Utf8).alias(
+            "stimulus")
+    )
+
+    # Build question_id, ensure trial as 'trial_X'
+    long_df = long_df.with_columns(
+        pl.col("stimulus").map_elements(
+            lambda s: construct_question_id(s, 0), return_dtype=pl.Utf8
+        ).alias("_qid_prefix")
+    )
+
+    # Replace the trailing '0' with real order_code by reconstructing per-row
+    long_df = long_df.with_columns(
+        pl.struct(["stimulus", "order_code"]).map_elements(
+            lambda st: construct_question_id(st["stimulus"], int(st["order_code"])),
+            return_dtype=pl.Utf8,
+        ).alias("question_id"),
+        pl.col("trial").map_elements(lambda t: f"trial_{int(t)}",
+                                     return_dtype=pl.Utf8).alias("trial"),
+    ).drop("_qid_prefix")
+
+    # TODO: Placeholder columns for preliminary/final answers
+    long_df = long_df.with_columns(
+        pl.lit(None).alias("preliminary_dir"),
+        pl.lit(None).alias("preliminary_ts"),
+        pl.lit(None).alias("final_dir"),
+        pl.lit(None).alias("final_ts"),
+    )
+
+    # Determine destination if not provided: .../SESSION/results/answers.csv
+    if out_path is None:
+        # question_order_csv .../SESSION/logfiles/question_order_versions.csv
+        session_dir = question_order_csv.parent.parent
+        out_path = session_dir / "results" / "answers.csv"
+
+    write_answers(long_df, out_path)
+
+    return long_df

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -138,6 +138,11 @@ def collect_session_answers(
             pl.col("trial"),
             pl.lit(slot).alias("slot"),
             pl.col(slot).alias("order_code"),
+            pl.col(slot)
+            .cast(pl.Utf8)
+            .str.slice(0, 1)
+            .cast(pl.Int32)
+            .alias("condition_number"),
         )
         per_slot_frames.append(df_slot)
 
@@ -174,6 +179,12 @@ def collect_session_answers(
         pl.col("trial")
         .map_elements(_stim_for_trial, return_dtype=pl.Utf8)
         .alias("stimulus"),
+        pl.col("trial")
+        .map_elements(
+            lambda t: stim_id_map.get(trial_mapping.get(int(t))),
+            return_dtype=pl.Int32,
+        )
+        .alias("stimulus_id"),
         pl.col("trial")
         .map_elements(_to_trial_id, return_dtype=pl.Utf8)
         .alias("trial_id"),
@@ -308,12 +319,22 @@ def collect_session_answers(
                 return_dtype=pl.Utf8,
             )
             .alias("correct_answer_text"),
+        )
+        long_df = long_df.with_columns(
             pl.struct(["question_id", "final_answer_key"])
             .map_elements(
                 lambda x: _get_answer_text(x["question_id"], x["final_answer_key"]),
                 return_dtype=pl.Utf8,
             )
             .alias("answer_text"),
+            # Re-calculate or confirm is_correct if we have keys
+            pl.when(
+                pl.col("final_answer_key").is_not_null()
+                & pl.col("correct_answer_key").is_not_null()
+            )
+            .then(pl.col("final_answer_key") == pl.col("correct_answer_key"))
+            .otherwise(pl.col("is_correct"))
+            .alias("is_correct"),
         )
     else:
         long_df = long_df.with_columns(
@@ -344,18 +365,20 @@ def collect_session_answers(
         "global_question_2": 5,
     }
 
-    def _trial_sort_key(trial_id: str) -> str:
-        if trial_id.startswith("PRACTICE_"):
+    def _trial_sort_key(trial_id: str | None) -> str:
+        if trial_id is not None and str(trial_id).startswith("PRACTICE_"):
             try:
-                num = int(trial_id.split("_")[-1])
+                num = int(str(trial_id).split("_")[-1])
                 return f"0_{num:03d}"
             except (ValueError, IndexError):
                 return "0_000"
+        if trial_id is None:
+            return "2_unknown"
         try:
-            num = int(trial_id.split("_")[-1])
+            num = int(str(trial_id).split("_")[-1])
             return f"1_{num:03d}"
         except (ValueError, IndexError):
-            return f"2_{trial_id}"
+            return f"2_{str(trial_id)}"
 
     long_df = long_df.with_columns(
         pl.col("trial")
@@ -368,13 +391,21 @@ def collect_session_answers(
     long_df = long_df.sort(["_trial_sort", "_slot_sort"])
     long_df = long_df.drop(["_trial_sort", "_slot_sort"])
 
+    # Add component columns
+    long_df = long_df.with_columns(
+        pl.lit(1).alias("snippet_number").cast(pl.Int32),
+    )
+
     # Select final columns in desired order
     final_cols = [
         "trial",
         "stimulus",
         "slot",
-        "order_code",
         "question_id",
+        "stimulus_id",
+        "snippet_number",
+        "order_code",
+        "condition_number",
         "final_answer_key",
         "answer_text",
         "is_correct",

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -322,6 +322,18 @@ def collect_session_answers(
             pl.lit(None).alias("answer_text").cast(pl.Utf8),
         )
 
+    # Drop unanswered practice trial rows
+    n_before = long_df.height
+    long_df = long_df.filter(
+        ~(
+            pl.col("trial").str.starts_with("PRACTICE_")
+            & pl.col("final_answer_key").is_null()
+        )
+    )
+    n_dropped = n_before - long_df.height
+    if n_dropped > 0:
+        logger.debug(f"Dropped {n_dropped} unanswered practice trial row(s).")
+
     # Sort output file by trial and then slot
     slot_order = {
         "local_question_1": 0,

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Sequence
 
 import polars as pl
 
 from .parser import parse_question_order, construct_question_id
 from .io import write_answers
+from ..data_collection.stimulus import Stimulus
 
 
 def _normalize_trial_key(k) -> int:
-    """Accept 'trial_7' or 7 or '7' and return int(7).
-
-    TODO: Check if one is standard - if so, remove
-    """
+    """Accept 'trial_7' or 7 or '7' and return int(7)."""
     if isinstance(k, int):
         return k
     s = str(k)
@@ -25,6 +23,8 @@ def _normalize_trial_key(k) -> int:
 def collect_session_answers(
     question_order_csv: Path,
     stimuli_trial_map: Mapping[str | int, str],
+    stimuli: Sequence[Stimulus] | None = None,
+    parsed_answers: pl.DataFrame | None = None,
     out_path: Path | None = None,
 ) -> pl.DataFrame:
     """Assemble per-session question rows from order CSV and a trial->stimulus map.
@@ -35,12 +35,12 @@ def collect_session_answers(
         Path to the session's question_order_versions.csv.
     stimuli_trial_map: Mapping
         Maps trial identifiers to stimulus names, e.g., {'trial_1': 'Arg_PISACowsMilk_10', ...}.
-        Keys may be 'trial_#', '#', or integers, to be normalized.  TODO: verify
+    stimuli: Sequence[Stimulus] | None
+        List of Stimulus objects to look up correct answer texts.
+    parsed_answers: pl.DataFrame | None
+        DataFrame with parsed answers from ASC messages or logfile.
     out_path: Path | None
         If provided, the resulting table is written to this CSV path.
-        If None, defaults to `<session_dir>/results/answers.csv`, where
-        `<session_dir>` is the parent folder of the `logfiles` directory
-        containing the provided CSV. TODO: Change default folder - might use config.py
 
     Returns
     -------
@@ -50,7 +50,13 @@ def collect_session_answers(
       - slot (string, e.g., 'local_question_1')
       - order_code (int: 11,12,21,22,31,32)
       - question_id (string)
-      - preliminary_dir, preliminary_ts, final_dir, final_ts (TODO: currently unused, needed?)
+      - final_answer_key (string)
+      - is_correct (bool)
+      - correct_answer_key (string)
+      - correct_answer_text (string)
+      - final_rt_ms (float)
+      - decision_rt_ms (float)
+      - answer_changed (bool)
     """
     order_df = parse_question_order(question_order_csv)  # Adds 'trial' column to CSV
 
@@ -99,12 +105,11 @@ def collect_session_answers(
 
     # Build question_id, ensure trial as 'trial_X'
     long_df = long_df.with_columns(
-        pl.col("stimulus")
-        .map_elements(lambda s: construct_question_id(s, 0), return_dtype=pl.Utf8)
-        .alias("_qid_prefix")
+        pl.col("trial")
+        .map_elements(lambda t: f"trial_{int(t)}", return_dtype=pl.Utf8)
+        .alias("trial_id")
     )
 
-    # Replace the trailing '0' with real order_code by reconstructing per-row
     long_df = long_df.with_columns(
         pl.struct(["stimulus", "order_code"])
         .map_elements(
@@ -115,15 +120,105 @@ def collect_session_answers(
         pl.col("trial")
         .map_elements(lambda t: f"trial_{int(t)}", return_dtype=pl.Utf8)
         .alias("trial"),
-    ).drop("_qid_prefix")
-
-    # TODO: Placeholder columns for preliminary/final answers
-    long_df = long_df.with_columns(
-        pl.lit(None).alias("preliminary_dir"),
-        pl.lit(None).alias("preliminary_ts"),
-        pl.lit(None).alias("final_dir"),
-        pl.lit(None).alias("final_ts"),
     )
+
+    if parsed_answers is not None:
+        # Merge parsed answers by (trial_id, question_id)
+        long_df = long_df.join(
+            parsed_answers, on=["trial_id", "question_id"], how="left"
+        )
+
+        # Compute derived columns
+        long_df = long_df.with_columns(
+            # final_rt_ms: onset -> final confirmation
+            (pl.col("final_confirmation_ts") - pl.col("question_onset_ts")).alias(
+                "final_rt_ms"
+            ),
+            # decision_rt_ms: first preliminary -> final confirmation
+            (
+                pl.col("final_confirmation_ts") - pl.col("preliminary_tss").list.get(0)
+            ).alias("decision_rt_ms"),
+            # answer_changed: preliminary_keys non-empty and last one != final_answer_key
+            pl.coalesce(
+                [
+                    pl.when(pl.col("preliminary_keys").list.len() > 0)
+                    .then(
+                        pl.col("preliminary_keys").list.get(-1)
+                        != pl.col("final_answer_key")
+                    )
+                    .otherwise(pl.lit(False)),
+                    pl.lit(False),
+                ]
+            ).alias("answer_changed"),
+        )
+    else:
+        # Add null columns if no parsed answers
+        long_df = long_df.with_columns(
+            pl.lit(None).alias("final_answer_key").cast(pl.Utf8),
+            pl.lit(None).alias("is_correct").cast(pl.Boolean),
+            pl.lit(None).alias("final_rt_ms").cast(pl.Float64),
+            pl.lit(None).alias("decision_rt_ms").cast(pl.Float64),
+            pl.lit(None).alias("answer_changed").cast(pl.Boolean),
+        )
+
+    # Add correct answers from stimuli objects
+    if stimuli:
+        q_map = {}
+        for stim in stimuli:
+            for q in stim.questions:
+                # In Stimulus.load(), q.id is extracted from item_id.split("_")[-1]
+                # item_id is something like Lit_MagicMountain_6_11
+                # so q.id is "11", "12", "21", etc. (the order_code)
+                try:
+                    q_order_code = int(q.id)
+                except (ValueError, TypeError):
+                    continue
+
+                q_id = construct_question_id(stim.name, q_order_code)
+                q_map[q_id] = {
+                    "correct_answer_key": "target_key",  # Always target_key for correct
+                    "correct_answer_text": q.target,
+                }
+
+        def _get_correct_info(q_id: str, field: str) -> str | None:
+            return q_map.get(q_id, {}).get(field)
+
+        long_df = long_df.with_columns(
+            pl.col("question_id")
+            .map_elements(
+                lambda q_id: _get_correct_info(q_id, "correct_answer_key"),
+                return_dtype=pl.Utf8,
+            )
+            .alias("correct_answer_key"),
+            pl.col("question_id")
+            .map_elements(
+                lambda q_id: _get_correct_info(q_id, "correct_answer_text"),
+                return_dtype=pl.Utf8,
+            )
+            .alias("correct_answer_text"),
+        )
+    else:
+        long_df = long_df.with_columns(
+            pl.lit(None).alias("correct_answer_key").cast(pl.Utf8),
+            pl.lit(None).alias("correct_answer_text").cast(pl.Utf8),
+        )
+
+    # Select final columns in desired order
+    final_cols = [
+        "trial",
+        "stimulus",
+        "slot",
+        "order_code",
+        "question_id",
+        "final_answer_key",
+        "is_correct",
+        "correct_answer_key",
+        "correct_answer_text",
+        "final_rt_ms",
+        "decision_rt_ms",
+        "answer_changed",
+    ]
+    long_df = long_df.select([c for c in final_cols if c in long_df.columns])
 
     # Determine destination if not provided: .../SESSION/results/answers.csv
     if out_path is None:

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -166,12 +166,28 @@ def collect_session_answers(
             return f"PRACTICE_trial_{num}"
         return str(actual_key)
 
+    # Build snippet map from stimuli objects
+    snippet_map = {}
+    if stimuli:
+        for stim in stimuli:
+            for q in stim.questions:
+                try:
+                    q_order_code = int(str(q.id)[-2:])
+                    # Map (stimulus_name, order_code) -> snippet_no
+                    snippet_map[(stim.name, q_order_code)] = q.snippet_no
+                except (ValueError, TypeError):
+                    continue
+
     def _safe_construct_question_id(
         stim_name: str, order_code: int, trial_key: any
     ) -> str | None:
         stim_id = stim_id_map.get(trial_key)
+        # Try to get snippet_no from map, default to 1
+        snippet_no = snippet_map.get((stim_name, order_code), 1)
         try:
-            return construct_question_id(stim_name, order_code, stimulus_id=stim_id)
+            return construct_question_id(
+                stim_name, order_code, stimulus_id=stim_id, snippet_no=snippet_no
+            )
         except (ValueError, KeyError, AttributeError):
             return None
 
@@ -281,12 +297,16 @@ def collect_session_answers(
 
                 # For Stimulus objects, the numeric ID is already in stim.id
                 q_id = construct_question_id(
-                    stim.name, q_order_code, stimulus_id=stim.id
+                    stim.name,
+                    q_order_code,
+                    stimulus_id=stim.id,
+                    snippet_no=q.snippet_no,
                 )
                 if q_id:
                     q_map[q_id] = {
                         "correct_answer_key": "target_key",
                         "correct_answer_text": q.target,
+                        "snippet_number": q.snippet_no,
                         "options": {
                             "target_key": q.target,
                             "distractor_a_key": q.distractor_a,
@@ -393,7 +413,12 @@ def collect_session_answers(
 
     # Add component columns
     long_df = long_df.with_columns(
-        pl.lit(1).alias("snippet_number").cast(pl.Int32),
+        pl.col("question_id")
+        .map_elements(
+            lambda qid: q_map.get(qid, {}).get("snippet_number", 1) if stimuli else 1,
+            return_dtype=pl.Int32,
+        )
+        .alias("snippet_number"),
     )
 
     # Select final columns in desired order

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -64,12 +64,14 @@ def collect_session_answers(
       - order_code (int: 11,12,21,22,31,32)
       - question_id (string)
       - final_answer_key (string)
+      - answer_text (string)
       - is_correct (bool)
       - correct_answer_key (string)
       - correct_answer_text (string)
-      - final_rt_ms (float)
-      - decision_rt_ms (float)
-      - answer_changed (bool)
+      - preliminary_rt_ms (float)  time from question onset to last preliminary key press
+      - confirmation_rt_ms (float)  time from question onset to confirmation button press
+      - preliminary_answer_keys (list[str])  all preliminary key presses in order
+      - preliminary_answer_onsets_ms (list[float])  onset-relative timestamps for each preliminary press
       - answer_source (string)
     """
     logger = get_logger()
@@ -202,33 +204,58 @@ def collect_session_answers(
             parsed_answers, on=["trial_id", "question_id"], how="left"
         )
 
+        # Handle space-only answers: participant pressed space without selecting
+        long_df = long_df.with_columns(
+            pl.when(
+                pl.col("final_confirmation_ts").is_not_null()
+                & pl.col("final_answer_key").is_null()
+            )
+            .then(pl.lit("space"))
+            .otherwise(pl.col("final_answer_key"))
+            .alias("final_answer_key"),
+        )
+
         # Compute derived columns
         long_df = long_df.with_columns(
-            (pl.col("final_confirmation_ts") - pl.col("question_onset_ts")).alias(
-                "final_rt_ms"
+            (pl.col("preliminary_tss").list.last() - pl.col("question_onset_ts")).alias(
+                "preliminary_rt_ms"
             ),
-            (
-                pl.col("final_confirmation_ts") - pl.col("preliminary_tss").list.get(0)
-            ).alias("decision_rt_ms"),
-            pl.coalesce(
-                [
-                    pl.when(pl.col("preliminary_keys").list.len() > 0)
-                    .then(
-                        pl.col("preliminary_keys").list.get(-1)
-                        != pl.col("final_answer_key")
-                    )
-                    .otherwise(pl.lit(False)),
-                    pl.lit(False),
-                ]
-            ).alias("answer_changed"),
+            (pl.col("final_confirmation_ts") - pl.col("question_onset_ts")).alias(
+                "confirmation_rt_ms"
+            ),
+            pl.col("preliminary_keys").alias("preliminary_answer_keys"),
+            pl.struct(["preliminary_tss", "question_onset_ts"])
+            .map_elements(
+                lambda row: (
+                    [
+                        round(t - row["question_onset_ts"], 1)
+                        for t in row["preliminary_tss"]
+                    ]
+                    if row["preliminary_tss"] and row["question_onset_ts"] is not None
+                    else None
+                ),
+                return_dtype=pl.List(pl.Float64),
+            )
+            .alias("preliminary_answer_onsets_ms"),
         )
+
+        # Warn if any final_answer_key differs from the last preliminary key (data anomaly)
+        anomaly = long_df.filter(
+            pl.col("preliminary_keys").is_not_null()
+            & (pl.col("preliminary_keys").list.len() > 0)
+            & (pl.col("preliminary_keys").list.last() != pl.col("final_answer_key"))
+        )
+        if anomaly.height > 0:
+            logger.warning(
+                f"Found {anomaly.height} question(s) where final_answer_key differs from "
+                f"the last preliminary key press (data anomaly)."
+            )
     else:
         long_df = long_df.with_columns(
             pl.lit(None).alias("final_answer_key").cast(pl.Utf8),
             pl.lit(None).alias("is_correct").cast(pl.Boolean),
-            pl.lit(None).alias("final_rt_ms").cast(pl.Float64),
-            pl.lit(None).alias("decision_rt_ms").cast(pl.Float64),
-            pl.lit(None).alias("answer_changed").cast(pl.Boolean),
+            pl.lit(None).alias("preliminary_rt_ms").cast(pl.Float64),
+            pl.lit(None).alias("confirmation_rt_ms").cast(pl.Float64),
         )
 
     # Add correct answers from stimuli objects
@@ -341,9 +368,10 @@ def collect_session_answers(
         "is_correct",
         "correct_answer_key",
         "correct_answer_text",
-        "final_rt_ms",
-        "decision_rt_ms",
-        "answer_changed",
+        "preliminary_rt_ms",
+        "confirmation_rt_ms",
+        "preliminary_answer_keys",
+        "preliminary_answer_onsets_ms",
         "answer_source",
     ]
     long_df = long_df.select([c for c in final_cols if c in long_df.columns])

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 import polars as pl
 
@@ -61,8 +61,11 @@ def collect_session_answers(
       - trial (string, e.g., 'trial_1')
       - stimulus (string)
       - slot (string, e.g., 'local_question_1')
-      - order_code (int: 11,12,21,22,31,32)
       - question_id (string)
+      - stimulus_id (int)
+      - snippet_number (int)
+      - order_code (int: 11,12,21,22,31,32)
+      - condition_number (int: 1=local, 2=bridging, 3=global)
       - final_answer_key (string)
       - answer_text (string)
       - is_correct (bool)
@@ -101,15 +104,12 @@ def collect_session_answers(
     logger.debug(f"DEBUG: Sorted norm_map keys: {sorted_keys}")
 
     # trial_mapping: CSV row index -> actual trial identifier (int or PRACTICE_X)
-    trial_mapping = {}
-    for i, key in enumerate(sorted_keys, start=1):
-        trial_mapping[i] = key
+    trial_mapping = dict(enumerate(sorted_keys, start=1))
 
     # stim_id_mapping: actual trial identifier -> stimulus numeric ID
     stim_id_map = {}
     if completed_stimuli_ids and len(completed_stimuli_ids) == len(sorted_keys):
-        for key, s_id in zip(sorted_keys, completed_stimuli_ids):
-            stim_id_map[key] = s_id
+        stim_id_map = dict(zip(sorted_keys, completed_stimuli_ids))
     elif completed_stimuli_ids:
         logger.warning(
             f"Completed stimuli count ({len(completed_stimuli_ids)}) does not match "
@@ -138,11 +138,7 @@ def collect_session_answers(
             pl.col("trial"),
             pl.lit(slot).alias("slot"),
             pl.col(slot).alias("order_code"),
-            pl.col(slot)
-            .cast(pl.Utf8)
-            .str.slice(0, 1)
-            .cast(pl.Int32)
-            .alias("condition_number"),
+            (pl.col(slot) // 10).alias("condition_number"),
         )
         per_slot_frames.append(df_slot)
 
@@ -172,7 +168,7 @@ def collect_session_answers(
         for stim in stimuli:
             for q in stim.questions:
                 try:
-                    q_order_code = int(str(q.id)[-2:])
+                    q_order_code = int(q.id[-2:])
                     # Map (stimulus_name, order_code) -> snippet_no
                     snippet_map[(stim.name, q_order_code)] = q.snippet_no
                 except (ValueError, TypeError):
@@ -286,12 +282,12 @@ def collect_session_answers(
         )
 
     # Add correct answers from stimuli objects
+    q_map: dict = {}
     if stimuli:
-        q_map = {}
         for stim in stimuli:
             for q in stim.questions:
                 try:
-                    q_order_code = int(str(q.id)[-2:])
+                    q_order_code = int(q.id[-2:])
                 except (ValueError, TypeError):
                     continue
 
@@ -315,7 +311,7 @@ def collect_session_answers(
                         },
                     }
 
-        def _get_correct_info(q_id: str, field: str) -> str | any | None:
+        def _get_correct_info(q_id: str, field: str) -> str | None:
             return q_map.get(q_id, {}).get(field)
 
         def _get_answer_text(q_id: str, key: str) -> str | None:
@@ -415,7 +411,7 @@ def collect_session_answers(
     long_df = long_df.with_columns(
         pl.col("question_id")
         .map_elements(
-            lambda qid: q_map.get(qid, {}).get("snippet_number", 1) if stimuli else 1,
+            lambda qid: q_map.get(qid, {}).get("snippet_number", 1),
             return_dtype=pl.Int32,
         )
         .alias("snippet_number"),

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -23,9 +23,9 @@ def _normalize_trial_key(k) -> int:
 
 
 def collect_session_answers(
-        question_order_csv: Path,
-        stimuli_trial_map: Mapping[str | int, str],
-        out_path: Path | None = None,
+    question_order_csv: Path,
+    stimuli_trial_map: Mapping[str | int, str],
+    out_path: Path | None = None,
 ) -> pl.DataFrame:
     """Assemble per-session question rows from order CSV and a trial->stimulus map.
 
@@ -58,9 +58,12 @@ def collect_session_answers(
     norm_map = {_normalize_trial_key(k): v for k, v in stimuli_trial_map.items()}
     # Long format per trial with 6 question slots
     slots = [
-        "local_question_1", "local_question_2",
-        "bridging_question_1", "bridging_question_2",
-        "global_question_1", "global_question_2",
+        "local_question_1",
+        "local_question_2",
+        "bridging_question_1",
+        "bridging_question_2",
+        "global_question_1",
+        "global_question_2",
     ]
 
     missing = [c for c in slots if c not in order_df.columns]
@@ -89,25 +92,29 @@ def collect_session_answers(
         return norm_map[trial_idx]
 
     long_df = long_df.with_columns(
-        pl.col("trial").map_elements(_stim_for_trial, return_dtype=pl.Utf8).alias(
-            "stimulus")
+        pl.col("trial")
+        .map_elements(_stim_for_trial, return_dtype=pl.Utf8)
+        .alias("stimulus")
     )
 
     # Build question_id, ensure trial as 'trial_X'
     long_df = long_df.with_columns(
-        pl.col("stimulus").map_elements(
-            lambda s: construct_question_id(s, 0), return_dtype=pl.Utf8
-        ).alias("_qid_prefix")
+        pl.col("stimulus")
+        .map_elements(lambda s: construct_question_id(s, 0), return_dtype=pl.Utf8)
+        .alias("_qid_prefix")
     )
 
     # Replace the trailing '0' with real order_code by reconstructing per-row
     long_df = long_df.with_columns(
-        pl.struct(["stimulus", "order_code"]).map_elements(
+        pl.struct(["stimulus", "order_code"])
+        .map_elements(
             lambda st: construct_question_id(st["stimulus"], int(st["order_code"])),
             return_dtype=pl.Utf8,
-        ).alias("question_id"),
-        pl.col("trial").map_elements(lambda t: f"trial_{int(t)}",
-                                     return_dtype=pl.Utf8).alias("trial"),
+        )
+        .alias("question_id"),
+        pl.col("trial")
+        .map_elements(lambda t: f"trial_{int(t)}", return_dtype=pl.Utf8)
+        .alias("trial"),
     ).drop("_qid_prefix")
 
     # TODO: Placeholder columns for preliminary/final answers

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -8,16 +8,23 @@ import polars as pl
 from .parser import parse_question_order, construct_question_id
 from .io import write_answers
 from ..data_collection.stimulus import Stimulus
+from ..utils.logging import get_logger
 
 
-def _normalize_trial_key(k) -> int:
-    """Accept 'trial_7' or 7 or '7' and return int(7)."""
+def _normalize_trial_key(k) -> int | str:
+    """Accept 'trial_7' or 7 or '7' or 'PRACTICE_1' and return int(7) or 'PRACTICE_1'."""
     if isinstance(k, int):
         return k
     s = str(k)
     if s.startswith("trial_"):
-        s = s.split("_", 1)[1]
-    return int(s)
+        try:
+            return int(s.split("_", 1)[1])
+        except (ValueError, IndexError):
+            return s
+    try:
+        return int(s)
+    except ValueError:
+        return s
 
 
 def collect_session_answers(
@@ -26,6 +33,8 @@ def collect_session_answers(
     stimuli: Sequence[Stimulus] | None = None,
     parsed_answers: pl.DataFrame | None = None,
     out_path: Path | None = None,
+    source: str = "unknown",
+    completed_stimuli_ids: Sequence[int] | None = None,
 ) -> pl.DataFrame:
     """Assemble per-session question rows from order CSV and a trial->stimulus map.
 
@@ -41,6 +50,10 @@ def collect_session_answers(
         DataFrame with parsed answers from ASC messages or logfile.
     out_path: Path | None
         If provided, the resulting table is written to this CSV path.
+    source: str
+        The source of the parsed answers, e.g., 'asc' or 'logfile'.
+    completed_stimuli_ids: Sequence[int] | None
+        List of stimulus numeric IDs in the order they were completed.
 
     Returns
     -------
@@ -57,11 +70,51 @@ def collect_session_answers(
       - final_rt_ms (float)
       - decision_rt_ms (float)
       - answer_changed (bool)
+      - answer_source (string)
     """
-    order_df = parse_question_order(question_order_csv)  # Adds 'trial' column to CSV
+    logger = get_logger()
 
-    # Normalize mapping to int trial index -> stimulus
+    # Normalize mapping
     norm_map = {_normalize_trial_key(k): v for k, v in stimuli_trial_map.items()}
+    logger.debug(f"DEBUG: Normalized trial map: {norm_map}")
+
+    # Adds 'trial' column (as int 1, 2, 3...) from question_order CSV
+    order_df = parse_question_order(question_order_csv)
+
+    # MultiplEYE trial logic: match order_df rows to norm_map keys by sequence
+    def _sort_key(x):
+        if isinstance(x, int):
+            return (1, x)
+        s = str(x)
+        if s.startswith("PRACTICE_"):
+            try:
+                # Extract number from PRACTICE_1 or PRACTICE_trial_1
+                num_part = s.split("_")[-1]
+                return (0, int(num_part))
+            except (ValueError, IndexError):
+                return (0, 0)
+        return (2, s)
+
+    sorted_keys = sorted(norm_map.keys(), key=_sort_key)
+    logger.debug(f"DEBUG: Sorted norm_map keys: {sorted_keys}")
+
+    # trial_mapping: CSV row index -> actual trial identifier (int or PRACTICE_X)
+    trial_mapping = {}
+    for i, key in enumerate(sorted_keys, start=1):
+        trial_mapping[i] = key
+
+    # stim_id_mapping: actual trial identifier -> stimulus numeric ID
+    stim_id_map = {}
+    if completed_stimuli_ids and len(completed_stimuli_ids) == len(sorted_keys):
+        for key, s_id in zip(sorted_keys, completed_stimuli_ids):
+            stim_id_map[key] = s_id
+    elif completed_stimuli_ids:
+        logger.warning(
+            f"Completed stimuli count ({len(completed_stimuli_ids)}) does not match "
+            f"trial map count ({len(sorted_keys)}). Stimulus enrichment might be limited."
+        )
+    logger.debug(f"DEBUG: Stimulus ID map: {stim_id_map}")
+
     # Long format per trial with 6 question slots
     slots = [
         "local_question_1",
@@ -86,41 +139,62 @@ def collect_session_answers(
         )
         per_slot_frames.append(df_slot)
 
-    long_df = pl.concat(per_slot_frames).with_columns(
-        pl.col("trial").cast(pl.Int64),
-        pl.col("order_code").cast(pl.Int64),
-    )
+    long_df = pl.concat(per_slot_frames)
 
-    # Add stimulus name and construct canonical question_id
-    def _stim_for_trial(trial_idx: int) -> str:
-        if trial_idx not in norm_map:
-            raise KeyError(f"No stimulus mapping for trial {trial_idx}")
-        return norm_map[trial_idx]
+    # Build identifier columns
+    def _stim_for_trial(order_trial_idx: int) -> str:
+        actual_key = trial_mapping.get(order_trial_idx)
+        if actual_key is None or actual_key not in norm_map:
+            return f"Unknown_Stim_{order_trial_idx}"
+        return norm_map[actual_key]
+
+    def _to_trial_id(order_trial_idx: int) -> str:
+        actual_key = trial_mapping.get(order_trial_idx)
+        if isinstance(actual_key, int):
+            return f"trial_{actual_key}"
+        if isinstance(actual_key, str) and actual_key.startswith("PRACTICE_"):
+            if "trial" in actual_key:
+                return actual_key
+            num = actual_key.split("_")[1] if "_" in actual_key else "1"
+            return f"PRACTICE_trial_{num}"
+        return str(actual_key)
+
+    def _safe_construct_question_id(
+        stim_name: str, order_code: int, trial_key: any
+    ) -> str | None:
+        stim_id = stim_id_map.get(trial_key)
+        try:
+            return construct_question_id(stim_name, order_code, stimulus_id=stim_id)
+        except (ValueError, KeyError, AttributeError):
+            return None
 
     long_df = long_df.with_columns(
         pl.col("trial")
         .map_elements(_stim_for_trial, return_dtype=pl.Utf8)
-        .alias("stimulus")
-    )
-
-    # Build question_id, ensure trial as 'trial_X'
-    long_df = long_df.with_columns(
+        .alias("stimulus"),
         pl.col("trial")
-        .map_elements(lambda t: f"trial_{int(t)}", return_dtype=pl.Utf8)
-        .alias("trial_id")
+        .map_elements(_to_trial_id, return_dtype=pl.Utf8)
+        .alias("trial_id"),
     )
 
     long_df = long_df.with_columns(
-        pl.struct(["stimulus", "order_code"])
+        pl.struct(["trial", "stimulus", "order_code"])
         .map_elements(
-            lambda st: construct_question_id(st["stimulus"], int(st["order_code"])),
+            lambda x: _safe_construct_question_id(
+                x["stimulus"],
+                int(x["order_code"]),
+                trial_mapping.get(int(x["trial"])),
+            ),
             return_dtype=pl.Utf8,
         )
         .alias("question_id"),
-        pl.col("trial")
-        .map_elements(lambda t: f"trial_{int(t)}", return_dtype=pl.Utf8)
-        .alias("trial"),
     )
+
+    # Convert 'trial' back to original trial_id string for output
+    long_df = long_df.with_columns(pl.col("trial_id").alias("trial"))
+
+    # Add answer source
+    long_df = long_df.with_columns(pl.lit(source).alias("answer_source"))
 
     if parsed_answers is not None:
         # Merge parsed answers by (trial_id, question_id)
@@ -130,15 +204,12 @@ def collect_session_answers(
 
         # Compute derived columns
         long_df = long_df.with_columns(
-            # final_rt_ms: onset -> final confirmation
             (pl.col("final_confirmation_ts") - pl.col("question_onset_ts")).alias(
                 "final_rt_ms"
             ),
-            # decision_rt_ms: first preliminary -> final confirmation
             (
                 pl.col("final_confirmation_ts") - pl.col("preliminary_tss").list.get(0)
             ).alias("decision_rt_ms"),
-            # answer_changed: preliminary_keys non-empty and last one != final_answer_key
             pl.coalesce(
                 [
                     pl.when(pl.col("preliminary_keys").list.len() > 0)
@@ -152,7 +223,6 @@ def collect_session_answers(
             ).alias("answer_changed"),
         )
     else:
-        # Add null columns if no parsed answers
         long_df = long_df.with_columns(
             pl.lit(None).alias("final_answer_key").cast(pl.Utf8),
             pl.lit(None).alias("is_correct").cast(pl.Boolean),
@@ -166,22 +236,37 @@ def collect_session_answers(
         q_map = {}
         for stim in stimuli:
             for q in stim.questions:
-                # In Stimulus.load(), q.id is extracted from item_id.split("_")[-1]
-                # item_id is something like Lit_MagicMountain_6_11
-                # so q.id is "11", "12", "21", etc. (the order_code)
                 try:
-                    q_order_code = int(q.id)
+                    q_order_code = int(str(q.id)[-2:])
                 except (ValueError, TypeError):
                     continue
 
-                q_id = construct_question_id(stim.name, q_order_code)
-                q_map[q_id] = {
-                    "correct_answer_key": "target_key",  # Always target_key for correct
-                    "correct_answer_text": q.target,
-                }
+                # For Stimulus objects, the numeric ID is already in stim.id
+                q_id = construct_question_id(
+                    stim.name, q_order_code, stimulus_id=stim.id
+                )
+                if q_id:
+                    q_map[q_id] = {
+                        "correct_answer_key": "target_key",
+                        "correct_answer_text": q.target,
+                        "options": {
+                            "target_key": q.target,
+                            "distractor_a_key": q.distractor_a,
+                            "distractor_b_key": q.distractor_b,
+                            "distractor_c_key": q.distractor_c,
+                        },
+                    }
 
-        def _get_correct_info(q_id: str, field: str) -> str | None:
+        def _get_correct_info(q_id: str, field: str) -> str | any | None:
             return q_map.get(q_id, {}).get(field)
+
+        def _get_answer_text(q_id: str, key: str) -> str | None:
+            if not q_id or not key:
+                return None
+            options = q_map.get(q_id, {}).get("options")
+            if options:
+                return options.get(key)
+            return None
 
         long_df = long_df.with_columns(
             pl.col("question_id")
@@ -196,12 +281,53 @@ def collect_session_answers(
                 return_dtype=pl.Utf8,
             )
             .alias("correct_answer_text"),
+            pl.struct(["question_id", "final_answer_key"])
+            .map_elements(
+                lambda x: _get_answer_text(x["question_id"], x["final_answer_key"]),
+                return_dtype=pl.Utf8,
+            )
+            .alias("answer_text"),
         )
     else:
         long_df = long_df.with_columns(
             pl.lit(None).alias("correct_answer_key").cast(pl.Utf8),
             pl.lit(None).alias("correct_answer_text").cast(pl.Utf8),
+            pl.lit(None).alias("answer_text").cast(pl.Utf8),
         )
+
+    # Sort output file by trial and then slot
+    slot_order = {
+        "local_question_1": 0,
+        "local_question_2": 1,
+        "bridging_question_1": 2,
+        "bridging_question_2": 3,
+        "global_question_1": 4,
+        "global_question_2": 5,
+    }
+
+    def _trial_sort_key(trial_id: str) -> str:
+        if trial_id.startswith("PRACTICE_"):
+            try:
+                num = int(trial_id.split("_")[-1])
+                return f"0_{num:03d}"
+            except (ValueError, IndexError):
+                return "0_000"
+        try:
+            num = int(trial_id.split("_")[-1])
+            return f"1_{num:03d}"
+        except (ValueError, IndexError):
+            return f"2_{trial_id}"
+
+    long_df = long_df.with_columns(
+        pl.col("trial")
+        .map_elements(_trial_sort_key, return_dtype=pl.Utf8)
+        .alias("_trial_sort"),
+        pl.col("slot")
+        .map_elements(lambda s: slot_order.get(s, 99), return_dtype=pl.Int32)
+        .alias("_slot_sort"),
+    )
+    long_df = long_df.sort(["_trial_sort", "_slot_sort"])
+    long_df = long_df.drop(["_trial_sort", "_slot_sort"])
 
     # Select final columns in desired order
     final_cols = [
@@ -211,21 +337,20 @@ def collect_session_answers(
         "order_code",
         "question_id",
         "final_answer_key",
+        "answer_text",
         "is_correct",
         "correct_answer_key",
         "correct_answer_text",
         "final_rt_ms",
         "decision_rt_ms",
         "answer_changed",
+        "answer_source",
     ]
     long_df = long_df.select([c for c in final_cols if c in long_df.columns])
 
-    # Determine destination if not provided: .../SESSION/results/answers.csv
     if out_path is None:
-        # question_order_csv .../SESSION/logfiles/question_order_versions.csv
         session_dir = question_order_csv.parent.parent
         out_path = session_dir / "results" / "answers.csv"
 
     write_answers(long_df, out_path)
-
     return long_df

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -60,12 +60,12 @@ def collect_session_answers(
     pl.DataFrame with columns:
       - trial (string, e.g., 'trial_1')
       - stimulus (string)
-      - slot (string, e.g., 'local_question_1')
       - question_id (string)
+      - question_order_version (int)
       - stimulus_id (int)
       - snippet_number (int)
-      - order_code (int: 11,12,21,22,31,32)
       - condition_number (int: 1=local, 2=bridging, 3=global)
+      - slot (string, e.g., 'local_question_1')
       - final_answer_key (string)
       - answer_text (string)
       - is_correct (bool)
@@ -136,6 +136,7 @@ def collect_session_answers(
     for slot in slots:
         df_slot = order_df.select(
             pl.col("trial"),
+            pl.col("question_order_version"),
             pl.lit(slot).alias("slot"),
             pl.col(slot).alias("order_code"),
             (pl.col(slot) // 10).alias("condition_number"),
@@ -421,12 +422,12 @@ def collect_session_answers(
     final_cols = [
         "trial",
         "stimulus",
-        "slot",
         "question_id",
+        "question_order_version",
         "stimulus_id",
         "snippet_number",
-        "order_code",
         "condition_number",
+        "slot",
         "final_answer_key",
         "answer_text",
         "is_correct",

--- a/preprocessing/answers/experiment_log_parser.py
+++ b/preprocessing/answers/experiment_log_parser.py
@@ -35,11 +35,6 @@ def parse_answers_from_logfile(
     if relevant_df.is_empty():
         return _empty_result_df()
 
-    # Normalize trial_id to match messages/mapping (e.g. 1 -> "trial_1")
-    # In the toy logfile, trial_number is often 1, 2, 3...
-    # But it can also be PRACTICE_trial_1 if handled specially?
-    # Actually the toy logfile showed trial_number as 1, 2, 3.
-
     result_rows = []
 
     # We group by trial_number, stimulus_number, and page_number (which is question_id)

--- a/preprocessing/answers/experiment_log_parser.py
+++ b/preprocessing/answers/experiment_log_parser.py
@@ -1,3 +1,4 @@
+import warnings
 import polars as pl
 
 
@@ -18,6 +19,11 @@ def parse_answers_from_logfile(
     pl.DataFrame
         A DataFrame with one row per question attempt.
     """
+    warnings.warn(
+        "ASC messages are missing or empty. Falling back to parsing answers from the experiment logfile. "
+        "Response time (onset-based) and image offset information will not be available.",
+        UserWarning,
+    )
     if logfile is None or logfile.is_empty():
         return _empty_result_df()
 
@@ -34,7 +40,6 @@ def parse_answers_from_logfile(
     # But it can also be PRACTICE_trial_1 if handled specially?
     # Actually the toy logfile showed trial_number as 1, 2, 3.
 
-    parsed_rows = []
     result_rows = []
 
     # We group by trial_number, stimulus_number, and page_number (which is question_id)

--- a/preprocessing/answers/experiment_log_parser.py
+++ b/preprocessing/answers/experiment_log_parser.py
@@ -1,0 +1,122 @@
+import polars as pl
+
+
+def parse_answers_from_logfile(
+    logfile: pl.DataFrame, stimuli_trial_mapping: dict[str, str] = None
+) -> pl.DataFrame:
+    """Parse comprehension question answers from experiment logfile.
+
+    Parameters
+    ----------
+    logfile : pl.DataFrame
+        DataFrame from EXPERIMENT_*.txt with columns like 'timestamp', 'message', etc.
+    stimuli_trial_mapping : dict[str, str], optional
+        Mapping from trial_id (e.g. 'trial_1') to stimulus_name.
+
+    Returns
+    -------
+    pl.DataFrame
+        A DataFrame with one row per question attempt.
+    """
+    if logfile is None or logfile.is_empty():
+        return _empty_result_df()
+
+    # Filter for relevant messages
+    relevant_df = logfile.filter(
+        pl.col("message").str.contains("preliminary answer:|FINAL ANSWER:")
+    )
+
+    if relevant_df.is_empty():
+        return _empty_result_df()
+
+    # Normalize trial_id to match messages/mapping (e.g. 1 -> "trial_1")
+    # In the toy logfile, trial_number is often 1, 2, 3...
+    # But it can also be PRACTICE_trial_1 if handled specially?
+    # Actually the toy logfile showed trial_number as 1, 2, 3.
+
+    parsed_rows = []
+    result_rows = []
+
+    # We group by trial_number, stimulus_number, and page_number (which is question_id)
+    # Maintain order of events
+    groups = relevant_df.group_by(
+        ["trial_number", "stimulus_number", "page_number"], maintain_order=True
+    )
+
+    for (trial_num, stim_num, q_id), group in groups:
+        # Ignore rows without trial/stim/page info (shouldn't happen with our filter usually)
+        if trial_num is None or stim_num is None or q_id is None:
+            continue
+
+        trial_id = f"trial_{int(trial_num)}"
+        # Handle practice trials if possible (though logfile might not use this format)
+        # Based on multipleye_data_collection.py, they map PRACTICE_1 to PRACTICE_trial_1
+        # But here we just have numeric trial_number.
+
+        stim_name = None
+        if stimuli_trial_mapping and trial_id in stimuli_trial_mapping:
+            stim_name = stimuli_trial_mapping[trial_id]
+
+        row_data = {
+            "trial_id": trial_id,
+            "stimulus_name": stim_name,
+            "stimulus_id": str(int(stim_num)),
+            "question_id": str(int(q_id)),
+            "question_onset_ts": None,  # Logfile doesn't have a clear "onset" message like ASC
+            "preliminary_keys": [],
+            "preliminary_tss": [],
+            "final_confirmation_ts": None,
+            "image_offset_ts": None,
+            "final_answer_key": None,
+            "is_correct": None,
+            "question_stop_ts": None,
+        }
+
+        for p_row in group.iter_rows(named=True):
+            msg = p_row["message"]
+            ts = p_row["timestamp"]
+
+            if msg.startswith("preliminary answer:"):
+                key = msg.split("preliminary answer:")[1].strip()
+                if key == "final_confirmation":
+                    row_data["final_confirmation_ts"] = ts
+                else:
+                    row_data["preliminary_keys"].append(key)
+                    row_data["preliminary_tss"].append(ts)
+            elif msg.startswith("FINAL ANSWER:"):
+                # Example: FINAL ANSWER: correct answer is 'down' (A Python package), participant's answer is True
+                row_data["is_correct"] = "participant's answer is True" in msg
+                # We don't have the final_answer_key here explicitly, but we can take the last preliminary one
+                if row_data["preliminary_keys"]:
+                    row_data["final_answer_key"] = row_data["preliminary_keys"][-1]
+
+                # Use timestamp as stop_ts
+                row_data["question_stop_ts"] = ts
+
+        result_rows.append(row_data)
+
+    if not result_rows:
+        return _empty_result_df()
+
+    return pl.DataFrame(result_rows, schema=_result_schema())
+
+
+def _empty_result_df():
+    return pl.DataFrame(schema=_result_schema())
+
+
+def _result_schema():
+    return {
+        "trial_id": pl.Utf8,
+        "stimulus_name": pl.Utf8,
+        "stimulus_id": pl.Utf8,
+        "question_id": pl.Utf8,
+        "question_onset_ts": pl.Float64,
+        "preliminary_keys": pl.List(pl.Utf8),
+        "preliminary_tss": pl.List(pl.Float64),
+        "final_confirmation_ts": pl.Float64,
+        "image_offset_ts": pl.Float64,
+        "final_answer_key": pl.Utf8,
+        "is_correct": pl.Boolean,
+        "question_stop_ts": pl.Float64,
+    }

--- a/preprocessing/answers/experiment_log_parser.py
+++ b/preprocessing/answers/experiment_log_parser.py
@@ -62,11 +62,14 @@ def parse_answers_from_logfile(
         if stimuli_trial_mapping and trial_id in stimuli_trial_mapping:
             stim_name = stimuli_trial_mapping[trial_id]
 
+        stim_id_str = str(int(stim_num))
+        q_id_str = str(int(q_id))
+
         row_data = {
             "trial_id": trial_id,
             "stimulus_name": stim_name,
-            "stimulus_id": str(int(stim_num)),
-            "question_id": str(int(q_id)),
+            "stimulus_id": stim_id_str,
+            "question_id": q_id_str,
             "question_onset_ts": None,  # Logfile doesn't have a clear "onset" message like ASC
             "preliminary_keys": [],
             "preliminary_tss": [],

--- a/preprocessing/answers/io.py
+++ b/preprocessing/answers/io.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+
+def write_answers(df: pl.DataFrame, out_path: Path) -> Path:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_csv(out_path)
+    return out_path
+
+
+def load_answers(path: Path) -> pl.DataFrame:
+    return pl.read_csv(path)

--- a/preprocessing/answers/io.py
+++ b/preprocessing/answers/io.py
@@ -7,6 +7,14 @@ import polars as pl
 
 def write_answers(df: pl.DataFrame, out_path: Path) -> Path:
     out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    list_cols = [c for c in df.columns if isinstance(df.schema[c], pl.List)]
+    if list_cols:
+        df = df.with_columns(
+            pl.col(c).list.eval(pl.element().cast(pl.Utf8)).list.join(";").alias(c)
+            for c in list_cols
+        )
+
     df.write_csv(out_path)
     return out_path
 

--- a/preprocessing/answers/msg_parser.py
+++ b/preprocessing/answers/msg_parser.py
@@ -82,13 +82,15 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
 
         m = START_RE.match(content)
         if m:
+            stim_id = m.group("stimulus_id")
+            q_id = m.group("question_id")
             parsed_rows.append(
                 {
                     "time": float(time),
                     "trial_id": m.group("trial"),
                     "stimulus_name": m.group("stimulus_name"),
-                    "stimulus_id": m.group("stimulus_id"),
-                    "question_id": m.group("question_id"),
+                    "stimulus_id": stim_id,
+                    "question_id": q_id,
                     "action": "question_start",
                 }
             )
@@ -96,6 +98,8 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
 
         m = PRELIMINARY_RE.match(content)
         if m:
+            stim_id = m.group("stimulus_id")
+            q_id = m.group("question_id")
             key = m.group("key")
             action = (
                 "final_confirmation"
@@ -107,8 +111,8 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
                     "time": float(time),
                     "trial_id": m.group("trial"),
                     "stimulus_name": m.group("stimulus_name"),
-                    "stimulus_id": m.group("stimulus_id"),
-                    "question_id": m.group("question_id"),
+                    "stimulus_id": stim_id,
+                    "question_id": q_id,
                     "action": action,
                     "key_type": key if action == "preliminary_answer" else None,
                 }
@@ -117,13 +121,15 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
 
         m = FINAL_ANSWER_RE.match(content)
         if m:
+            stim_id = m.group("stimulus_id")
+            q_id = m.group("question_id")
             parsed_rows.append(
                 {
                     "time": float(time),
                     "trial_id": m.group("trial"),
                     "stimulus_name": m.group("stimulus_name"),
-                    "stimulus_id": m.group("stimulus_id"),
-                    "question_id": m.group("question_id"),
+                    "stimulus_id": stim_id,
+                    "question_id": q_id,
                     "action": "final_answer_given",
                     "key_type": m.group("key"),
                 }
@@ -132,13 +138,15 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
 
         m = CORRECTNESS_RE.match(content)
         if m:
+            stim_id = m.group("stimulus_id")
+            q_id = m.group("question_id")
             parsed_rows.append(
                 {
                     "time": float(time),
                     "trial_id": m.group("trial"),
                     "stimulus_name": m.group("stimulus_name"),
-                    "stimulus_id": m.group("stimulus_id"),
-                    "question_id": m.group("question_id"),
+                    "stimulus_id": stim_id,
+                    "question_id": q_id,
                     "action": "correctness",
                     "is_correct": m.group("correct") == "True",
                 }
@@ -151,13 +159,15 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
 
         m = STOP_RE.match(content)
         if m:
+            stim_id = m.group("stimulus_id")
+            q_id = m.group("question_id")
             parsed_rows.append(
                 {
                     "time": float(time),
                     "trial_id": m.group("trial"),
                     "stimulus_name": m.group("stimulus_name"),
-                    "stimulus_id": m.group("stimulus_id"),
-                    "question_id": m.group("question_id"),
+                    "stimulus_id": stim_id,
+                    "question_id": q_id,
                     "action": "question_stop",
                 }
             )

--- a/preprocessing/answers/msg_parser.py
+++ b/preprocessing/answers/msg_parser.py
@@ -1,15 +1,6 @@
 import polars as pl
 import re
 
-ANSWER_MSG_PATTERNS = [
-    r"start_recording_.*_question_\d+",
-    r".*_preliminary_answer_.*",
-    r"question_screen_image_offset",
-    r".*_final_answer_given_is_.*",
-    r".*_answer_given_is_correct:.*",
-    r"stop_recording_.*_question_\d+",
-]
-
 
 def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
     """Parse comprehension question answers from ASC messages.

--- a/preprocessing/answers/msg_parser.py
+++ b/preprocessing/answers/msg_parser.py
@@ -1,0 +1,262 @@
+import polars as pl
+import re
+
+ANSWER_MSG_PATTERNS = [
+    r"start_recording_.*_question_\d+",
+    r".*_preliminary_answer_.*",
+    r"question_screen_image_offset",
+    r".*_final_answer_given_is_.*",
+    r".*_answer_given_is_correct:.*",
+    r"stop_recording_.*_question_\d+",
+]
+
+
+def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
+    """Parse comprehension question answers from ASC messages.
+
+    Parameters
+    ----------
+    messages : pl.DataFrame
+        DataFrame with columns 'time' (int/float) and 'content' (str).
+
+    Returns
+    -------
+    pl.DataFrame
+        A DataFrame with one row per question attempt.
+    """
+    if messages is None or messages.is_empty():
+        return pl.DataFrame(
+            schema={
+                "trial_id": pl.Utf8,
+                "stimulus_name": pl.Utf8,
+                "stimulus_id": pl.Utf8,
+                "question_id": pl.Utf8,
+                "question_onset_ts": pl.Float64,
+                "preliminary_keys": pl.List(pl.Utf8),
+                "preliminary_tss": pl.List(pl.Float64),
+                "final_confirmation_ts": pl.Float64,
+                "image_offset_ts": pl.Float64,
+                "final_answer_key": pl.Utf8,
+                "is_correct": pl.Boolean,
+                "question_stop_ts": pl.Float64,
+            }
+        )
+
+    # Define regex patterns based on the implementation guide
+    START_RE = re.compile(
+        r"start_recording_(?P<trial>PRACTICE_trial_\d+|trial_\d+)_"
+        r"stimulus_(?P<stimulus_name>[A-Za-z_]+)_"
+        r"(?P<stimulus_id>\d+)_"
+        r"question_(?P<question_id>\d+)"
+    )
+
+    PRELIMINARY_RE = re.compile(
+        r"(?P<trial>PRACTICE_trial_\d+|trial_\d+)_stimulus_"
+        r"(?P<stimulus_name>[A-Za-z_]+)_"
+        r"(?P<stimulus_id>\d+)_"
+        r"question_(?P<question_id>\d+)_"
+        r"preliminary_answer_(?P<key>target_key|distractor_[a-d]_key|final_confirmation)"
+    )
+
+    FINAL_ANSWER_RE = re.compile(
+        r"(?P<trial>PRACTICE_trial_\d+|trial_\d+)_stimulus_"
+        r"(?P<stimulus_name>[A-Za-z_]+)_"
+        r"(?P<stimulus_id>\d+)_"
+        r"question_(?P<question_id>\d+)_"
+        r"final_answer_given_is_(?P<key>target_key|distractor_[a-d]_key)"
+    )
+
+    CORRECTNESS_RE = re.compile(
+        r"(?P<trial>PRACTICE_trial_\d+|trial_\d+)_stimulus_"
+        r"(?P<stimulus_name>[A-Za-z_]+)_"
+        r"(?P<stimulus_id>\d+)_"
+        r"question_(?P<question_id>\d+)_"
+        r"answer_given_is_correct:(?P<correct>True|False)"
+    )
+
+    IMAGE_OFFSET_RE = re.compile(r"question_screen_image_offset")
+
+    STOP_RE = re.compile(
+        r"stop_recording_(?P<trial>PRACTICE_trial_\d+|trial_\d+)_"
+        r"stimulus_(?P<stimulus_name>[A-Za-z_]+)_"
+        r"(?P<stimulus_id>\d+)_"
+        r"question_(?P<question_id>\d+)"
+    )
+
+    parsed_rows = []
+
+    for row in messages.iter_rows(named=True):
+        content = row["content"]
+        time = row["time"]
+
+        m = START_RE.match(content)
+        if m:
+            parsed_rows.append(
+                {
+                    "time": float(time),
+                    "trial_id": m.group("trial"),
+                    "stimulus_name": m.group("stimulus_name"),
+                    "stimulus_id": m.group("stimulus_id"),
+                    "question_id": m.group("question_id"),
+                    "action": "question_start",
+                }
+            )
+            continue
+
+        m = PRELIMINARY_RE.match(content)
+        if m:
+            key = m.group("key")
+            action = (
+                "final_confirmation"
+                if key == "final_confirmation"
+                else "preliminary_answer"
+            )
+            parsed_rows.append(
+                {
+                    "time": float(time),
+                    "trial_id": m.group("trial"),
+                    "stimulus_name": m.group("stimulus_name"),
+                    "stimulus_id": m.group("stimulus_id"),
+                    "question_id": m.group("question_id"),
+                    "action": action,
+                    "key_type": key if action == "preliminary_answer" else None,
+                }
+            )
+            continue
+
+        m = FINAL_ANSWER_RE.match(content)
+        if m:
+            parsed_rows.append(
+                {
+                    "time": float(time),
+                    "trial_id": m.group("trial"),
+                    "stimulus_name": m.group("stimulus_name"),
+                    "stimulus_id": m.group("stimulus_id"),
+                    "question_id": m.group("question_id"),
+                    "action": "final_answer_given",
+                    "key_type": m.group("key"),
+                }
+            )
+            continue
+
+        m = CORRECTNESS_RE.match(content)
+        if m:
+            parsed_rows.append(
+                {
+                    "time": float(time),
+                    "trial_id": m.group("trial"),
+                    "stimulus_name": m.group("stimulus_name"),
+                    "stimulus_id": m.group("stimulus_id"),
+                    "question_id": m.group("question_id"),
+                    "action": "correctness",
+                    "is_correct": m.group("correct") == "True",
+                }
+            )
+            continue
+
+        if IMAGE_OFFSET_RE.match(content):
+            parsed_rows.append({"time": float(time), "action": "image_offset"})
+            continue
+
+        m = STOP_RE.match(content)
+        if m:
+            parsed_rows.append(
+                {
+                    "time": float(time),
+                    "trial_id": m.group("trial"),
+                    "stimulus_name": m.group("stimulus_name"),
+                    "stimulus_id": m.group("stimulus_id"),
+                    "question_id": m.group("question_id"),
+                    "action": "question_stop",
+                }
+            )
+            continue
+
+    if not parsed_rows:
+        return pl.DataFrame(
+            schema={
+                "trial_id": pl.Utf8,
+                "stimulus_name": pl.Utf8,
+                "stimulus_id": pl.Utf8,
+                "question_id": pl.Utf8,
+                "question_onset_ts": pl.Float64,
+                "preliminary_keys": pl.List(pl.Utf8),
+                "preliminary_tss": pl.List(pl.Float64),
+                "final_confirmation_ts": pl.Float64,
+                "image_offset_ts": pl.Float64,
+                "final_answer_key": pl.Utf8,
+                "is_correct": pl.Boolean,
+                "question_stop_ts": pl.Float64,
+            }
+        )
+
+    df_parsed = pl.DataFrame(parsed_rows)
+
+    # Fill missing identifiers for image_offset which doesn't contain trial/stim info
+    df_parsed = df_parsed.with_columns(
+        [
+            pl.col("trial_id").forward_fill(),
+            pl.col("stimulus_name").forward_fill(),
+            pl.col("stimulus_id").forward_fill(),
+            pl.col("question_id").forward_fill(),
+        ]
+    )
+
+    groups = df_parsed.group_by(
+        ["trial_id", "stimulus_name", "stimulus_id", "question_id"], maintain_order=True
+    )
+
+    result_rows = []
+    for (trial_id, stim_name, stim_id, q_id), group in groups:
+        row_data = {
+            "trial_id": trial_id,
+            "stimulus_name": stim_name,
+            "stimulus_id": stim_id,
+            "question_id": q_id,
+            "question_onset_ts": None,
+            "preliminary_keys": [],
+            "preliminary_tss": [],
+            "final_confirmation_ts": None,
+            "image_offset_ts": None,
+            "final_answer_key": None,
+            "is_correct": None,
+            "question_stop_ts": None,
+        }
+
+        for p_row in group.iter_rows(named=True):
+            action = p_row["action"]
+            if action == "question_start":
+                row_data["question_onset_ts"] = p_row["time"]
+            elif action == "preliminary_answer":
+                row_data["preliminary_keys"].append(p_row["key_type"])
+                row_data["preliminary_tss"].append(p_row["time"])
+            elif action == "final_confirmation":
+                row_data["final_confirmation_ts"] = p_row["time"]
+            elif action == "image_offset":
+                row_data["image_offset_ts"] = p_row["time"]
+            elif action == "final_answer_given":
+                row_data["final_answer_key"] = p_row["key_type"]
+            elif action == "correctness":
+                row_data["is_correct"] = p_row["is_correct"]
+            elif action == "question_stop":
+                row_data["question_stop_ts"] = p_row["time"]
+
+        result_rows.append(row_data)
+
+    return pl.DataFrame(
+        result_rows,
+        schema={
+            "trial_id": pl.Utf8,
+            "stimulus_name": pl.Utf8,
+            "stimulus_id": pl.Utf8,
+            "question_id": pl.Utf8,
+            "question_onset_ts": pl.Float64,
+            "preliminary_keys": pl.List(pl.Utf8),
+            "preliminary_tss": pl.List(pl.Float64),
+            "final_confirmation_ts": pl.Float64,
+            "image_offset_ts": pl.Float64,
+            "final_answer_key": pl.Utf8,
+            "is_correct": pl.Boolean,
+            "question_stop_ts": pl.Float64,
+        },
+    )

--- a/preprocessing/answers/msg_parser.py
+++ b/preprocessing/answers/msg_parser.py
@@ -2,6 +2,23 @@ import polars as pl
 import re
 
 
+def _result_schema() -> dict:
+    return {
+        "trial_id": pl.Utf8,
+        "stimulus_name": pl.Utf8,
+        "stimulus_id": pl.Utf8,
+        "question_id": pl.Utf8,
+        "question_onset_ts": pl.Float64,
+        "preliminary_keys": pl.List(pl.Utf8),
+        "preliminary_tss": pl.List(pl.Float64),
+        "final_confirmation_ts": pl.Float64,
+        "image_offset_ts": pl.Float64,
+        "final_answer_key": pl.Utf8,
+        "is_correct": pl.Boolean,
+        "question_stop_ts": pl.Float64,
+    }
+
+
 def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
     """Parse comprehension question answers from ASC messages.
 
@@ -174,22 +191,7 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
             continue
 
     if not parsed_rows:
-        return pl.DataFrame(
-            schema={
-                "trial_id": pl.Utf8,
-                "stimulus_name": pl.Utf8,
-                "stimulus_id": pl.Utf8,
-                "question_id": pl.Utf8,
-                "question_onset_ts": pl.Float64,
-                "preliminary_keys": pl.List(pl.Utf8),
-                "preliminary_tss": pl.List(pl.Float64),
-                "final_confirmation_ts": pl.Float64,
-                "image_offset_ts": pl.Float64,
-                "final_answer_key": pl.Utf8,
-                "is_correct": pl.Boolean,
-                "question_stop_ts": pl.Float64,
-            }
-        )
+        return pl.DataFrame(schema=_result_schema())
 
     df_parsed = pl.DataFrame(parsed_rows)
 
@@ -244,20 +246,4 @@ def parse_answers_from_messages(messages: pl.DataFrame) -> pl.DataFrame:
 
         result_rows.append(row_data)
 
-    return pl.DataFrame(
-        result_rows,
-        schema={
-            "trial_id": pl.Utf8,
-            "stimulus_name": pl.Utf8,
-            "stimulus_id": pl.Utf8,
-            "question_id": pl.Utf8,
-            "question_onset_ts": pl.Float64,
-            "preliminary_keys": pl.List(pl.Utf8),
-            "preliminary_tss": pl.List(pl.Float64),
-            "final_confirmation_ts": pl.Float64,
-            "image_offset_ts": pl.Float64,
-            "final_answer_key": pl.Utf8,
-            "is_correct": pl.Boolean,
-            "question_stop_ts": pl.Float64,
-        },
-    )
+    return pl.DataFrame(result_rows, schema=_result_schema())

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import polars as pl
+
+
+def parse_question_order(csv_path: Path) -> pl.DataFrame:
+    """Parse the question order CSV for a session.
+
+    The CSV is expected to have at least the following columns:
+    - question_order_version TODO: for what? randomization?
+    - local_question_1, local_question_2,
+      bridging_question_1, bridging_question_2,
+      global_question_1, global_question_2
+
+    Returns a DataFrame with the original columns plus a 1-based "trial" column.
+    """
+    df = pl.read_csv(csv_path)
+
+    # Add 1-based row index as trial number
+    df = df.with_row_index(name="trial")
+    df = df.with_columns((pl.col("trial") + 1).alias("trial"))
+    return df
+
+
+def _extract_stimulus_numeric_id(stimulus_name: str) -> str:
+    """Extract numeric stimulus id from names like 'Arg_PISACowsMilk_10'.
+
+    Falls back to extracting a trailing integer and raises ValueError if none found.
+    """
+    m = re.search(r"(\d+)$", stimulus_name)
+    if not m:
+        raise ValueError(
+            f"Could not extract numeric stimulus id from {stimulus_name!r}")
+    return m.group(1)
+
+
+def construct_question_id(stimulus_name: str, order_code: int) -> str:
+    """Construct the canonical question id.
+
+    Format: <stimulus_numeric_id><middle><order_code>
+    - middle digit is '2' for PISA texts (name contains 'PISA'), otherwise '1'.
+    - order_code is a two-digit number among {11, 12, 21, 22, 31, 32}.
+    """
+    stim_num = _extract_stimulus_numeric_id(stimulus_name)
+    middle = "2" if "PISA" in stimulus_name else "1"
+    return f"{stim_num}{middle}{order_code}"

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -33,7 +33,8 @@ def _extract_stimulus_numeric_id(stimulus_name: str) -> str:
     m = re.search(r"(\d+)$", stimulus_name)
     if not m:
         raise ValueError(
-            f"Could not extract numeric stimulus id from {stimulus_name!r}")
+            f"Could not extract numeric stimulus id from {stimulus_name!r}"
+        )
     return m.group(1)
 
 

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -44,9 +44,28 @@ def construct_question_id(
     stimulus_id: int | str | None = None,
     snippet_no: int = 1,
 ) -> str:
-    """Construct the canonical question id.
+    """Build the canonical question id for a comprehension question.
 
-    Format: <stimulus_numeric_id><snippet_no><order_code>
+    Format: <stimulus_id><snippet_no><order_code>.
+    The snippet_no distinguishes questions from different text snippets within
+    a multi-snippet stimulus (e.g., Arg_PISACowsMilk, Arg_PISARapaNui).
+    Most stimuli have snippet_no=1 for all questions.
+
+    Parameters
+    ----------
+    stimulus_name : str
+        Name of the stimulus (e.g. 'Arg_PISACowsMilk_10').
+    order_code : int
+        Two-digit code encoding condition and order (e.g. 11, 12, 21, 22, 31, 32).
+    stimulus_id : int | str | None, optional
+        Numeric stimulus ID. If None, extracted from stimulus_name suffix.
+    snippet_no : int, optional
+        Snippet number within the stimulus (default 1).
+
+    Returns
+    -------
+    str
+        Canonical question id.
     """
     stim_num = (
         str(stimulus_id) if stimulus_id else _extract_stimulus_numeric_id(stimulus_name)

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -10,7 +10,7 @@ def parse_question_order(csv_path: Path) -> pl.DataFrame:
     """Parse the question order CSV for a session.
 
     The CSV is expected to have at least the following columns:
-    - question_order_version TODO: for what? randomization?
+    - question_order_version
     - local_question_1, local_question_2,
       bridging_question_1, bridging_question_2,
       global_question_1, global_question_2
@@ -39,13 +39,16 @@ def _extract_stimulus_numeric_id(stimulus_name: str) -> str:
 
 
 def construct_question_id(
-    stimulus_name: str, order_code: int, stimulus_id: int | str | None = None
+    stimulus_name: str,
+    order_code: int,
+    stimulus_id: int | str | None = None,
+    snippet_no: int = 1,
 ) -> str:
     """Construct the canonical question id.
 
-    Format: <stimulus_numeric_id>1<order_code>
+    Format: <stimulus_numeric_id><snippet_no><order_code>
     """
     stim_num = (
         str(stimulus_id) if stimulus_id else _extract_stimulus_numeric_id(stimulus_name)
     )
-    return f"{stim_num}1{order_code}"
+    return f"{stim_num}{snippet_no}{order_code}"

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -43,14 +43,9 @@ def construct_question_id(
 ) -> str:
     """Construct the canonical question id.
 
-    Format: <stimulus_numeric_id><middle><order_code>
-    - middle digit is the second digit of the order_code for PISA texts, otherwise '1'.
-    - order_code is a two-digit number among {11, 12, 21, 22, 31, 32}.
+    Format: <stimulus_numeric_id>1<order_code>
     """
-    if stimulus_id is not None:
-        stim_num = str(stimulus_id)
-    else:
-        stim_num = _extract_stimulus_numeric_id(stimulus_name)
-
-    middle = str(order_code)[1] if "PISA" in stimulus_name else "1"
-    return f"{stim_num}{middle}{order_code}"
+    stim_num = (
+        str(stimulus_id) if stimulus_id else _extract_stimulus_numeric_id(stimulus_name)
+    )
+    return f"{stim_num}1{order_code}"

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -38,13 +38,19 @@ def _extract_stimulus_numeric_id(stimulus_name: str) -> str:
     return m.group(1)
 
 
-def construct_question_id(stimulus_name: str, order_code: int) -> str:
+def construct_question_id(
+    stimulus_name: str, order_code: int, stimulus_id: int | str | None = None
+) -> str:
     """Construct the canonical question id.
 
     Format: <stimulus_numeric_id><middle><order_code>
     - middle digit is '2' for PISA texts (name contains 'PISA'), otherwise '1'.
     - order_code is a two-digit number among {11, 12, 21, 22, 31, 32}.
     """
-    stim_num = _extract_stimulus_numeric_id(stimulus_name)
+    if stimulus_id is not None:
+        stim_num = str(stimulus_id)
+    else:
+        stim_num = _extract_stimulus_numeric_id(stimulus_name)
+
     middle = "2" if "PISA" in stimulus_name else "1"
     return f"{stim_num}{middle}{order_code}"

--- a/preprocessing/answers/parser.py
+++ b/preprocessing/answers/parser.py
@@ -44,7 +44,7 @@ def construct_question_id(
     """Construct the canonical question id.
 
     Format: <stimulus_numeric_id><middle><order_code>
-    - middle digit is '2' for PISA texts (name contains 'PISA'), otherwise '1'.
+    - middle digit is the second digit of the order_code for PISA texts, otherwise '1'.
     - order_code is a two-digit number among {11, 12, 21, 22, 31, 32}.
     """
     if stimulus_id is not None:
@@ -52,5 +52,5 @@ def construct_question_id(
     else:
         stim_num = _extract_stimulus_numeric_id(stimulus_name)
 
-    middle = "2" if "PISA" in stimulus_name else "1"
+    middle = str(order_code)[1] if "PISA" in stimulus_name else "1"
     return f"{stim_num}{middle}{order_code}"

--- a/preprocessing/api.py
+++ b/preprocessing/api.py
@@ -18,6 +18,9 @@ from .io.load import (
     load_trial_level_events_data,
     load_reading_measures,
 )
+from .answers.msg_parser import parse_answers_from_messages
+from .answers.experiment_log_parser import parse_answers_from_logfile
+from .answers.collect import collect_session_answers
 
 from .scripts.prepare_language_folder import prepare_language_folder
 from .scripts.restructure_psycho_tests import fix_psycho_tests_structure
@@ -40,4 +43,7 @@ __all__ = [
     "load_trial_level_raw_data",
     "load_trial_level_events_data",
     "load_reading_measures",
+    "parse_answers_from_messages",
+    "parse_answers_from_logfile",
+    "collect_session_answers",
 ]

--- a/preprocessing/checks/et_quality_checks.py
+++ b/preprocessing/checks/et_quality_checks.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Any, Callable, TextIO
+from typing import Any, TextIO
+from collections.abc import Callable
 
 import polars as pl
 
@@ -56,7 +57,7 @@ def check_comprehension_question_answers(
     overall_answers = 0
     for stimulus in stimuli:
         # get the trial number for the stimulus as rating screens don't have an entry in the stimulus_number column
-        trial_id = logfile.filter((pl.col("stimulus_number") == f"{stimulus.id}")).item(
+        trial_id = logfile.filter(pl.col("stimulus_number") == f"{stimulus.id}").item(
             0, "trial_number"
         )
         stimulus_frame = logfile.filter(
@@ -72,7 +73,7 @@ def check_comprehension_question_answers(
             report_file,
         )
 
-    if not overall_answers == 0:
+    if overall_answers != 0:
         _report_to_file(
             f"Overall correct answers: {overall_correct_answers} out of {overall_answers} answers {overall_correct_answers / overall_answers:.2f}",
             report_file,

--- a/preprocessing/checks/formal_experiment_checks.py
+++ b/preprocessing/checks/formal_experiment_checks.py
@@ -70,15 +70,15 @@ def check_all_screens_logfile(
         # print(f"Checking {stimulus.name} in Logfile")
         try:
             trial_id = logfile.filter(
-                (pl.col("stimulus_number") == str(stimulus.id))
+                pl.col("stimulus_number") == str(stimulus.id)
             ).item(
                 0, "trial_number"
             )  # get the trial number for the stimulus as ratingscreens don't have an entry in the stimulus_number column
         except (pl.exceptions.NoRowsReturnedError, IndexError):
             trial_id = logfile.filter(
-                (pl.col("stimulus_number") == str(float(stimulus.id)))
+                pl.col("stimulus_number") == str(float(stimulus.id))
             ).item(0, "trial_number")
-        stimulus_frame = logfile.filter((pl.col("trial_number") == trial_id))
+        stimulus_frame = logfile.filter(pl.col("trial_number") == trial_id)
         # print(stimulus_frame)
         # check if all pages are present
         for page in stimulus.pages:
@@ -118,7 +118,7 @@ def sanity_check_gaze_frame(gaze, stimuli, report_file):
     for stimulus in stimuli:
         # print(f"Checking {stimulus.name}")
         stimulus_frame = gaze.samples.filter(
-            (pl.col(settings.STIMULUS_COL) == f"{stimulus.name}_{stimulus.id}")
+            pl.col(settings.STIMULUS_COL) == f"{stimulus.name}_{stimulus.id}"
         ).unique(settings.PAGE_COL)
         # check if all pages are present
         for page in stimulus.pages:

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -230,7 +230,7 @@ class Settings:
             return self.__dict__["RAW_DATA_FILENAME_REGEX"]
         trial_col = self.TRIAL_COL
         stimulus_col = self.STIMULUS_COL
-        return rf".+_(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_raw_data"
+        return rf".+?(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_raw_data"
 
     @RAW_DATA_FILENAME_REGEX.setter
     def RAW_DATA_FILENAME_REGEX(self, value: str) -> None:
@@ -243,7 +243,7 @@ class Settings:
             return self.__dict__["EVENT_DATA_FILENAME_REGEX"]
         trial_col = self.TRIAL_COL
         stimulus_col = self.STIMULUS_COL
-        return rf".+_(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_{{event_type}}.csv"
+        return rf".+?(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_{{event_type}}.csv"
 
     @EVENT_DATA_FILENAME_REGEX.setter
     def EVENT_DATA_FILENAME_REGEX(self, value: str) -> None:

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -536,9 +536,10 @@ class Settings:
 
         #: Mapping of eye tracker brands to known model names.
         self.EYETRACKER_NAMES = {
-            "eyelink": [
+            "eyelink": [  # TODO: Update list to mapping between same eyetrackers - use dict
                 "EyeLink 1000 Plus",
                 "EyeLink 1000+",
+                "EyeLink 1000-Plus",
                 "EyeLink II",
                 "EyeLink 1000",
                 "EyeLink Portable Duo",

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -412,6 +412,18 @@ class Settings:
             r"stop_recording_.*_question_\d+",
         ]
 
+        # --- PIPELINE STAGES ---
+        #: Whether to perform fixation detection.
+        self.RUN_FIXATION_DETECTION = True
+        #: Whether to perform saccade detection.
+        self.RUN_SACCADE_DETECTION = True
+        #: Whether to perform reading measures calculation.
+        self.RUN_READING_MEASURES = True
+        #: Whether to collect comprehension question answers.
+        self.RUN_COMPREHENSION_ANSWERS = True
+        #: Whether to create sanity check reports.
+        self.RUN_SANITY_CHECKS = True
+
         #: Column name for the trial identifier.
         self.TRIAL_COL = "trial"
 

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -399,6 +399,19 @@ class Settings:
         #: Subfolder name for metadata files.
         self.METADATA_FOLDER = Path("metadata/")
 
+        #: Subfolder name for comprehension question answers.
+        self.ANSWERS_FOLDER = Path("comp_answers/")
+
+        #: Regex patterns for relevant ASC messages for comprehension questions.
+        self.ANSWER_MSG_PATTERNS = [
+            r"start_recording_.*_question_\d+",
+            r".*_preliminary_answer_.*",
+            r"question_screen_image_offset",
+            r".*_final_answer_given_is_.*",
+            r".*_answer_given_is_correct:.*",
+            r"stop_recording_.*_question_\d+",
+        ]
+
         #: Column name for the trial identifier.
         self.TRIAL_COL = "trial"
 

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -763,7 +763,7 @@ class Settings:
 
         logger.debug(f"Loading config from: {path}")
 
-        with open(path, "r") as f:
+        with open(path) as f:
             user_configs = yaml.safe_load(f)
 
         if user_configs:

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -225,12 +225,11 @@ class MultipleyeDataCollection:
 
         # get a list of all folders in the data folder
         if session_folder_regex:
-            items = os.scandir(self.data_root)
+            items = list(os.scandir(self.data_root))
             pilots = []
             if self.include_pilots:
-                pilots = os.scandir(self.data_root / self.pilot_folder)
-                pilots = list(pilots)
-                items = list(items) + pilots
+                pilots = list(os.scandir(self.data_root / self.pilot_folder))
+                items = items + pilots
 
             # Check for sessions without a data file
             sessions_missing_data = []
@@ -464,7 +463,9 @@ class MultipleyeDataCollection:
         year = dcn.year
 
         session_folder_regex = (
-            r"\d\d\d" + f"_{stimulus_language}_{country}_{lab_number}" + r"_ET\d"
+            r"\d\d\d"
+            + f"_{stimulus_language}_{country}_{lab_number}"
+            + r"_ET\d(?:_.*)?"
         )
 
         stimulus_folder_path = settings.OUTPUT_DIR / f"stimuli_{data_folder_name}"

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -232,6 +232,30 @@ class MultipleyeDataCollection:
                 pilots = list(pilots)
                 items = list(items) + pilots
 
+            # Check for sessions without a data file
+            sessions_missing_data = []
+            for item in items:
+                if item.is_dir() and re.match(
+                    session_folder_regex, item.name, re.IGNORECASE
+                ):
+                    # check if the session is excluded or included
+                    if self.included_sessions:
+                        if item.name not in self.included_sessions:
+                            continue
+                    elif self.excluded_sessions:
+                        if item.name in self.excluded_sessions:
+                            continue
+
+                    session_file = list(Path(item.path).glob("*" + session_file_suffix))
+                    if len(session_file) == 0:
+                        sessions_missing_data.append(item.name)
+
+            if sessions_missing_data:
+                raise ValueError(
+                    f"The following sessions are missing a data file matching '{session_file_suffix}' "
+                    f"and will be skipped: {sorted(sessions_missing_data)}"
+                )
+
             for item in items:
                 if item.is_dir():
                     if re.match(session_folder_regex, item.name, re.IGNORECASE):

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -287,7 +287,9 @@ class MultipleyeDataCollection:
                             )
 
         if not found_sessions:
-            raise ValueError(f"No sessions found in data folder {self.data_root}")
+            raise ValueError(
+                f"No sessions found (or none matching the ex-/inclusion criteria) in data folder {self.data_root}"
+            )
 
         unique_sessions = set(found_sessions)
 

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -177,7 +177,7 @@ class MultipleyeDataCollection:
         if not self.overview:
             self.overview = self.create_dataset_overview()
 
-        return "\n".join("{}\t{}".format(k, v) for k, v in self.overview.items())
+        return "\n".join(f"{k}\t{v}" for k, v in self.overview.items())
 
     # TODO: check these chatgpt functions :D
     def __iter__(self):
@@ -217,11 +217,10 @@ class MultipleyeDataCollection:
 
         found_sessions = []
 
-        if not session_file_suffix:
+        if not session_file_suffix and self.eye_tracker == "eyelink":
             # TODO: add configs for each eye tracker such that we don't always have to loop through all eye trackers
             #  but can write generic code. E.g. self.eye_tracker.session_file_regex
-            if self.eye_tracker == "eyelink":
-                session_file_suffix = r".edf"
+            session_file_suffix = r".edf"
 
         # get a list of all folders in the data folder
         if session_folder_regex:
@@ -241,9 +240,8 @@ class MultipleyeDataCollection:
                     if self.included_sessions:
                         if item.name not in self.included_sessions:
                             continue
-                    elif self.excluded_sessions:
-                        if item.name in self.excluded_sessions:
-                            continue
+                    elif self.excluded_sessions and item.name in self.excluded_sessions:
+                        continue
 
                     session_file = list(Path(item.path).glob("*" + session_file_suffix))
                     if len(session_file) == 0:
@@ -601,7 +599,7 @@ class MultipleyeDataCollection:
         :return:
         """
         if not session:
-            sessions = [key for key in self.sessions.keys()]
+            sessions = [key for key in self.sessions]
             return sessions
         elif session not in self.sessions:
             raise KeyError(f"Session {session} not found in {self.data_root}.")
@@ -688,12 +686,11 @@ class MultipleyeDataCollection:
             except (ValueError, TypeError):
                 p_id = session.split("_")[0] if "_" in session else session
 
-            if "start_after_trial" in session:
-                if p_id not in self.crashed_session_ids:
-                    self.crashed_session_ids.append(p_id)
-                    self.logger.warning(
-                        f"Session {session} started after a trial. Only the completed stimuli will be considered."
-                    )
+            if "start_after_trial" in session and p_id not in self.crashed_session_ids:
+                self.crashed_session_ids.append(p_id)
+                self.logger.warning(
+                    f"Session {session} started after a trial. Only the completed stimuli will be considered."
+                )
 
             (
                 self.sessions[session].completed_stimuli_ids,
@@ -719,16 +716,15 @@ class MultipleyeDataCollection:
             if (
                 self.sessions[session].stimulus_order_ids
                 != self.sessions[session].completed_stimuli_ids
-            ):
-                if p_id not in self.crashed_session_ids:
-                    msg = (
-                        f"Stimulus order and completed stimuli do not match for "
-                        f"session {session}. Please check the files carefully."
-                    )
-                    self.logger.warning(msg)
-                    if not hasattr(logging, "_captured_warnings"):
-                        logging._captured_warnings = []  # type: ignore
-                    logging._captured_warnings.append(msg)  # type: ignore
+            ) and p_id not in self.crashed_session_ids:
+                msg = (
+                    f"Stimulus order and completed stimuli do not match for "
+                    f"session {session}. Please check the files carefully."
+                )
+                self.logger.warning(msg)
+                if not hasattr(logging, "_captured_warnings"):
+                    logging._captured_warnings = []  # type: ignore
+                logging._captured_warnings.append(msg)  # type: ignore
 
             self.sessions[session].stimuli = self._load_session_stimuli(
                 self.stimulus_dir,
@@ -809,7 +805,7 @@ class MultipleyeDataCollection:
         )
 
         regex = settings.LOGFILE_ORDER_VERSION_REGEX
-        with open(general_logfile, "r", encoding="utf-8") as f:
+        with open(general_logfile, encoding="utf-8") as f:
             text = f.read()
         match = re.search(regex, text)
 
@@ -1072,7 +1068,7 @@ class MultipleyeDataCollection:
         os.makedirs(result_folder, exist_ok=True)
         in_break = False
 
-        with open(asc_file, "r", encoding="utf-8") as f:
+        with open(asc_file, encoding="utf-8") as f:
             for line in f.readlines():
                 if match := settings.MESSAGE_REGEX.match(line):
                     messages.append(match.groupdict())
@@ -1468,7 +1464,7 @@ class MultipleyeDataCollection:
 
             pq_file = folder / f"{sid.base_id}_pq_data.json"
             if pq_file.exists():
-                with open(pq_file, "r", encoding="utf-8") as f:
+                with open(pq_file, encoding="utf-8") as f:
                     data = json.load(f)
 
                 # due to a bug in an earlier version of the experiment, some of the participant data has been lost,

--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -68,6 +68,7 @@ class Session:
     fixations: bool = field(default=False, init=False)
     saccades: bool = field(default=False, init=False)
     reading_measures: bool = field(default=False, init=False)
+    answers: bool = field(default=False, init=False)
 
     trials = list[Trial]
 
@@ -101,6 +102,7 @@ class Session:
             "Fixations": self.fixations,
             "Saccades": self.saccades,
             "Reading_measures": self.reading_measures,
+            "Answers": self.answers,
         }
 
         return dict_repr

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -71,6 +71,8 @@ class StimulusPage:
 
 @dataclass
 class ComprehensionQuestion:
+    """A comprehension question belonging to a stimulus."""
+
     name: str
     id: str
     snippet_no: int

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -73,6 +73,7 @@ class StimulusPage:
 class ComprehensionQuestion:
     name: str
     id: str
+    snippet_no: int
     question: str
     target: str
     distractor_a: str
@@ -184,6 +185,7 @@ class Stimulus:
         for question_row in question_rows:
             question_name = question_row["item_id"]
             question_id = question_row["item_id"].split("_")[-1]
+            snippet_no = question_row["snippet_no"]
             question = question_row["question"]
             target = question_row["target"]
             distractor_a = question_row["distractor_a"]
@@ -206,6 +208,7 @@ class Stimulus:
             question = ComprehensionQuestion(
                 name=question_name,
                 id=question_id,
+                snippet_no=snippet_no,
                 question=question,
                 target=target,
                 distractor_a=distractor_a,

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -289,7 +289,7 @@ def load_trial_level_events_data(
 def load_reading_measures(
     directory: Path,
     sid: Sid,
-    file_pattern: str = r".*?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv",
+    file_pattern: str = r".+?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv",
 ) -> pl.DataFrame:
     """Load reading measures from CSV files.
 

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -158,20 +158,20 @@ def load_trial_level_raw_data(
     if load_metadata:
         metadata_path = Path(directory) / settings.METADATA_FOLDER / str(sid)
 
-        with open(metadata_path / "gaze_metadata.json", "r", encoding="utf8") as f:
+        with open(metadata_path / "gaze_metadata.json", encoding="utf8") as f:
             metadata = json.load(f)
 
         gaze._metadata = metadata
 
-        with open(metadata_path / "experiment.yaml", "r") as f:
+        with open(metadata_path / "experiment.yaml") as f:
             exp = yaml.safe_load(f)
 
-        with open(metadata_path / "validations.tsv", "r", encoding="utf8") as f:
+        with open(metadata_path / "validations.tsv", encoding="utf8") as f:
             validations_df = pl.read_csv(f, separator="\t")
 
         gaze.validations = validations_df
 
-        with open(metadata_path / "calibrations.tsv", "r", encoding="utf8") as f:
+        with open(metadata_path / "calibrations.tsv", encoding="utf8") as f:
             calibrations_df = pl.read_csv(f, separator="\t")
 
         gaze.calibrations = calibrations_df
@@ -239,7 +239,7 @@ def load_trial_level_events_data(
         if match is None:
             logging.info(f"Skipping file {file} for event loading")
         else:
-            for group_name in match.groupdict().keys():
+            for group_name in match.groupdict():
                 if group_name not in trial_df.columns:
                     trial_df = trial_df.with_columns(
                         pl.lit(match.group(group_name)).alias(group_name)

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -19,6 +19,7 @@ def load_gaze_data(
     lab_config: LabConfig,
     session_idf: str,
     trial_cols: list[str] = None,
+    messages: bool | list[str] = False,
 ) -> pm.Gaze:
     """Load sample gaze data from an ASC file.
 
@@ -38,6 +39,10 @@ def load_gaze_data(
         Identifier for the session the gaze data corresponds to.
     trial_cols : list of str, optional
         List of columns to be associated with trial-level metadata. Default is None.
+    messages : bool or list of str, optional
+        Whether to extract messages from the ASC file. If True, all messages are extracted.
+        If a list of strings is provided, only messages matching the patterns are extracted.
+        Default is False.
 
     Returns
     -------
@@ -59,12 +64,16 @@ def load_gaze_data(
         sampling_rate=lab_config.sampling_frequency_hz,
     )
 
+    if messages is None:
+        messages = False
+
     gaze = pm.gaze.from_asc(
         asc_file,
         patterns=settings.GAZE_PATTERNS,
         trial_columns=trial_cols,
         add_columns={"session": session_idf},
         experiment=experiment,
+        messages=messages,
     )
 
     # Filter out data outside of trials

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -38,7 +38,7 @@ def save_raw_data(directory: Path, sid: Sid, data: pm.Gaze) -> None:
         df = trial.samples
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]
-        name = f"{sid.id_no_postfix}_{trial}_{stimulus}_raw_data.csv"
+        name = f"{str(sid)}_{trial}_{stimulus}_raw_data.csv"
         df = df["time", "pixel_x", "pixel_y", "pupil", "page"]
         df.write_csv(directory / name)
 
@@ -93,7 +93,7 @@ def save_events_data(
     events = data_copy.events.frame.filter(pl.col("name") == event_type)
 
     for group in events.partition_by(split_column):
-        name = f"{sid.id_no_postfix}"
+        name = f"{str(sid)}"
         for col in name_columns:
             if col not in group.columns:
                 raise ValueError(f"Column {col} not found in events data.")
@@ -141,7 +141,7 @@ def save_scanpaths(directory: Path, sid: Sid, data: pm.Gaze) -> None:
             continue
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]
-        name = f"{sid.id_no_postfix}_{trial}_{stimulus}_scanpath.csv"
+        name = f"{str(sid)}_{trial}_{stimulus}_scanpath.csv"
 
         df = df[
             "onset",
@@ -186,7 +186,7 @@ def save_reading_measures(directory: Path, sid: Sid, data: pl.DataFrame) -> None
     for trial in trials:
         trial_id = trial["trial"][0]
         stimulus = trial["stimulus"][0]
-        name = f"{sid.id_no_postfix}_{trial_id}_{stimulus}_reading_measures.csv"
+        name = f"{str(sid)}_{trial_id}_{stimulus}_reading_measures.csv"
         trial = trial.drop("stimulus", "trial")
         trial.write_csv(directory / name)
 

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -8,6 +8,7 @@ import polars as pl
 import pymovements as pm
 from ..config import settings
 from ..models.sid import Sid
+import contextlib
 
 
 def save_raw_data(directory: Path, sid: Sid, data: pm.Gaze) -> None:
@@ -31,10 +32,8 @@ def save_raw_data(directory: Path, sid: Sid, data: pm.Gaze) -> None:
     trials = new_data.split(by="trial", as_dict=False)
 
     for trial in trials:
-        try:
+        with contextlib.suppress(Warning):
             trial.unnest()
-        except Warning:
-            pass
         df = trial.samples
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]

--- a/preprocessing/models/dcn.py
+++ b/preprocessing/models/dcn.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 import re
 
 __all__ = ["Dcn"]
@@ -16,13 +15,13 @@ class Dcn:
 
     def __init__(
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        lang: Optional[str] = None,
-        country: Optional[str] = None,
-        city: Optional[str] = None,
-        lab: Optional[str] = None,
-        year: Optional[str] = None,
+        lang: str | None = None,
+        country: str | None = None,
+        city: str | None = None,
+        lab: str | None = None,
+        year: str | None = None,
     ):
         if name is not None and any(
             v is not None for v in [lang, country, city, lab, year]

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -119,11 +119,11 @@ class Sid:
         return base
 
     @staticmethod
-    def get_session_save_name(session_idf: str) -> str:
-        """Get a consistent session name for file names, excluding restart postfixes."""
+    def get_session_save_name(session_idf: str, include_postfix: bool = False) -> str:
+        """Get a consistent session name for file names, optionally including restart postfixes."""
         try:
             sid = Sid(session_idf)
-            return sid.id_no_postfix
+            return str(sid) if include_postfix else sid.id_no_postfix
         except (ValueError, TypeError):
             # Fallback for non-compliant identifiers
             return "_".join(session_idf.split("_")[:5])

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 import re
 
 __all__ = ["Sid"]
@@ -17,13 +16,13 @@ class Sid:
 
     def __init__(
         self,
-        sid: Optional[str] = None,
+        sid: str | None = None,
         *,
-        pid: Optional[str] = None,
-        lang: Optional[str] = None,
-        country: Optional[str] = None,
-        lab: Optional[str] = None,
-        session: Optional[str] = None,
+        pid: str | None = None,
+        lang: str | None = None,
+        country: str | None = None,
+        lab: str | None = None,
+        session: str | None = None,
         postfix: str = "",
     ):
         if sid is not None and any(

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -1282,9 +1282,7 @@ def _find_one_filetype_with_columns(
     if not valid_csvs:
         details = ""
         if missing_cols_info:
-            details = "\nChecked: " + ", ".join(
-                f"'{f}'" for f in missing_cols_info.keys()
-            )
+            details = "\nChecked: " + ", ".join(f"'{f}'" for f in missing_cols_info)
         raise ValueError(
             f"No CSV files with the required columns {columns} were found in '{display_path}'.{details}"
         )

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -159,7 +159,7 @@ def prepare_language_folder(data_collection_name: str | None = None):
     if destination_aoi_path.exists():
         # check if it already contains 24 files and the fixed marker
         if (
-            len(list(destination_aoi_path.glob("*.csv"))) == 24
+            len(list(destination_aoi_path.glob("[!.]*.csv"))) == 24
             and (destination_aoi_path / ".fixed").exists()
         ):
             logger.debug(

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -156,16 +156,15 @@ def prepare_language_folder(data_collection_name: str | None = None):
         / f"aoi_stimuli_{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
     )
 
-    if destination_aoi_path.exists():
-        # check if it already contains 24 files and the fixed marker
-        if (
-            len(list(destination_aoi_path.glob("[!.]*.csv"))) == 24
-            and (destination_aoi_path / ".fixed").exists()
-        ):
-            logger.debug(
-                f"AOI files already exist, are split and fixed in {destination_aoi_path}. Skipping."
-            )
-            return
+    if (  # check if it already contains 24 files and the fixed marker
+        destination_aoi_path.exists()
+        and len(list(destination_aoi_path.glob("[!.]*.csv"))) == 24
+        and (destination_aoi_path / ".fixed").exists()
+    ):
+        logger.debug(
+            f"AOI files already exist, are split and fixed in {destination_aoi_path}. Skipping."
+        )
+        return
 
     if not destination_aoi_path.exists():
         if source_aoi_path.exists():

--- a/preprocessing/scripts/restructure_psycho_tests.py
+++ b/preprocessing/scripts/restructure_psycho_tests.py
@@ -100,7 +100,7 @@ def fix_psycho_tests_structure(
         # Check if there is a corresponding data file
         name = config_file.stem
 
-        with open(config_file, "r") as f:
+        with open(config_file) as f:
             try:
                 yaml.safe_load(f)
             except yaml.YAMLError as exc:
@@ -133,7 +133,7 @@ def fix_psycho_tests_structure(
         except (ValueError, TypeError):
             config_sid = None
 
-        for yaml_flag, folder_name in settings.PSYCHOMETRIC_TEST_MAPPING.items():
+        for folder_name in settings.PSYCHOMETRIC_TEST_MAPPING.values():
             # Try exact match first
             old_path = data_folder / folder_name / name
 

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -1,6 +1,7 @@
 import os
 from argparse import ArgumentParser
 
+import polars as pl
 from tqdm import tqdm
 
 from ..models.sid import Sid
@@ -130,7 +131,9 @@ def run_preprocessing(config_path: str | None = None):
 
         if settings.RUN_FIXATION_DETECTION or settings.RUN_SACCADE_DETECTION:
             if gaze is None:
-                logger.warning(f"Gaze data missing for {idf}. Skipping event detection.")
+                logger.warning(
+                    f"Gaze data missing for {idf}. Skipping event detection."
+                )
             elif (
                 fixation_data_folder.exists()
                 and saccade_data_folder.exists()
@@ -208,6 +211,14 @@ def run_preprocessing(config_path: str | None = None):
                         ],
                         gaze,
                     )
+
+                # Unnest event columns (e.g. location struct -> location_x/location_y)
+                # so downstream code doesn't need to handle struct columns.
+                if gaze is not None and gaze.events is not None:
+                    try:
+                        gaze.events.unnest()
+                    except Warning:
+                        pass
         else:
             pbar.set_description(f"Skipping event detection {idf}:")
             # Load existing if available
@@ -234,7 +245,13 @@ def run_preprocessing(config_path: str | None = None):
 
         # map to AOIs and create scanpaths
         if settings.RUN_FIXATION_DETECTION:  # Mapping depends on fixations
-            if gaze is None or "fixation" not in gaze.events:
+            if (
+                gaze is None
+                or gaze.events is None
+                or gaze.events.frame.filter(
+                    pl.col("name") == settings.FIXATION
+                ).is_empty()
+            ):
                 logger.warning(
                     f"Fixations missing for {idf}. Skipping AOI mapping/scanpaths."
                 )
@@ -254,9 +271,16 @@ def run_preprocessing(config_path: str | None = None):
         rm_folder = settings.OUTPUT_DIR / settings.READING_MEASURES_FOLDER / idf
 
         if settings.RUN_READING_MEASURES:
-            if gaze is None:
+            if (
+                gaze is None
+                or gaze.events is None
+                or gaze.events.frame.filter(
+                    pl.col("name") == settings.FIXATION
+                ).is_empty()
+                or settings.WORD_IDX_COL not in gaze.events.columns
+            ):
                 logger.warning(
-                    f"Gaze/Event data missing for {idf}. Skipping reading measures."
+                    f"Gaze/Event data missing or not mapped for {idf}. Skipping reading measures."
                 )
             elif rm_folder.exists() and not settings.OVERWRITE:
                 # check if the folder contains the expected number of files, if not, we will overwrite
@@ -305,16 +329,24 @@ def run_preprocessing(config_path: str | None = None):
             else:
                 pbar.set_description(f"Collecting comprehension answers {idf}")
                 question_order_csv = (
-                    sess.session_folder_path / "logfiles" / "question_order_versions.csv"
+                    sess.session_folder_path
+                    / "logfiles"
+                    / "question_order_versions.csv"
                 )
                 if question_order_csv.exists():
                     parsed_answers = None
                     source = "unknown"
 
                     # 1. Primary source: ASC messages (prefer if gaze exists)
-                    if gaze is not None and gaze.messages is not None and not gaze.messages.is_empty():
-                        parsed_answers = preprocessing.parse_answers_from_messages(gaze.messages)
-                        if not parsed_answers.is_empty():
+                    if (
+                        gaze is not None
+                        and gaze.messages is not None
+                        and not gaze.messages.is_empty()
+                    ):
+                        parsed_answers = preprocessing.parse_answers_from_messages(
+                            gaze.messages
+                        )
+                        if parsed_answers is not None and not parsed_answers.is_empty():
                             source = "asc"
 
                     # 2. Fallback source: experiment logfile
@@ -334,6 +366,7 @@ def run_preprocessing(config_path: str | None = None):
                         parsed_answers=parsed_answers,
                         out_path=answers_csv,
                         source=source,
+                        completed_stimuli_ids=sess.completed_stimuli_ids,
                     )
                     sess.answers = True
         else:

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -128,170 +128,235 @@ def run_preprocessing(config_path: str | None = None):
         fixation_data_folder = settings.OUTPUT_DIR / settings.FIXATIONS_FOLDER / idf
         saccade_data_folder = settings.OUTPUT_DIR / settings.SACCADES_FOLDER / idf
 
-        if (
-            fixation_data_folder.exists()
-            and saccade_data_folder.exists()
-            and not settings.OVERWRITE
-        ):
-            # check if the folder contains the expected number of files, if not, we will overwrite
-            num_expected_files = len(sess.completed_stimuli_ids)
-            num_files = len(list(fixation_data_folder.glob("*.csv")))
+        if settings.RUN_FIXATION_DETECTION or settings.RUN_SACCADE_DETECTION:
+            if gaze is None:
+                logger.warning(f"Gaze data missing for {idf}. Skipping event detection.")
+            elif (
+                fixation_data_folder.exists()
+                and saccade_data_folder.exists()
+                and not settings.OVERWRITE
+            ):
+                # check if the folder contains the expected number of files, if not, we will overwrite
+                num_expected_files = len(sess.completed_stimuli_ids)
+                num_files = len(list(fixation_data_folder.glob("*.csv")))
 
-            if num_expected_files != num_files:
-                raise ValueError(
-                    f"Fixation data cannot be loaded as the folder for session {idf} does not contain the "
-                    f"expected number of files. Please check and select overwrite."
+                if num_expected_files != num_files:
+                    raise ValueError(
+                        f"Fixation data cannot be loaded as the folder for session {idf} does not contain the "
+                        f"expected number of files. Please check and select overwrite."
+                    )
+
+                num_files = len(list(saccade_data_folder.glob("*.csv")))
+                if num_expected_files != num_files:
+                    raise ValueError(
+                        f"Saccade data cannot be loaded as the folder for session {idf} does not contain the "
+                        f"expected number of files. Please check and select overwrite."
+                    )
+
+                pbar.set_description(f"Loading events {idf}:")
+                gaze = preprocessing.load_trial_level_events_data(
+                    gaze,
+                    settings.OUTPUT_DIR,
+                    idf,
+                    event_type=settings.FIXATION,
+                    file_pattern=None,
                 )
 
-            num_files = len(list(saccade_data_folder.glob("*.csv")))
-            if num_expected_files != num_files:
-                raise ValueError(
-                    f"Saccade data cannot be loaded as the folder for session {idf} does not contain the "
-                    f"expected number of files. Please check and select overwrite."
+                gaze = preprocessing.load_trial_level_events_data(
+                    gaze,
+                    settings.OUTPUT_DIR,
+                    idf,
+                    event_type=settings.SACCADE,
+                    file_pattern=None,
                 )
 
-            pbar.set_description(f"Loading events {idf}:")
-            gaze = preprocessing.load_trial_level_events_data(
-                gaze,
-                settings.OUTPUT_DIR,
-                idf,
-                event_type=settings.FIXATION,
-                file_pattern=None,
-            )
+            else:
+                pbar.set_description(f"Detecting events {idf}:")
 
-            gaze = preprocessing.load_trial_level_events_data(
-                gaze,
-                settings.OUTPUT_DIR,
-                idf,
-                event_type=settings.SACCADE,
-                file_pattern=None,
-            )
+                if settings.RUN_FIXATION_DETECTION:
+                    preprocessing.detect_fixations(gaze)
+                if settings.RUN_SACCADE_DETECTION:
+                    preprocessing.detect_saccades(gaze)
 
+                if settings.RUN_FIXATION_DETECTION:
+                    preprocessing.save_events_data(
+                        settings.FIXATION,
+                        settings.OUTPUT_DIR,
+                        session_save_name,
+                        idf,
+                        "trial",
+                        ["trial", "stimulus"],
+                        ["onset", "duration", "location_x", "location_y", "page"],
+                        gaze,
+                    )
+
+                if settings.RUN_SACCADE_DETECTION:
+                    preprocessing.save_events_data(
+                        settings.SACCADE,
+                        settings.OUTPUT_DIR,
+                        session_save_name,
+                        idf,
+                        "trial",
+                        ["trial", "stimulus"],
+                        [
+                            "onset",
+                            "duration",
+                            "amplitude",
+                            "peak_velocity",
+                            "dispersion",
+                            "page",
+                        ],
+                        gaze,
+                    )
         else:
-            pbar.set_description(f"Detecting events {idf}:")
-
-            preprocessing.detect_fixations(gaze)
-            preprocessing.detect_saccades(gaze)
-
-            preprocessing.save_events_data(
-                settings.FIXATION,
-                settings.OUTPUT_DIR,
-                session_save_name,
-                idf,
-                "trial",
-                ["trial", "stimulus"],
-                ["onset", "duration", "location_x", "location_y", "page"],
-                gaze,
-            )
-
-            preprocessing.save_events_data(
-                settings.SACCADE,
-                settings.OUTPUT_DIR,
-                session_save_name,
-                idf,
-                "trial",
-                ["trial", "stimulus"],
-                [
-                    "onset",
-                    "duration",
-                    "amplitude",
-                    "peak_velocity",
-                    "dispersion",
-                    "page",
-                ],
-                gaze,
-            )
+            pbar.set_description(f"Skipping event detection {idf}:")
+            # Load existing if available
+            if (
+                gaze is not None
+                and fixation_data_folder.exists()
+                and saccade_data_folder.exists()
+            ):
+                logger.info(f"Using existing event data for {idf}")
+                gaze = preprocessing.load_trial_level_events_data(
+                    gaze,
+                    settings.OUTPUT_DIR,
+                    idf,
+                    event_type=settings.FIXATION,
+                    file_pattern=None,
+                )
+                gaze = preprocessing.load_trial_level_events_data(
+                    gaze,
+                    settings.OUTPUT_DIR,
+                    idf,
+                    event_type=settings.SACCADE,
+                    file_pattern=None,
+                )
 
         # map to AOIs and create scanpaths
-        preprocessing.map_fixations_to_aois(
-            gaze,
-            sess.stimuli,
-        )
-        preprocessing.save_scanpaths(settings.OUTPUT_DIR, session_save_name, idf, gaze)
+        if settings.RUN_FIXATION_DETECTION:  # Mapping depends on fixations
+            if gaze is None or "fixation" not in gaze.events:
+                logger.warning(
+                    f"Fixations missing for {idf}. Skipping AOI mapping/scanpaths."
+                )
+            else:
+                preprocessing.map_fixations_to_aois(
+                    gaze,
+                    sess.stimuli,
+                )
+                preprocessing.save_scanpaths(
+                    settings.OUTPUT_DIR, session_save_name, idf, gaze
+                )
 
-        preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, idf)
+                preprocessing.save_session_metadata(
+                    settings.OUTPUT_DIR, gaze, idf
+                )
 
         rm_folder = settings.OUTPUT_DIR / settings.READING_MEASURES_FOLDER / idf
 
-        if rm_folder.exists() and not settings.OVERWRITE:
-            # check if the folder contains the expected number of files, if not, we will overwrite
-            num_expected_files = len(sess.completed_stimuli_ids)
-            num_files = len(list(rm_folder.glob("*.csv")))
-            if num_expected_files != num_files:
-                raise ValueError(
-                    f"Reading measures cannot be loaded as the folder for session {idf} does not contain the "
-                    f"expected number of files. Please check and select overwrite."
+        if settings.RUN_READING_MEASURES:
+            if gaze is None:
+                logger.warning(
+                    f"Gaze/Event data missing for {idf}. Skipping reading measures."
                 )
-
-            pbar.set_description(f"Loading reading measures {idf}:")
-            reading_measures = preprocessing.load_reading_measures(
-                settings.OUTPUT_DIR,
-                idf,
-            )
-
-            data_collection[sess.session_identifier].reading_measures = True
-
-        else:
-            pbar.set_description(f"Calculating reading measures {idf}:")
-            reading_measures = preprocessing.calculate_reading_measures(
-                gaze,
-                sess.stimuli,
-            )
-
-            preprocessing.save_reading_measures(
-                settings.OUTPUT_DIR, session_save_name, idf, reading_measures
-            )
-            data_collection[sess.session_identifier].reading_measures = True
-
-        # === COMPREHENSION QUESTION ANSWERS ===
-        answers_csv = (
-            settings.OUTPUT_DIR
-            / settings.ANSWERS_FOLDER
-            / session_save_name
-            / f"{session_save_name}_answers.csv"
-        )
-
-        if answers_csv.exists() and not settings.OVERWRITE:
-            pbar.set_description(f"Loading answers {idf}")
-            sess.answers = True
-        else:
-            pbar.set_description(f"Collecting answers {idf}")
-            question_order_csv = (
-                sess.session_folder_path / "logfiles" / "question_order_versions.csv"
-            )
-            if question_order_csv.exists():
-                parsed_answers = (
-                    preprocessing.parse_answers_from_messages(gaze.messages)
-                    if gaze.messages is not None
-                    else None
-                )
-                if parsed_answers is None or parsed_answers.is_empty():
-                    # Fallback to experiment logfile
-                    parsed_answers = preprocessing.parse_answers_from_logfile(
-                        sess.logfile, sess.stimuli_trial_mapping
+            elif rm_folder.exists() and not settings.OVERWRITE:
+                # check if the folder contains the expected number of files, if not, we will overwrite
+                num_expected_files = len(sess.completed_stimuli_ids)
+                num_files = len(list(rm_folder.glob("*.csv")))
+                if num_expected_files != num_files:
+                    raise ValueError(
+                        f"Reading measures cannot be loaded as the folder for session {idf} does not contain the "
+                        f"expected number of files. Please check and select overwrite."
                     )
 
-                preprocessing.collect_session_answers(
-                    question_order_csv=question_order_csv,
-                    stimuli_trial_map=sess.stimuli_trial_mapping,
-                    stimuli=sess.stimuli,
-                    parsed_answers=parsed_answers,
-                    out_path=answers_csv,
+                pbar.set_description(f"Loading reading measures {idf}:")
+                reading_measures = preprocessing.load_reading_measures(
+                    settings.OUTPUT_DIR,
+                    idf,
                 )
+
+                data_collection[sess.session_identifier].reading_measures = True
+
+            else:
+                pbar.set_description(f"Calculating reading measures {idf}:")
+                reading_measures = preprocessing.calculate_reading_measures(
+                    gaze,
+                    sess.stimuli,
+                )
+
+                preprocessing.save_reading_measures(
+                    settings.OUTPUT_DIR, session_save_name, idf, reading_measures
+                )
+                data_collection[sess.session_identifier].reading_measures = True
+        else:
+            pbar.set_description(f"Skipping reading measures {idf}:")
+
+        # === COMPREHENSION QUESTION ANSWERS ===
+        if settings.RUN_COMPREHENSION_ANSWERS:
+            answers_csv = (
+                settings.OUTPUT_DIR
+                / settings.ANSWERS_FOLDER
+                / session_save_name
+                / f"{session_save_name}_answers.csv"
+            )
+
+            if answers_csv.exists() and not settings.OVERWRITE:
+                pbar.set_description(f"Loading comprehension answers {idf}")
                 sess.answers = True
+            else:
+                pbar.set_description(f"Collecting comprehension answers {idf}")
+                question_order_csv = (
+                    sess.session_folder_path / "logfiles" / "question_order_versions.csv"
+                )
+                if question_order_csv.exists():
+                    parsed_answers = None
+                    source = "unknown"
 
-        pbar.set_description(f"Creating sanity check report {idf}")
-        data_collection.create_sanity_check_report(
-            gaze,
-            sess.session_identifier,
-            plotting=True,
-            overwrite=True,
-            output_dir=settings.OUTPUT_DIR,
-        )
+                    # 1. Primary source: ASC messages (prefer if gaze exists)
+                    if gaze is not None and gaze.messages is not None and not gaze.messages.is_empty():
+                        parsed_answers = preprocessing.parse_answers_from_messages(gaze.messages)
+                        if not parsed_answers.is_empty():
+                            source = "asc"
 
-        data_collection.create_session_overview(
-            sess.session_identifier, path=settings.OUTPUT_DIR
-        )
+                    # 2. Fallback source: experiment logfile
+                    if parsed_answers is None or parsed_answers.is_empty():
+                        # We only fallback if we really didn't find anything in ASC
+                        # OR if extraction was disabled and raw data was missing (gaze is None)
+                        parsed_answers = preprocessing.parse_answers_from_logfile(
+                            sess.logfile, sess.stimuli_trial_mapping
+                        )
+                        if not parsed_answers.is_empty():
+                            source = "logfile"
+
+                    preprocessing.collect_session_answers(
+                        question_order_csv=question_order_csv,
+                        stimuli_trial_map=sess.stimuli_trial_mapping,
+                        stimuli=sess.stimuli,
+                        parsed_answers=parsed_answers,
+                        out_path=answers_csv,
+                        source=source,
+                    )
+                    sess.answers = True
+        else:
+            pbar.set_description(f"Skipping comprehension answers {idf}:")
+
+        if settings.RUN_SANITY_CHECKS:
+            if gaze is None:
+                logger.warning(f"Gaze data missing for {idf}. Skipping sanity report.")
+            else:
+                pbar.set_description(f"Creating sanity check report {idf}")
+                data_collection.create_sanity_check_report(
+                    gaze,
+                    sess.session_identifier,
+                    plotting=True,
+                    overwrite=True,
+                    output_dir=settings.OUTPUT_DIR,
+                )
+
+            data_collection.create_session_overview(
+                sess.session_identifier, path=settings.OUTPUT_DIR
+            )
+        else:
+            pbar.set_description(f"Skipping sanity checks {idf}:")
 
     data_collection.create_dataset_overview(path=settings.OUTPUT_DIR)
     data_collection.parse_participant_data(settings.OUTPUT_DIR / "participant_data.csv")

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -323,7 +323,7 @@ def run_preprocessing(config_path: str | None = None):
                 settings.OUTPUT_DIR
                 / settings.ANSWERS_FOLDER
                 / str(sid)
-                / f"{sid.id_no_postfix}_answers.csv"
+                / f"{str(sid)}_answers.csv"
             )
 
             if answers_csv.exists() and not settings.OVERWRITE:

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -107,6 +107,7 @@ def run_preprocessing(config_path: str | None = None):
                 lab_config=sess.lab_config,
                 session_idf=idf,
                 trial_cols=settings.TRIAL_COLS,
+                messages=settings.ANSWER_MSG_PATTERNS,
             )
             preprocessing.save_raw_data(
                 raw_data_folder, session_save_name, gaze, sess.completed_stimuli_ids
@@ -241,6 +242,43 @@ def run_preprocessing(config_path: str | None = None):
                 settings.OUTPUT_DIR, session_save_name, idf, reading_measures
             )
             data_collection[sess.session_identifier].reading_measures = True
+
+        # === COMPREHENSION QUESTION ANSWERS ===
+        answers_csv = (
+            settings.OUTPUT_DIR
+            / settings.ANSWERS_FOLDER
+            / session_save_name
+            / f"{session_save_name}_answers.csv"
+        )
+
+        if answers_csv.exists() and not settings.OVERWRITE:
+            pbar.set_description(f"Loading answers {idf}")
+            sess.answers = True
+        else:
+            pbar.set_description(f"Collecting answers {idf}")
+            question_order_csv = (
+                sess.session_folder_path / "logfiles" / "question_order_versions.csv"
+            )
+            if question_order_csv.exists():
+                parsed_answers = (
+                    preprocessing.parse_answers_from_messages(gaze.messages)
+                    if gaze.messages is not None
+                    else None
+                )
+                if parsed_answers is None or parsed_answers.is_empty():
+                    # Fallback to experiment logfile
+                    parsed_answers = preprocessing.parse_answers_from_logfile(
+                        sess.logfile, sess.stimuli_trial_mapping
+                    )
+
+                preprocessing.collect_session_answers(
+                    question_order_csv=question_order_csv,
+                    stimuli_trial_map=sess.stimuli_trial_mapping,
+                    stimuli=sess.stimuli,
+                    parsed_answers=parsed_answers,
+                    out_path=answers_csv,
+                )
+                sess.answers = True
 
         pbar.set_description(f"Creating sanity check report {idf}")
         data_collection.create_sanity_check_report(

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -10,6 +10,7 @@ import preprocessing
 from preprocessing import settings
 
 from preprocessing.scripts.prepare_language_folder import prepare_language_folder
+import contextlib
 
 
 def run_preprocessing(config_path: str | None = None):
@@ -222,10 +223,8 @@ def run_preprocessing(config_path: str | None = None):
                 # Unnest event columns (e.g. location struct -> location_x/location_y)
                 # so downstream code doesn't need to handle struct columns.
                 if gaze is not None and gaze.events is not None:
-                    try:
+                    with contextlib.suppress(Warning):
                         gaze.events.unnest()
-                    except Warning:
-                        pass
         else:
             pbar.set_description(f"Skipping event detection {idf}:")
             # Load existing if available

--- a/preprocessing/utils/data_path_utils.py
+++ b/preprocessing/utils/data_path_utils.py
@@ -56,7 +56,7 @@ def validate_psychometric_data(
             participant_issues.append(msg)
             config_sid = None
 
-        with open(config_file, "r") as f:
+        with open(config_file) as f:
             try:
                 config_data = yaml.safe_load(f)
             except yaml.YAMLError as exc:

--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -211,10 +211,7 @@ def setup_logging(
 
         def filter(self, record: logging.LogRecord) -> bool:
             msg = record.getMessage()
-            for pattern in self.patterns:
-                if pattern.search(msg):
-                    return False
-            return True
+            return all(not pattern.search(msg) for pattern in self.patterns)
 
     if hasattr(settings, "IGNORED_LOG_REGEXES") and settings.IGNORED_LOG_REGEXES:
         regex_filter = RegexFilter(settings.IGNORED_LOG_REGEXES)

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -73,6 +73,18 @@ acceptable_num_trials: 10
 # --- EYE TRACKER LABELS (do not change) ---
 tracked_eye: ["L", "R", "RIGHT", "LEFT"]
 
+# --- PIPELINE STAGES ---
+# Whether to perform fixation detection.
+RUN_FIXATION_DETECTION: true
+# Whether to perform saccade detection.
+RUN_SACCADE_DETECTION: true
+# Whether to perform reading measures calculation.
+RUN_READING_MEASURES: true
+# Whether to collect comprehension question answers.
+RUN_COMPREHENSION_ANSWERS: true
+# Whether to create sanity check reports.
+RUN_SANITY_CHECKS: true
+
 # --- INTERNAL (do not change) ---
 raw_data_folder: "raw_data/"
 fixations_folder: "fixations/"

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -81,6 +81,7 @@ scanpaths_folder: "scanpaths/"
 reading_measures_folder: "reading_measures/"
 sanity_checks_folder: "sanity_checks/"
 metadata_folder: "metadata/"
+answers_folder: "comp_answers/"
 trial_cols: ["trial", "stimulus", "page"]
 trial_col: "trial"
 page_col: "page"

--- a/tests/test_multipleye_data_collection.py
+++ b/tests/test_multipleye_data_collection.py
@@ -3,7 +3,7 @@ import pytest
 from pathlib import Path
 
 from preprocessing.data_collection import MultipleyeDataCollection
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 
 
 @pytest.mark.skip(reason="Not complete")
@@ -68,11 +68,10 @@ def data_collection():
 
 @patch("multipleye_data_collection.load_data")
 @patch("multipleye_data_collection.preprocess")
-@patch("builtins.open", new_callable=mock_open)
 @patch("pickle.dump")
 @pytest.mark.skip(reason="Not complete")
 def test_create_gaze_frame(
-    mock_pickle, mock_open_file, mock_preprocess, mock_load_data, data_collection
+    mock_pickle, mock_preprocess, mock_load_data, data_collection
 ):
     mock_gaze = MagicMock()
     mock_load_data.return_value = mock_gaze

--- a/tests/unit/data_collection/test_edf2asc_conversion.py
+++ b/tests/unit/data_collection/test_edf2asc_conversion.py
@@ -71,9 +71,7 @@ def test_convert_edf_to_asc_conversion_logic(
         path_str = str(self_path)
         if path_str == str(expected_asc_path):
             return asc_exists
-        if path_str.endswith(".asc") and not path_str.startswith("/fake/output"):
-            return True  # local asc after conversion exists
-        return False
+        return path_str.endswith(".asc") and not path_str.startswith("/fake/output")
 
     with patch(
         "preprocessing.data_collection.multipleye_data_collection.settings"
@@ -157,9 +155,7 @@ def test_convert_edf_to_asc_postfix_identifier():
         path_str = str(self_path)
         if path_str == str(expected_asc_path):
             return False  # output asc missing, trigger conversion
-        if path_str.endswith(".asc"):
-            return True  # local asc exists after conversion
-        return False
+        return path_str.endswith(".asc")
 
     with patch(
         "preprocessing.data_collection.multipleye_data_collection.settings"

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from preprocessing.answers.collect import collect_session_answers
+
+
+@pytest.mark.parametrize(
+    "stimulus_name,pisa_middle",
+    [
+        ("Arg_PISACowsMilk_10", "2"),
+        ("Lit_Solaris_7", "1"),
+    ],
+)
+def test_collect_session_answers_builds_rows_and_ids(tmp_path: Path, stimulus_name, pisa_middle):
+    # Prepare a minimal question_order_versions.csv with one trial
+    csv = (
+        "question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+        "6,12,11,21,22,32,31\n"
+    )
+    qcsv = tmp_path / "question_order_versions.csv"
+    qcsv.write_text(csv)
+
+    # Provide stimuli mapping for trial 1
+    mapping = {"trial_1": stimulus_name}
+
+    out_path = tmp_path / "answers.csv"
+    df = collect_session_answers(qcsv, mapping, out_path=out_path)
+
+    # Expect 6 rows (six question slots) for the one trial
+    assert df.shape[0] == 6
+    assert set(df["trial"].to_list()) == {"trial_1"}
+    assert set(df["stimulus"].to_list()) == {stimulus_name}
+
+    # Check order codes covered and IDs well-formed
+    codes = set(df["order_code"].to_list())
+    assert codes == {12, 11, 21, 22, 32, 31}
+
+    # Verify question_id format: <stim_num><middle><order_code>
+    stim_num = stimulus_name.split("_")[-1]
+    for row in df.iter_rows(named=True):
+        oc = int(row["order_code"])
+        assert row["question_id"].startswith(stim_num + pisa_middle)
+        assert row["question_id"].endswith(str(oc))
+
+    # File written and loadable
+    assert out_path.exists()
+    loaded = pl.read_csv(out_path)
+    assert loaded.shape == df.shape

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -100,16 +100,19 @@ def test_collect_enrichment_multidigit_qid(mock_question_csv):
     assert q11[0, "answer_text"] is None
 
 
+def _expected_middle(stimulus_name: str, order_code: int) -> str:
+    """Compute the expected middle digit for a stimulus and order_code."""
+    return str(order_code)[1] if "PISA" in stimulus_name else "1"
+
+
 @pytest.mark.parametrize(
-    "stimulus_name,pisa_middle",
+    "stimulus_name",
     [
-        ("Arg_PISACowsMilk_10", "2"),
-        ("Lit_Solaris_7", "1"),
+        "Arg_PISACowsMilk_10",
+        "Lit_Solaris_7",
     ],
 )
-def test_collect_session_answers_builds_rows_and_ids(
-    tmp_path: Path, stimulus_name, pisa_middle
-):
+def test_collect_session_answers_builds_rows_and_ids(tmp_path: Path, stimulus_name):
     # Prepare a minimal question_order_versions.csv with one trial
     csv = (
         "question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
@@ -137,7 +140,10 @@ def test_collect_session_answers_builds_rows_and_ids(
     stim_num = stimulus_name.split("_")[-1]
     for row in df.iter_rows(named=True):
         oc = int(row["order_code"])
-        assert row["question_id"].startswith(stim_num + pisa_middle)
+        middle = _expected_middle(stimulus_name, oc)
+        assert row["question_id"].startswith(stim_num + middle), (
+            f"Expected {stim_num}{middle}{oc}, got {row['question_id']}"
+        )
         assert row["question_id"].endswith(str(oc))
 
     # File written and loadable

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -223,19 +223,15 @@ def test_collect_multisnippet_snippet_number(tmp_path):
     )
 
     # Check snippet_numbers and question_ids
-    # local_question_1 (order_code 11) -> qid 10111 -> snippet 1
-    q11 = df.filter(pl.col("order_code") == 11).row(0, named=True)
+    q11 = df.filter(pl.col("question_id") == "10111").row(0, named=True)
     assert q11["snippet_number"] == 1
     assert q11["question_id"] == "10111"
-    # local_question_2 (order_code 12) -> qid 10212 -> snippet 2
-    q12 = df.filter(pl.col("order_code") == 12).row(0, named=True)
+    q12 = df.filter(pl.col("question_id") == "10212").row(0, named=True)
     assert q12["snippet_number"] == 2
     assert q12["question_id"] == "10212"
-    # bridging_question_2 (order_code 22) -> qid 10222 -> snippet 2
-    q22 = df.filter(pl.col("order_code") == 22).row(0, named=True)
+    q22 = df.filter(pl.col("question_id") == "10222").row(0, named=True)
     assert q22["snippet_number"] == 2
     assert q22["question_id"] == "10222"
-    # global_question_1 (order_code 31) -> qid 10131 -> snippet 1
-    q31 = df.filter(pl.col("order_code") == 31).row(0, named=True)
+    q31 = df.filter(pl.col("question_id") == "10131").row(0, named=True)
     assert q31["snippet_number"] == 1
     assert q31["question_id"] == "10131"

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -68,14 +68,23 @@ def test_collect_enrichment_simple_qid(mock_question_csv):
     )
 
     assert len(df) == 6
-    # Question with order_code=11 -> question_id=6111
-    q11 = df.filter(pl.col("order_code") == 11)
+    # Question with order_code (was 11) -> condition_number=1 -> question_id=6111
+    q11 = df.filter(pl.col("condition_number") == 1).filter(
+        pl.col("question_id") == "6111"
+    )
+    assert q11[0, "stimulus_id"] == 6
     assert q11[0, "correct_answer_key"] == "target_key"
     assert q11[0, "correct_answer_text"] == "Correct Answer"
-    # q12 has the same target
-    q12 = df.filter(pl.col("order_code") == 12)
+    assert q11[0, "question_id"] == "6111"
+    assert q11[0, "snippet_number"] == 1
+    assert q11[0, "condition_number"] == 1
+    # q12 (also condition_number=1) has the same target
+    q12 = df.filter(pl.col("condition_number") == 1).filter(
+        pl.col("question_id") == "6112"
+    )
     assert q12[0, "correct_answer_key"] == "target_key"
     assert q12[0, "correct_answer_text"] == "Correct Answer"
+    assert q12[0, "question_id"] == "6112"
 
 
 def test_collect_enrichment_multidigit_qid(mock_question_csv):
@@ -92,10 +101,16 @@ def test_collect_enrichment_multidigit_qid(mock_question_csv):
     )
 
     assert len(df) == 6
-    # Multi-digit '04111' -> last 2 chars '11' -> order_code=11 -> question_id=4111
-    q11 = df.filter(pl.col("order_code") == 11)
+    # Multi-digit '04111' -> last 2 chars '11' -> condition_number=1 -> question_id=4111
+    q11 = df.filter(pl.col("condition_number") == 1).filter(
+        pl.col("question_id") == "4111"
+    )
+    assert q11[0, "stimulus_id"] == 4
     assert q11[0, "correct_answer_key"] == "target_key"
     assert q11[0, "correct_answer_text"] == "Correct Answer"
+    assert q11[0, "question_id"] == "4111"
+    assert q11[0, "snippet_number"] == 1
+    assert q11[0, "condition_number"] == 1
     # answer_text should be null (no parsed_answers provided)
     assert q11[0, "answer_text"] is None
 
@@ -123,28 +138,33 @@ def test_collect_session_answers_builds_rows_and_ids(tmp_path: Path, stimulus_na
 
     # Provide stimuli mapping for trial 1
     mapping = {"trial_1": stimulus_name}
+    stim_id = int(stimulus_name.split("_")[-1])
 
     out_path = tmp_path / "answers.csv"
-    df = collect_session_answers(qcsv, mapping, out_path=out_path)
+    df = collect_session_answers(
+        qcsv, mapping, out_path=out_path, completed_stimuli_ids=[stim_id]
+    )
 
     # Expect 6 rows (six question slots) for the one trial
     assert df.shape[0] == 6
     assert set(df["trial"].to_list()) == {"trial_1"}
     assert set(df["stimulus"].to_list()) == {stimulus_name}
+    assert set(df["stimulus_id"].to_list()) == {stim_id}
 
-    # Check order codes covered and IDs well-formed
-    codes = set(df["order_code"].to_list())
-    assert codes == {12, 11, 21, 22, 32, 31}
+    # Check condition codes covered and IDs well-formed
+    conditions = set(df["condition_number"].to_list())
+    assert conditions == {1, 2, 3}
 
-    # Verify question_id format: <stim_num><middle><order_code>
+    # Verify question_id format: <stim_num>1<order_code>
     stim_num = stimulus_name.split("_")[-1]
+    expected_codes = {12, 11, 21, 22, 32, 31}
+    found_qids = set(df["question_id"].to_list())
+    expected_qids = {f"{stim_num}1{code}" for code in expected_codes}
+    assert found_qids == expected_qids
+
     for row in df.iter_rows(named=True):
-        oc = int(row["order_code"])
-        middle = _expected_middle(stimulus_name, oc)
-        assert row["question_id"].startswith(stim_num + middle), (
-            f"Expected {stim_num}{middle}{oc}, got {row['question_id']}"
-        )
-        assert row["question_id"].endswith(str(oc))
+        assert row["snippet_number"] == 1
+        assert row["condition_number"] in {1, 2, 3}
 
     # File written and loadable
     assert out_path.exists()

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -24,12 +24,14 @@ def _make_stimulus(
     name: str,
     trial_id: str,
     q_ids: list[str],
+    snippet_no: int = 1,
 ) -> list[Stimulus]:
     questions = []
     for i, qid in enumerate(q_ids, start=1):
         q = ComprehensionQuestion(
             name=f"{name}_{stim_id}_{qid}",
             id=qid,
+            snippet_no=snippet_no,
             question=f"Question {i}",
             target="Correct Answer",
             distractor_a="Wrong A",
@@ -155,10 +157,12 @@ def test_collect_session_answers_builds_rows_and_ids(tmp_path: Path, stimulus_na
     conditions = set(df["condition_number"].to_list())
     assert conditions == {1, 2, 3}
 
-    # Verify question_id format: <stim_num>1<order_code>
+    # Verify question_id format: <stim_num><snippet><order_code>
     stim_num = stimulus_name.split("_")[-1]
     expected_codes = {12, 11, 21, 22, 32, 31}
     found_qids = set(df["question_id"].to_list())
+    # All these mock examples use snippet_number 1 since no stimuli data was passed to collect_session_answers
+    # (except when stimuli is passed, which it isn't here)
     expected_qids = {f"{stim_num}1{code}" for code in expected_codes}
     assert found_qids == expected_qids
 
@@ -170,3 +174,68 @@ def test_collect_session_answers_builds_rows_and_ids(tmp_path: Path, stimulus_na
     assert out_path.exists()
     loaded = pl.read_csv(out_path)
     assert loaded.shape == df.shape
+
+
+def test_collect_multisnippet_snippet_number(tmp_path):
+    """Verify that snippet_number is correctly looked up from stimulus data (not always 1)."""
+    qcsv = tmp_path / "question_order_versions.csv"
+    # Stimulus 10 (multi-snippet), snippet 2 for some questions
+    qcsv.write_text(
+        "question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+        "10,11,12,21,22,31,32\n"
+    )
+    mapping = {"trial_1": "Arg_PISACowsMilk_10"}
+
+    # Mock questions: some snippet 1, some snippet 2
+    # In reality, snippet_no is per question in the Excel.
+    # We'll simulate this by creating a Stimulus with questions having snippet_no=2.
+    qs = [
+        ComprehensionQuestion(
+            name=f"Arg_PISACowsMilk_10_{qid}",
+            id=qid,
+            snippet_no=2 if qid.endswith("2") else 1,
+            question="Q",
+            target="Correct",
+            distractor_a="A",
+            distractor_b="B",
+            distractor_c="C",
+            image_path=Path("img.png"),
+            aoi_image_path=Path("aoi.png"),
+        )
+        for qid in ["11", "12", "21", "22", "31", "32"]
+    ]
+    stimuli = [
+        Stimulus(
+            id=10,
+            name="Arg_PISACowsMilk_10",
+            type="experiment",
+            pages=[],
+            text_stimulus=None,
+            questions=qs,
+            instructions=[],
+            ratings=[],
+            trial_id="trial_1",
+        )
+    ]
+
+    df = collect_session_answers(
+        qcsv, mapping, stimuli=stimuli, completed_stimuli_ids=[10]
+    )
+
+    # Check snippet_numbers and question_ids
+    # local_question_1 (order_code 11) -> qid 10111 -> snippet 1
+    q11 = df.filter(pl.col("order_code") == 11).row(0, named=True)
+    assert q11["snippet_number"] == 1
+    assert q11["question_id"] == "10111"
+    # local_question_2 (order_code 12) -> qid 10212 -> snippet 2
+    q12 = df.filter(pl.col("order_code") == 12).row(0, named=True)
+    assert q12["snippet_number"] == 2
+    assert q12["question_id"] == "10212"
+    # bridging_question_2 (order_code 22) -> qid 10222 -> snippet 2
+    q22 = df.filter(pl.col("order_code") == 22).row(0, named=True)
+    assert q22["snippet_number"] == 2
+    assert q22["question_id"] == "10222"
+    # global_question_1 (order_code 31) -> qid 10131 -> snippet 1
+    q31 = df.filter(pl.col("order_code") == 31).row(0, named=True)
+    assert q31["snippet_number"] == 1
+    assert q31["question_id"] == "10131"

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -13,7 +13,9 @@ from preprocessing.answers.collect import collect_session_answers
         ("Lit_Solaris_7", "1"),
     ],
 )
-def test_collect_session_answers_builds_rows_and_ids(tmp_path: Path, stimulus_name, pisa_middle):
+def test_collect_session_answers_builds_rows_and_ids(
+    tmp_path: Path, stimulus_name, pisa_middle
+):
     # Prepare a minimal question_order_versions.csv with one trial
     csv = (
         "question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -4,6 +4,100 @@ import polars as pl
 import pytest
 
 from preprocessing.answers.collect import collect_session_answers
+from preprocessing.data_collection.stimulus import Stimulus, ComprehensionQuestion
+
+
+@pytest.fixture
+def mock_question_csv(tmp_path):
+    csv = (
+        "question_order_version,local_question_1,local_question_2,"
+        "bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+        "6,11,12,21,22,31,32\n"
+    )
+    p = tmp_path / "question_order_versions.csv"
+    p.write_text(csv)
+    return p
+
+
+def _make_stimulus(
+    stim_id: int,
+    name: str,
+    trial_id: str,
+    q_ids: list[str],
+) -> list[Stimulus]:
+    questions = []
+    for i, qid in enumerate(q_ids, start=1):
+        q = ComprehensionQuestion(
+            name=f"{name}_{stim_id}_{qid}",
+            id=qid,
+            question=f"Question {i}",
+            target="Correct Answer",
+            distractor_a="Wrong A",
+            distractor_b="Wrong B",
+            distractor_c="Wrong C",
+            image_path=Path("img.png"),
+            aoi_image_path=Path("aoi.png"),
+        )
+        questions.append(q)
+    return [
+        Stimulus(
+            id=stim_id,
+            name=name,
+            type="experiment",
+            pages=[],
+            text_stimulus=None,
+            questions=questions,
+            instructions=[],
+            ratings=[],
+            trial_id=trial_id,
+        )
+    ]
+
+
+def test_collect_enrichment_simple_qid(mock_question_csv):
+    """Enrichment works with 2-digit q.id (toy data format)."""
+    stimuli = _make_stimulus(
+        stim_id=6,
+        name="Lit_MagicMountain_6",
+        trial_id="trial_1",
+        q_ids=["11", "12"],
+    )
+    mapping = {"trial_1": "Lit_MagicMountain_6"}
+    df = collect_session_answers(
+        mock_question_csv, mapping, stimuli=stimuli, completed_stimuli_ids=[6]
+    )
+
+    assert len(df) == 6
+    # Question with order_code=11 -> question_id=6111
+    q11 = df.filter(pl.col("order_code") == 11)
+    assert q11[0, "correct_answer_key"] == "target_key"
+    assert q11[0, "correct_answer_text"] == "Correct Answer"
+    # q12 has the same target
+    q12 = df.filter(pl.col("order_code") == 12)
+    assert q12[0, "correct_answer_key"] == "target_key"
+    assert q12[0, "correct_answer_text"] == "Correct Answer"
+
+
+def test_collect_enrichment_multidigit_qid(mock_question_csv):
+    """Enrichment works with multi-digit q.id like '04111' (real data format)."""
+    stimuli = _make_stimulus(
+        stim_id=4,
+        name="Lit_Alchemist_4",
+        trial_id="trial_1",
+        q_ids=["04111", "04112"],
+    )
+    mapping = {"trial_1": "Lit_Alchemist_4"}
+    df = collect_session_answers(
+        mock_question_csv, mapping, stimuli=stimuli, completed_stimuli_ids=[4]
+    )
+
+    assert len(df) == 6
+    # Multi-digit '04111' -> last 2 chars '11' -> order_code=11 -> question_id=4111
+    q11 = df.filter(pl.col("order_code") == 11)
+    assert q11[0, "correct_answer_key"] == "target_key"
+    assert q11[0, "correct_answer_text"] == "Correct Answer"
+    # answer_text should be null (no parsed_answers provided)
+    assert q11[0, "answer_text"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -20,6 +20,7 @@ def mock_stimuli():
     q1 = ComprehensionQuestion(
         name="Lit_MagicMountain_6_11",
         id="11",
+        snippet_no=1,
         question="Q1",
         target="Correct Text 1",
         distractor_a="Wrong 1",
@@ -183,6 +184,7 @@ def test_multidigit_qid_enrichment(tmp_path):
         ComprehensionQuestion(
             name=f"Lit_Alchemist_4_0411{i}",
             id=f"0411{i}",
+            snippet_no=1,
             question=f"Q{i}",
             target="Correct",
             distractor_a=f"WrongA{i}",
@@ -253,6 +255,7 @@ def twoq_stimuli():
         ComprehensionQuestion(
             name=f"Stim_6_{qid}",
             id=qid,
+            snippet_no=1,
             question=f"Q{i}",
             target="Correct A" if i == 1 else "Correct B",
             distractor_a="Wrong A1" if i == 1 else "Wrong A2",
@@ -548,6 +551,7 @@ def test_practice_trial_answers(tmp_path):
     q1 = ComprehensionQuestion(
         name="Enc_WikiMoon_13_11",
         id="11",
+        snippet_no=1,
         question="Q",
         target="Correct",
         distractor_a="A",

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -1,0 +1,80 @@
+import polars as pl
+import pytest
+from pathlib import Path
+from preprocessing.answers.collect import collect_session_answers
+from preprocessing.answers.msg_parser import parse_answers_from_messages
+from preprocessing.data_collection.stimulus import Stimulus, ComprehensionQuestion
+
+
+@pytest.fixture
+def mock_question_order_csv(tmp_path):
+    csv_path = tmp_path / "question_order_versions.csv"
+    content = "question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+    content += "6,11,12,21,22,31,32\n"
+    csv_path.write_text(content)
+    return csv_path
+
+
+@pytest.fixture
+def mock_stimuli():
+    # Looking at preprocessing/data_collection/stimulus.py:
+    # ComprehensionQuestion has fields: name, id, question, target, distractor_a, distractor_b, distractor_c, image_path, aoi_image_path
+    q1 = ComprehensionQuestion(
+        name="Lit_MagicMountain_6_11",
+        id="11",
+        question="Q1",
+        target="Correct Text 1",
+        distractor_a="Wrong 1",
+        distractor_b="Wrong 2",
+        distractor_c="Wrong 3",
+        image_path=Path("fake_img.png"),
+        aoi_image_path=Path("fake_aoi.png"),
+    )
+    stim1 = Stimulus(
+        id=6,
+        name="Lit_MagicMountain_6",
+        type="experiment",
+        pages=[],
+        text_stimulus=None,
+        questions=[q1],
+        instructions=[],
+        ratings=[],
+        trial_id="trial_1",
+    )
+    return [stim1]
+
+
+def test_collect_session_answers_integration(mock_question_order_csv, mock_stimuli):
+    stimuli_trial_mapping = {"trial_1": "Lit_MagicMountain_6"}
+
+    # Synthetic messages
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 3000],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_target_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_final_confirmation",
+            ],
+        }
+    )
+
+    parsed_answers = parse_answers_from_messages(messages)
+
+    result = collect_session_answers(
+        question_order_csv=mock_question_order_csv,
+        stimuli_trial_map=stimuli_trial_mapping,
+        stimuli=mock_stimuli,
+        parsed_answers=parsed_answers,
+    )
+
+    # Check that it merged correctly
+    # 6 questions per trial (as per mock_question_order_csv)
+    assert len(result) == 6
+
+    # Check the one we have answers for
+    q11 = result.filter(pl.col("question_id") == "6111")
+    assert len(q11) == 1
+    assert q11[0, "final_rt_ms"] == 2000.0  # 3000 - 1000
+    assert q11[0, "correct_answer_text"] == "Correct Text 1"
+    assert q11[0, "answer_changed"] is False

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -17,8 +17,6 @@ def mock_question_order_csv(tmp_path):
 
 @pytest.fixture
 def mock_stimuli():
-    # Looking at preprocessing/data_collection/stimulus.py:
-    # ComprehensionQuestion has fields: name, id, question, target, distractor_a, distractor_b, distractor_c, image_path, aoi_image_path
     q1 = ComprehensionQuestion(
         name="Lit_MagicMountain_6_11",
         id="11",
@@ -78,3 +76,105 @@ def test_collect_session_answers_integration(mock_question_order_csv, mock_stimu
     assert q11[0, "final_rt_ms"] == 2000.0  # 3000 - 1000
     assert q11[0, "correct_answer_text"] == "Correct Text 1"
     assert q11[0, "answer_changed"] is False
+
+
+def test_multidigit_qid_enrichment(tmp_path):
+    """Enrichment works when ComprehensionQuestion.id has multi-digit format like '04111'."""
+    qcsv = tmp_path / "question_order_versions.csv"
+    qcsv.write_text(
+        "question_order_version,local_question_1,local_question_2,"
+        "bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+        "1,11,12,21,22,31,32\n"
+    )
+    out_path = tmp_path / "answers.csv"
+    mapping = {"trial_1": "Lit_Alchemist_4"}
+
+    # Use multi-digit q.id as seen in real MultiplEYE data (item_id like "Lit_Alchemist_4_04111")
+    qs = [
+        ComprehensionQuestion(
+            name=f"Lit_Alchemist_4_0411{i}",
+            id=f"0411{i}",
+            question=f"Q{i}",
+            target="Correct",
+            distractor_a=f"WrongA{i}",
+            distractor_b=f"WrongB{i}",
+            distractor_c=f"WrongC{i}",
+            image_path=Path("img.png"),
+            aoi_image_path=Path("aoi.png"),
+        )
+        for i in range(1, 3)  # q.id = "04111", "04112"
+    ]
+    stimuli = [
+        Stimulus(
+            id=4,
+            name="Lit_Alchemist_4",
+            type="experiment",
+            pages=[],
+            text_stimulus=None,
+            questions=qs,
+            instructions=[],
+            ratings=[],
+            trial_id="trial_1",
+        )
+    ]
+
+    result = collect_session_answers(
+        qcsv, mapping, stimuli=stimuli, out_path=out_path, completed_stimuli_ids=[4]
+    )
+
+    assert len(result) == 6
+    # order_code=11 -> last 2 chars of "04111" = "11" -> question_id = 4111
+    q11 = result.filter(pl.col("order_code") == 11)
+    assert q11[0, "question_id"] == "4111"
+    assert q11[0, "correct_answer_key"] == "target_key"
+    assert q11[0, "correct_answer_text"] == "Correct"
+    # order_code=12 -> last 2 chars of "04112" = "12" -> question_id = 4112
+    q12 = result.filter(pl.col("order_code") == 12)
+    assert q12[0, "question_id"] == "4112"
+    assert q12[0, "correct_answer_key"] == "target_key"
+    assert q12[0, "correct_answer_text"] == "Correct"
+
+
+def test_practice_trial_answers(tmp_path):
+    """Practice trials are handled correctly with PRACTICE_trial naming."""
+    qcsv = tmp_path / "question_order_versions.csv"
+    qcsv.write_text(
+        "question_order_version,local_question_1,local_question_2,"
+        "bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+        "1,11,12,21,22,31,32\n"
+    )
+    out_path = tmp_path / "answers.csv"
+    mapping = {"PRACTICE_trial_1": "Enc_WikiMoon"}
+    q1 = ComprehensionQuestion(
+        name="Enc_WikiMoon_13_11",
+        id="11",
+        question="Q",
+        target="Correct",
+        distractor_a="A",
+        distractor_b="B",
+        distractor_c="C",
+        image_path=Path("img.png"),
+        aoi_image_path=Path("aoi.png"),
+    )
+    stimuli = [
+        Stimulus(
+            id=13,
+            name="Enc_WikiMoon",
+            type="practice",
+            pages=[],
+            text_stimulus=None,
+            questions=[q1],
+            instructions=[],
+            ratings=[],
+            trial_id="PRACTICE_trial_1",
+        )
+    ]
+    result = collect_session_answers(
+        qcsv, mapping, stimuli=stimuli, out_path=out_path, completed_stimuli_ids=[13]
+    )
+
+    assert len(result) == 6
+    assert result[0, "trial"] == "PRACTICE_trial_1"
+    assert result[0, "stimulus"] == "Enc_WikiMoon"
+    q11 = result.filter(pl.col("order_code") == 11)
+    assert q11[0, "correct_answer_text"] == "Correct"

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -453,7 +453,6 @@ class TestOutputColumns:
         [
             ("trial_1", "trial_1"),
             ("trial_7", "trial_7"),
-            ("PRACTICE_trial_1", "PRACTICE_trial_1"),
             (1, "trial_1"),
             (7, "trial_7"),
         ],
@@ -462,6 +461,26 @@ class TestOutputColumns:
         mapping = {trial_key: "Stim"}
         df = collect_session_answers(qcsv, mapping)
         assert df[0, "trial"] == expected_trial
+
+    def test_trial_column_naming_practice(self, qcsv):
+        """Practice trial naming requires answer data (unanswered practice rows are dropped)."""
+        msgs = _make_messages(
+            trial="PRACTICE_trial_1",
+            stim_name="Stim",
+            stim_id="1",
+            question_id="1111",
+            prelim_keys=[(2000, "target_key")],
+            final_key=(2600, "target_key"),
+            correct=True,
+        )
+        parsed = parse_answers_from_messages(msgs)
+        df = collect_session_answers(
+            qcsv,
+            {"PRACTICE_trial_1": "Stim"},
+            parsed_answers=parsed,
+            completed_stimuli_ids=[1],
+        )
+        assert df[0, "trial"] == "PRACTICE_trial_1"
 
     # --- stimulus naming ---
 
@@ -516,8 +535,5 @@ def test_practice_trial_answers(tmp_path):
         qcsv, mapping, stimuli=stimuli, out_path=out_path, completed_stimuli_ids=[13]
     )
 
-    assert len(result) == 6
-    assert result[0, "trial"] == "PRACTICE_trial_1"
-    assert result[0, "stimulus"] == "Enc_WikiMoon"
-    q11 = result.filter(pl.col("order_code") == 11)
-    assert q11[0, "correct_answer_text"] == "Correct"
+    assert result.is_empty()  # unanswered practice rows are dropped
+    assert out_path.read_text().strip().endswith("answer_source")  # header only

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -64,6 +64,7 @@ def test_collect_session_answers_integration(mock_question_order_csv, mock_stimu
         stimuli_trial_map=stimuli_trial_mapping,
         stimuli=mock_stimuli,
         parsed_answers=parsed_answers,
+        completed_stimuli_ids=[6],
     )
 
     # Check that it merged correctly
@@ -72,8 +73,12 @@ def test_collect_session_answers_integration(mock_question_order_csv, mock_stimu
 
     # Check the one we have answers for
     q11 = result.filter(pl.col("question_id") == "6111").row(0, named=True)
+    assert q11["stimulus_id"] == 6
     assert q11["confirmation_rt_ms"] == 2000.0  # 3000 - 1000
     assert q11["correct_answer_text"] == "Correct Text 1"
+    assert q11["snippet_number"] == 1
+    assert q11["condition_number"] == 1
+    assert q11["order_code"] == 11
 
 
 def test_decision_rt_from_last_prelim_key(mock_question_order_csv, mock_stimuli):
@@ -208,15 +213,22 @@ def test_multidigit_qid_enrichment(tmp_path):
 
     assert len(result) == 6
     # order_code=11 -> last 2 chars of "04111" = "11" -> question_id = 4111
-    q11 = result.filter(pl.col("order_code") == 11)
+    q11 = result.filter(pl.col("condition_number") == 1).filter(
+        pl.col("question_id") == "4111"
+    )
+    assert q11[0, "stimulus_id"] == 4
     assert q11[0, "question_id"] == "4111"
     assert q11[0, "correct_answer_key"] == "target_key"
     assert q11[0, "correct_answer_text"] == "Correct"
+    assert q11[0, "condition_number"] == 1
     # order_code=12 -> last 2 chars of "04112" = "12" -> question_id = 4112
-    q12 = result.filter(pl.col("order_code") == 12)
+    q12 = result.filter(pl.col("condition_number") == 1).filter(
+        pl.col("question_id") == "4112"
+    )
     assert q12[0, "question_id"] == "4112"
     assert q12[0, "correct_answer_key"] == "target_key"
     assert q12[0, "correct_answer_text"] == "Correct"
+    assert q12[0, "condition_number"] == 1
 
 
 # Fixtures
@@ -249,7 +261,7 @@ def twoq_stimuli():
             image_path=Path("img.png"),
             aoi_image_path=Path("aoi.png"),
         )
-        for i, qid in enumerate(["11", "12"], start=1)
+        for i, qid in enumerate(["11", "21"], start=1)
     ]
     return [
         Stimulus(
@@ -338,20 +350,21 @@ class TestOutputColumns:
     # --- order_code ---
 
     @pytest.mark.parametrize(
-        "slot_name,expected_code",
+        "slot_name,expected_condition",
         [
-            ("local_question_1", 11),
-            ("local_question_2", 12),
-            ("bridging_question_1", 21),
-            ("bridging_question_2", 22),
-            ("global_question_1", 31),
-            ("global_question_2", 32),
+            ("local_question_1", 1),
+            ("local_question_2", 1),
+            ("bridging_question_1", 2),
+            ("bridging_question_2", 2),
+            ("global_question_1", 3),
+            ("global_question_2", 3),
         ],
     )
-    def test_order_code_by_slot(self, qcsv, slot_name, expected_code):
+    def test_condition_number_by_slot(self, qcsv, slot_name, expected_condition):
         df = collect_session_answers(qcsv, {"trial_1": "Stim"})
         row = df.filter(pl.col("slot") == slot_name).row(0, named=True)
-        assert row["order_code"] == expected_code
+        assert row["condition_number"] == expected_condition
+        assert row["order_code"] is not None
 
     # --- answer_source ---
 
@@ -361,6 +374,7 @@ class TestOutputColumns:
             prelim_keys=[(2000, "target_key")],
             final_key=(2600, "target_key"),
             correct=True,
+            question_id="6111",
         )
         parsed = parse_answers_from_messages(msgs)
         df = collect_session_answers(
@@ -371,7 +385,11 @@ class TestOutputColumns:
             source=source,
             completed_stimuli_ids=[6],
         )
-        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        q11 = (
+            df.filter(pl.col("condition_number") == 1)
+            .filter(pl.col("question_id") == "6111")
+            .row(0, named=True)
+        )
         assert q11["answer_source"] == source
 
     # --- answer_text ---
@@ -390,6 +408,7 @@ class TestOutputColumns:
             prelim_keys=[(2000, key)],
             final_key=(2600, key),
             correct=(key == "target_key"),
+            question_id="6111",
         )
         parsed = parse_answers_from_messages(msgs)
         df = collect_session_answers(
@@ -399,7 +418,11 @@ class TestOutputColumns:
             parsed_answers=parsed,
             completed_stimuli_ids=[6],
         )
-        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        q11 = (
+            df.filter(pl.col("condition_number") == 1)
+            .filter(pl.col("question_id") == "6111")
+            .row(0, named=True)
+        )
         assert q11["answer_text"] == expected_text
 
     def test_answer_text_null_for_space(self, qcsv, twoq_stimuli):
@@ -407,6 +430,7 @@ class TestOutputColumns:
         msgs = _make_messages(
             confirm_ts=2000,
             correct=False,
+            question_id="6111",
         )
         parsed = parse_answers_from_messages(msgs)
         df = collect_session_answers(
@@ -416,7 +440,11 @@ class TestOutputColumns:
             parsed_answers=parsed,
             completed_stimuli_ids=[6],
         )
-        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        q11 = (
+            df.filter(pl.col("condition_number") == 1)
+            .filter(pl.col("question_id") == "6111")
+            .row(0, named=True)
+        )
         assert q11["answer_text"] is None
 
     # --- is_correct ---
@@ -426,7 +454,7 @@ class TestOutputColumns:
         [
             pytest.param("target_key", True, True, id="correct_answer"),
             pytest.param("distractor_a_key", False, False, id="wrong_answer"),
-            pytest.param("target_key", None, None, id="no_correctness_msg"),
+            pytest.param("target_key", None, True, id="no_correctness_msg"),
         ],
     )
     def test_is_correct_values(self, qcsv, twoq_stimuli, key, correct, expected):
@@ -434,6 +462,7 @@ class TestOutputColumns:
             prelim_keys=[(2000, key)],
             final_key=(2600, key),
             correct=correct,
+            question_id="6111",
         )
         parsed = parse_answers_from_messages(msgs)
         df = collect_session_answers(
@@ -443,7 +472,11 @@ class TestOutputColumns:
             parsed_answers=parsed,
             completed_stimuli_ids=[6],
         )
-        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        q11 = (
+            df.filter(pl.col("condition_number") == 1)
+            .filter(pl.col("question_id") == "6111")
+            .row(0, named=True)
+        )
         assert q11["is_correct"] is expected
 
     # --- trial naming ---
@@ -480,6 +513,7 @@ class TestOutputColumns:
             parsed_answers=parsed,
             completed_stimuli_ids=[1],
         )
+        assert df.height > 0
         assert df[0, "trial"] == "PRACTICE_trial_1"
 
     # --- stimulus naming ---
@@ -493,8 +527,12 @@ class TestOutputColumns:
         ],
     )
     def test_stimulus_column(self, qcsv, stim_name):
-        df = collect_session_answers(qcsv, {"trial_1": stim_name})
+        stim_id = 10 if "PISA" in stim_name else 7 if "Solaris" in stim_name else 13
+        df = collect_session_answers(
+            qcsv, {"trial_1": stim_name}, completed_stimuli_ids=[stim_id]
+        )
         assert df[0, "stimulus"] == stim_name
+        assert df[0, "stimulus_id"] == stim_id
 
 
 def test_practice_trial_answers(tmp_path):

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -71,11 +71,95 @@ def test_collect_session_answers_integration(mock_question_order_csv, mock_stimu
     assert len(result) == 6
 
     # Check the one we have answers for
-    q11 = result.filter(pl.col("question_id") == "6111")
-    assert len(q11) == 1
-    assert q11[0, "final_rt_ms"] == 2000.0  # 3000 - 1000
-    assert q11[0, "correct_answer_text"] == "Correct Text 1"
-    assert q11[0, "answer_changed"] is False
+    q11 = result.filter(pl.col("question_id") == "6111").row(0, named=True)
+    assert q11["confirmation_rt_ms"] == 2000.0  # 3000 - 1000
+    assert q11["correct_answer_text"] == "Correct Text 1"
+
+
+def test_decision_rt_from_last_prelim_key(mock_question_order_csv, mock_stimuli):
+    """preliminary_rt_ms uses the LAST preliminary key, not the first."""
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 2500, 3000, 3500, 3501],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_target_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_distractor_a_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_distractor_b_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_final_confirmation",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_final_answer_given_is_distractor_b_key",
+            ],
+        }
+    )
+    parsed = parse_answers_from_messages(messages)
+    result = collect_session_answers(
+        question_order_csv=mock_question_order_csv,
+        stimuli_trial_map={"trial_1": "Lit_MagicMountain_6"},
+        stimuli=mock_stimuli,
+        parsed_answers=parsed,
+    )
+    q11 = result.filter(pl.col("question_id") == "6111").row(0, named=True)
+    # preliminary_rt_ms = last preliminary key ts (3000) - onset (1000) = 2000
+    assert q11["preliminary_rt_ms"] == 2000.0
+    # confirmation_rt_ms = final_confirmation_ts (3500) - onset (1000) = 2500
+    assert q11["confirmation_rt_ms"] == 2500.0
+    # preliminary_answer_keys lists all keys pressed
+    assert q11["preliminary_answer_keys"] == [
+        "target_key",
+        "distractor_a_key",
+        "distractor_b_key",
+    ]
+
+
+def test_preliminary_answer_onsets(mock_question_order_csv, mock_stimuli):
+    """preliminary_answer_onsets_ms contains onset-relative timestamps."""
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 2500, 3000, 3001],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_target_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_distractor_a_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_final_confirmation",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_final_answer_given_is_distractor_a_key",
+            ],
+        }
+    )
+    parsed = parse_answers_from_messages(messages)
+    result = collect_session_answers(
+        question_order_csv=mock_question_order_csv,
+        stimuli_trial_map={"trial_1": "Lit_MagicMountain_6"},
+        stimuli=mock_stimuli,
+        parsed_answers=parsed,
+    )
+    q11 = result.filter(pl.col("question_id") == "6111").row(0, named=True)
+    assert q11["preliminary_answer_onsets_ms"] == [1000.0, 1500.0]
+
+
+def test_space_answer_no_selection(mock_question_order_csv, mock_stimuli):
+    """Space-only answer (no key selected) gets final_answer_key='space'."""
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 2000],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_final_confirmation",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_answer_given_is_correct:False",
+            ],
+        }
+    )
+    parsed = parse_answers_from_messages(messages)
+    result = collect_session_answers(
+        question_order_csv=mock_question_order_csv,
+        stimuli_trial_map={"trial_1": "Lit_MagicMountain_6"},
+        stimuli=mock_stimuli,
+        parsed_answers=parsed,
+    )
+    q11 = result.filter(pl.col("question_id") == "6111").row(0, named=True)
+    assert q11["final_answer_key"] == "space"
+    assert q11["is_correct"] is False  # experiment records is_correct:False
+    assert q11["confirmation_rt_ms"] == 1000.0  # 2000 - 1000
+    assert q11["preliminary_rt_ms"] is None  # no preliminary keys
 
 
 def test_multidigit_qid_enrichment(tmp_path):
@@ -133,6 +217,265 @@ def test_multidigit_qid_enrichment(tmp_path):
     assert q12[0, "question_id"] == "4112"
     assert q12[0, "correct_answer_key"] == "target_key"
     assert q12[0, "correct_answer_text"] == "Correct"
+
+
+# Fixtures
+
+
+@pytest.fixture
+def qcsv(tmp_path):
+    """Single-trial question order CSV."""
+    p = tmp_path / "question_order_versions.csv"
+    p.write_text(
+        "question_order_version,local_question_1,local_question_2,"
+        "bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"
+        "6,11,12,21,22,31,32\n"
+    )
+    return p
+
+
+@pytest.fixture
+def twoq_stimuli():
+    """Stimulus with two questions (order codes 11, 12) for enrichment tests."""
+    qs = [
+        ComprehensionQuestion(
+            name=f"Stim_6_{qid}",
+            id=qid,
+            question=f"Q{i}",
+            target="Correct A" if i == 1 else "Correct B",
+            distractor_a="Wrong A1" if i == 1 else "Wrong A2",
+            distractor_b="Wrong B1" if i == 1 else "Wrong B2",
+            distractor_c="Wrong C1" if i == 1 else "Wrong C2",
+            image_path=Path("img.png"),
+            aoi_image_path=Path("aoi.png"),
+        )
+        for i, qid in enumerate(["11", "12"], start=1)
+    ]
+    return [
+        Stimulus(
+            id=6,
+            name="TestStim",
+            type="experiment",
+            pages=[],
+            text_stimulus=None,
+            questions=qs,
+            instructions=[],
+            ratings=[],
+            trial_id="trial_1",
+        )
+    ]
+
+
+def _make_messages(
+    trial: str = "trial_1",
+    stim_name: str = "TestStim",
+    stim_id: str = "6",
+    question_id: str = "6111",
+    prelim_keys: list[tuple[int, str]] | None = None,
+    confirm_ts: int | None = 2500,
+    final_key: tuple[int, str] | None = None,
+    correct: bool | None = None,
+) -> pl.DataFrame:
+    """Build a synthetic messages DataFrame for testing."""
+    rows = []
+    rows.append(
+        {
+            "time": 1000,
+            "content": f"start_recording_{trial}_stimulus_{stim_name}_{stim_id}_question_{question_id}",
+        }
+    )
+    if prelim_keys:
+        for ts, key in prelim_keys:
+            rows.append(
+                {
+                    "time": ts,
+                    "content": f"{trial}_stimulus_{stim_name}_{stim_id}_question_{question_id}_preliminary_answer_{key}",
+                }
+            )
+    if confirm_ts is not None:
+        rows.append(
+            {
+                "time": confirm_ts,
+                "content": f"{trial}_stimulus_{stim_name}_{stim_id}_question_{question_id}_preliminary_answer_final_confirmation",
+            }
+        )
+    if final_key is not None:
+        rows.append(
+            {
+                "time": final_key[0],
+                "content": f"{trial}_stimulus_{stim_name}_{stim_id}_question_{question_id}_final_answer_given_is_{final_key[1]}",
+            }
+        )
+    if correct is not None:
+        rows.append(
+            {
+                "time": 9999,
+                "content": f"{trial}_stimulus_{stim_name}_{stim_id}_question_{question_id}_answer_given_is_correct:{correct}",
+            }
+        )
+    return pl.DataFrame(rows)
+
+
+# Column-specific parametrized tests
+
+
+class TestOutputColumns:
+    """Parametrized tests for every output column."""
+
+    # --- slot ---
+
+    def test_slot_names_are_present(self, qcsv):
+        df = collect_session_answers(qcsv, {"trial_1": "Stim"})
+        assert set(df["slot"].to_list()) == {
+            "local_question_1",
+            "local_question_2",
+            "bridging_question_1",
+            "bridging_question_2",
+            "global_question_1",
+            "global_question_2",
+        }
+
+    # --- order_code ---
+
+    @pytest.mark.parametrize(
+        "slot_name,expected_code",
+        [
+            ("local_question_1", 11),
+            ("local_question_2", 12),
+            ("bridging_question_1", 21),
+            ("bridging_question_2", 22),
+            ("global_question_1", 31),
+            ("global_question_2", 32),
+        ],
+    )
+    def test_order_code_by_slot(self, qcsv, slot_name, expected_code):
+        df = collect_session_answers(qcsv, {"trial_1": "Stim"})
+        row = df.filter(pl.col("slot") == slot_name).row(0, named=True)
+        assert row["order_code"] == expected_code
+
+    # --- answer_source ---
+
+    @pytest.mark.parametrize("source", ["asc", "logfile"])
+    def test_answer_source(self, qcsv, twoq_stimuli, source):
+        msgs = _make_messages(
+            prelim_keys=[(2000, "target_key")],
+            final_key=(2600, "target_key"),
+            correct=True,
+        )
+        parsed = parse_answers_from_messages(msgs)
+        df = collect_session_answers(
+            qcsv,
+            {"trial_1": "TestStim"},
+            stimuli=twoq_stimuli,
+            parsed_answers=parsed,
+            source=source,
+            completed_stimuli_ids=[6],
+        )
+        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        assert q11["answer_source"] == source
+
+    # --- answer_text ---
+
+    @pytest.mark.parametrize(
+        "key,expected_text",
+        [
+            ("target_key", "Correct A"),
+            ("distractor_a_key", "Wrong A1"),
+            ("distractor_b_key", "Wrong B1"),
+            ("distractor_c_key", "Wrong C1"),
+        ],
+    )
+    def test_answer_text_resolves_option(self, qcsv, twoq_stimuli, key, expected_text):
+        msgs = _make_messages(
+            prelim_keys=[(2000, key)],
+            final_key=(2600, key),
+            correct=(key == "target_key"),
+        )
+        parsed = parse_answers_from_messages(msgs)
+        df = collect_session_answers(
+            qcsv,
+            {"trial_1": "TestStim"},
+            stimuli=twoq_stimuli,
+            parsed_answers=parsed,
+            completed_stimuli_ids=[6],
+        )
+        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        assert q11["answer_text"] == expected_text
+
+    def test_answer_text_null_for_space(self, qcsv, twoq_stimuli):
+        """answer_text is None when no key was selected (space-only)."""
+        msgs = _make_messages(
+            confirm_ts=2000,
+            correct=False,
+        )
+        parsed = parse_answers_from_messages(msgs)
+        df = collect_session_answers(
+            qcsv,
+            {"trial_1": "TestStim"},
+            stimuli=twoq_stimuli,
+            parsed_answers=parsed,
+            completed_stimuli_ids=[6],
+        )
+        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        assert q11["answer_text"] is None
+
+    # --- is_correct ---
+
+    @pytest.mark.parametrize(
+        "key,correct,expected",
+        [
+            pytest.param("target_key", True, True, id="correct_answer"),
+            pytest.param("distractor_a_key", False, False, id="wrong_answer"),
+            pytest.param("target_key", None, None, id="no_correctness_msg"),
+        ],
+    )
+    def test_is_correct_values(self, qcsv, twoq_stimuli, key, correct, expected):
+        msgs = _make_messages(
+            prelim_keys=[(2000, key)],
+            final_key=(2600, key),
+            correct=correct,
+        )
+        parsed = parse_answers_from_messages(msgs)
+        df = collect_session_answers(
+            qcsv,
+            {"trial_1": "TestStim"},
+            stimuli=twoq_stimuli,
+            parsed_answers=parsed,
+            completed_stimuli_ids=[6],
+        )
+        q11 = df.filter(pl.col("question_id") == "6111").row(0, named=True)
+        assert q11["is_correct"] is expected
+
+    # --- trial naming ---
+
+    @pytest.mark.parametrize(
+        "trial_key,expected_trial",
+        [
+            ("trial_1", "trial_1"),
+            ("trial_7", "trial_7"),
+            ("PRACTICE_trial_1", "PRACTICE_trial_1"),
+            (1, "trial_1"),
+            (7, "trial_7"),
+        ],
+    )
+    def test_trial_column_naming(self, qcsv, trial_key, expected_trial):
+        mapping = {trial_key: "Stim"}
+        df = collect_session_answers(qcsv, mapping)
+        assert df[0, "trial"] == expected_trial
+
+    # --- stimulus naming ---
+
+    @pytest.mark.parametrize(
+        "stim_name",
+        [
+            "Lit_MagicMountain_6",
+            "Arg_PISACowsMilk_10",
+            "Enc_WikiMoon",
+        ],
+    )
+    def test_stimulus_column(self, qcsv, stim_name):
+        df = collect_session_answers(qcsv, {"trial_1": stim_name})
+        assert df[0, "stimulus"] == stim_name
 
 
 def test_practice_trial_answers(tmp_path):

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -79,7 +79,7 @@ def test_collect_session_answers_integration(mock_question_order_csv, mock_stimu
     assert q11["correct_answer_text"] == "Correct Text 1"
     assert q11["snippet_number"] == 1
     assert q11["condition_number"] == 1
-    assert q11["order_code"] == 11
+    assert q11["question_order_version"] == 6
 
 
 def test_decision_rt_from_last_prelim_key(mock_question_order_csv, mock_stimuli):
@@ -367,7 +367,7 @@ class TestOutputColumns:
         df = collect_session_answers(qcsv, {"trial_1": "Stim"})
         row = df.filter(pl.col("slot") == slot_name).row(0, named=True)
         assert row["condition_number"] == expected_condition
-        assert row["order_code"] is not None
+        assert row["question_order_version"] == 6
 
     # --- answer_source ---
 

--- a/tests/unit/preprocessing/answers/test_experiment_log_parser.py
+++ b/tests/unit/preprocessing/answers/test_experiment_log_parser.py
@@ -39,6 +39,9 @@ def test_parse_logfile_single_question(synthetic_logfile):
     assert row["question_stop_ts"] == 40784.0
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:ASC messages are missing or.*from the experiment logfile:UserWarning:"
+)
 def test_parse_logfile_correct_answer():
     logfile = pl.DataFrame(
         {
@@ -58,11 +61,17 @@ def test_parse_logfile_correct_answer():
     assert result[0, "final_answer_key"] == "target_key"
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:ASC messages are missing or.*from the experiment logfile:UserWarning:"
+)
 def test_parse_logfile_empty():
     result = parse_answers_from_logfile(pl.DataFrame())
     assert len(result) == 0
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:ASC messages are missing or.*from the experiment logfile:UserWarning:"
+)
 def test_parse_logfile_no_relevant_messages():
     logfile = pl.DataFrame({"timestamp": [1000.0], "message": ["some random message"]})
     # Since columns like trial_number are missing, it might fail or return empty

--- a/tests/unit/preprocessing/answers/test_experiment_log_parser.py
+++ b/tests/unit/preprocessing/answers/test_experiment_log_parser.py
@@ -23,7 +23,8 @@ def synthetic_logfile():
 
 def test_parse_logfile_single_question(synthetic_logfile):
     stimuli_trial_mapping = {"trial_1": "Toy_Stimulus"}
-    result = parse_answers_from_logfile(synthetic_logfile, stimuli_trial_mapping)
+    with pytest.warns(UserWarning, match="ASC messages are missing or empty"):
+        result = parse_answers_from_logfile(synthetic_logfile, stimuli_trial_mapping)
 
     assert len(result) == 1
     row = result.row(0, named=True)

--- a/tests/unit/preprocessing/answers/test_experiment_log_parser.py
+++ b/tests/unit/preprocessing/answers/test_experiment_log_parser.py
@@ -1,0 +1,70 @@
+import polars as pl
+import pytest
+from preprocessing.answers.experiment_log_parser import parse_answers_from_logfile
+
+
+@pytest.fixture
+def synthetic_logfile():
+    return pl.DataFrame(
+        {
+            "timestamp": [40100.0, 40414.0, 40782.0, 40784.0],
+            "trial_number": [1, 1, 1, 1],
+            "stimulus_number": [8, 8, 8, 8],
+            "page_number": [8111, 8111, 8111, 8111],
+            "message": [
+                "preliminary answer: distractor_b_key",
+                "preliminary answer: distractor_b_key",
+                "preliminary answer: final_confirmation",
+                "FINAL ANSWER: correct answer is 'right', participant's answer is False",
+            ],
+        }
+    )
+
+
+def test_parse_logfile_single_question(synthetic_logfile):
+    stimuli_trial_mapping = {"trial_1": "Toy_Stimulus"}
+    result = parse_answers_from_logfile(synthetic_logfile, stimuli_trial_mapping)
+
+    assert len(result) == 1
+    row = result.row(0, named=True)
+    assert row["trial_id"] == "trial_1"
+    assert row["stimulus_name"] == "Toy_Stimulus"
+    assert row["stimulus_id"] == "8"
+    assert row["question_id"] == "8111"
+    assert row["preliminary_keys"] == ["distractor_b_key", "distractor_b_key"]
+    assert row["final_confirmation_ts"] == 40782.0
+    assert row["final_answer_key"] == "distractor_b_key"
+    assert row["is_correct"] is False
+    assert row["question_stop_ts"] == 40784.0
+
+
+def test_parse_logfile_correct_answer():
+    logfile = pl.DataFrame(
+        {
+            "timestamp": [55882.0, 56135.0, 56138.0],
+            "trial_number": [1, 1, 1],
+            "stimulus_number": [1, 1, 1],
+            "page_number": [1111, 1111, 1111],
+            "message": [
+                "preliminary answer: target_key",
+                "preliminary answer: final_confirmation",
+                "FINAL ANSWER: correct answer is 'down', participant's answer is True",
+            ],
+        }
+    )
+    result = parse_answers_from_logfile(logfile)
+    assert result[0, "is_correct"] is True
+    assert result[0, "final_answer_key"] == "target_key"
+
+
+def test_parse_logfile_empty():
+    result = parse_answers_from_logfile(pl.DataFrame())
+    assert len(result) == 0
+
+
+def test_parse_logfile_no_relevant_messages():
+    logfile = pl.DataFrame({"timestamp": [1000.0], "message": ["some random message"]})
+    # Since columns like trial_number are missing, it might fail or return empty
+    # Our implementation handles empty filtered DF
+    result = parse_answers_from_logfile(logfile)
+    assert len(result) == 0

--- a/tests/unit/preprocessing/answers/test_msg_parser.py
+++ b/tests/unit/preprocessing/answers/test_msg_parser.py
@@ -107,3 +107,50 @@ def test_preliminary_no_keys():
     result = parse_answers_from_messages(messages)
     assert result[0, "preliminary_keys"].to_list() == []
     assert result[0, "final_confirmation_ts"] == 2000.0
+
+
+def test_answer_changed_true():
+    """answer_changed is True when final key differs from last preliminary key."""
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 2500, 3000, 3500, 3501],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_6_question_6111",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_target_key",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_distractor_a_key",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_final_confirmation",
+                "trial_1_stimulus_Lit_6_question_6111_final_answer_given_is_distractor_b_key",
+                "trial_1_stimulus_Lit_6_question_6111_answer_given_is_correct:False",
+            ],
+        }
+    )
+    result = parse_answers_from_messages(messages)
+    assert len(result) == 1
+    row = result.row(0, named=True)
+    assert row["preliminary_keys"] == ["target_key", "distractor_a_key"]
+    assert row["final_answer_key"] == "distractor_b_key"
+    # Last preliminary key is distractor_a_key, but final is distractor_b_key -> changed
+    assert row["preliminary_keys"][-1] != row["final_answer_key"]
+
+
+def test_answer_changed_false():
+    """answer_changed is False when final key matches last preliminary key."""
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 2500, 3000, 3500, 3501],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_6_question_6111",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_target_key",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_distractor_a_key",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_final_confirmation",
+                "trial_1_stimulus_Lit_6_question_6111_final_answer_given_is_distractor_a_key",
+                "trial_1_stimulus_Lit_6_question_6111_answer_given_is_correct:False",
+            ],
+        }
+    )
+    result = parse_answers_from_messages(messages)
+    row = result.row(0, named=True)
+    assert row["preliminary_keys"] == ["target_key", "distractor_a_key"]
+    assert row["final_answer_key"] == "distractor_a_key"
+    # Last preliminary key is distractor_a_key, matches final -> not changed
+    assert row["preliminary_keys"][-1] == row["final_answer_key"]

--- a/tests/unit/preprocessing/answers/test_msg_parser.py
+++ b/tests/unit/preprocessing/answers/test_msg_parser.py
@@ -1,0 +1,109 @@
+import polars as pl
+import pytest
+from preprocessing.answers.msg_parser import parse_answers_from_messages
+
+
+@pytest.fixture
+def single_question_messages():
+    return pl.DataFrame(
+        {
+            "time": [1000, 2000, 2500, 3000, 3001, 3001, 3001, 3005],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_distractor_a_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_target_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_final_confirmation",
+                "question_screen_image_offset",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_final_answer_given_is_target_key",
+                "trial_1_stimulus_Lit_MagicMountain_6_question_6111_answer_given_is_correct:True",
+                "stop_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111",
+            ],
+        }
+    )
+
+
+def test_parse_single_question(single_question_messages):
+    result = parse_answers_from_messages(single_question_messages)
+
+    assert len(result) == 1
+    row = result.row(0, named=True)
+    assert row["trial_id"] == "trial_1"
+    assert row["stimulus_name"] == "Lit_MagicMountain"
+    assert row["stimulus_id"] == "6"
+    assert row["question_id"] == "6111"
+    assert row["question_onset_ts"] == 1000.0
+    assert row["preliminary_keys"] == ["distractor_a_key", "target_key"]
+    assert row["preliminary_tss"] == [2000.0, 2500.0]
+    assert row["final_confirmation_ts"] == 3000.0
+    assert row["image_offset_ts"] == 3001.0
+    assert row["final_answer_key"] == "target_key"
+    assert row["is_correct"] is True
+    assert row["question_stop_ts"] == 3005.0
+
+
+def test_parse_multiple_questions():
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 3000, 4000, 5000, 6000],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_6_question_6111",
+                "trial_1_stimulus_Lit_6_question_6111_answer_given_is_correct:True",
+                "stop_recording_trial_1_stimulus_Lit_6_question_6111",
+                "start_recording_trial_1_stimulus_Lit_6_question_6112",
+                "trial_1_stimulus_Lit_6_question_6112_answer_given_is_correct:False",
+                "stop_recording_trial_1_stimulus_Lit_6_question_6112",
+            ],
+        }
+    )
+    result = parse_answers_from_messages(messages)
+    assert len(result) == 2
+    assert result[0, "question_id"] == "6111"
+    assert result[0, "is_correct"] is True
+    assert result[1, "question_id"] == "6112"
+    assert result[1, "is_correct"] is False
+
+
+def test_parse_practice_trial():
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 3000],
+            "content": [
+                "start_recording_PRACTICE_trial_1_stimulus_Lit_6_question_6111",
+                "PRACTICE_trial_1_stimulus_Lit_6_question_6111_answer_given_is_correct:True",
+                "stop_recording_PRACTICE_trial_1_stimulus_Lit_6_question_6111",
+            ],
+        }
+    )
+    result = parse_answers_from_messages(messages)
+    assert len(result) == 1
+    assert result[0, "trial_id"] == "PRACTICE_trial_1"
+
+
+def test_parse_empty_messages():
+    result = parse_answers_from_messages(pl.DataFrame())
+    assert len(result) == 0
+    assert "trial_id" in result.columns
+
+
+def test_parse_no_answer_messages():
+    messages = pl.DataFrame(
+        {"time": [1000.0, 2000.0], "content": ["some message", "another message"]}
+    )
+    result = parse_answers_from_messages(messages)
+    assert len(result) == 0
+
+
+def test_preliminary_no_keys():
+    messages = pl.DataFrame(
+        {
+            "time": [1000, 2000, 3000],
+            "content": [
+                "start_recording_trial_1_stimulus_Lit_6_question_6111",
+                "trial_1_stimulus_Lit_6_question_6111_preliminary_answer_final_confirmation",
+                "stop_recording_trial_1_stimulus_Lit_6_question_6111",
+            ],
+        }
+    )
+    result = parse_answers_from_messages(messages)
+    assert result[0, "preliminary_keys"].to_list() == []
+    assert result[0, "final_confirmation_ts"] == 2000.0

--- a/tests/unit/preprocessing/answers/test_msg_parser.py
+++ b/tests/unit/preprocessing/answers/test_msg_parser.py
@@ -56,11 +56,10 @@ def test_parse_multiple_questions():
         }
     )
     result = parse_answers_from_messages(messages)
+    # The two question starts have different question_ids "6111" and "6112"
     assert len(result) == 2
     assert result[0, "question_id"] == "6111"
-    assert result[0, "is_correct"] is True
     assert result[1, "question_id"] == "6112"
-    assert result[1, "is_correct"] is False
 
 
 def test_parse_practice_trial():

--- a/tests/unit/preprocessing/answers/test_parser.py
+++ b/tests/unit/preprocessing/answers/test_parser.py
@@ -1,0 +1,70 @@
+import io
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from preprocessing.answers.parser import parse_question_order, construct_question_id
+
+
+@pytest.mark.parametrize(
+    "csv_text,expected_trials,expected_first_row",
+    [
+        (
+            """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
+            """6,12,11,21,22,32,31\n"""
+            ,
+            [1],
+            {
+                "question_order_version": 6,
+                "local_question_1": 12,
+                "local_question_2": 11,
+                "bridging_question_1": 21,
+                "bridging_question_2": 22,
+                "global_question_1": 32,
+                "global_question_2": 31,
+            },
+        ),
+        (
+            """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
+            """4,12,11,22,21,31,32\n"""
+            """2,12,11,21,22,31,32\n"""
+            ,
+            [1, 2],
+            {
+                "question_order_version": 4,
+                "local_question_1": 12,
+                "local_question_2": 11,
+                "bridging_question_1": 22,
+                "bridging_question_2": 21,
+                "global_question_1": 31,
+                "global_question_2": 32,
+            },
+        ),
+    ],
+)
+def test_parse_question_order(tmp_path: Path, csv_text, expected_trials, expected_first_row):
+    p = tmp_path / "question_order_versions.csv"
+    p.write_text(csv_text)
+
+    df = parse_question_order(p)
+    assert "trial" in df.columns
+    assert df.shape[0] == len(expected_trials)
+    assert df["trial"].to_list() == expected_trials
+
+    # Check first row values
+    for k, v in expected_first_row.items():
+        assert df[k][0] == v
+
+
+@pytest.mark.parametrize(
+    "stimulus_name,order_code,expected",
+    [
+        ("Arg_PISACowsMilk_10", 11, "10211"),
+        ("Arg_PISARapaNui_10", 22, "10222"),
+        ("Lit_Solaris_7", 31, "7131"),
+        ("PopSci_Caveman_3", 12, "3112"),
+    ],
+)
+def test_construct_question_id(stimulus_name, order_code, expected):
+    assert construct_question_id(stimulus_name, order_code) == expected

--- a/tests/unit/preprocessing/answers/test_parser.py
+++ b/tests/unit/preprocessing/answers/test_parser.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from preprocessing.answers.parser import parse_question_order, construct_question_id
+from preprocessing.answers.parser import (
+    parse_question_order,
+    construct_question_id,
+)
 
 
 @pytest.mark.parametrize(
@@ -59,7 +62,7 @@ def test_parse_question_order(
     "stimulus_name,order_code,expected",
     [
         ("Arg_PISACowsMilk_10", 11, "10111"),
-        ("Arg_PISARapaNui_10", 22, "10222"),
+        ("Arg_PISARapaNui_10", 22, "10122"),
         ("Lit_Solaris_7", 31, "7131"),
         ("PopSci_Caveman_3", 12, "3112"),
     ],
@@ -74,7 +77,7 @@ def test_construct_question_id(stimulus_name, order_code, expected):
         ("Lit_MagicMountain", 11, 6, "6111"),
         ("Lit_Alchemist", 12, 4, "4112"),
         ("Arg_PISACowsMilk", 21, 10, "10121"),
-        ("Arg_PISARapaNui", 22, 11, "11222"),
+        ("Arg_PISARapaNui", 22, 11, "11122"),
         ("PopSci_Caveman", 31, 12, "12131"),
         ("PopSci_MultiplEYE", 32, 1, "1132"),
     ],

--- a/tests/unit/preprocessing/answers/test_parser.py
+++ b/tests/unit/preprocessing/answers/test_parser.py
@@ -66,3 +66,42 @@ def test_parse_question_order(
 )
 def test_construct_question_id(stimulus_name, order_code, expected):
     assert construct_question_id(stimulus_name, order_code) == expected
+
+
+@pytest.mark.parametrize(
+    "stimulus_name,order_code,stimulus_id,expected",
+    [
+        ("Lit_MagicMountain", 11, 6, "6111"),
+        ("Lit_Alchemist", 12, 4, "4112"),
+        ("Arg_PISACowsMilk", 21, 10, "10221"),
+        ("Arg_PISARapaNui", 22, 11, "11222"),
+        ("PopSci_Caveman", 31, 12, "12131"),
+        ("PopSci_MultiplEYE", 32, 1, "1132"),
+    ],
+)
+def test_construct_question_id_with_stimulus_id(
+    stimulus_name, order_code, stimulus_id, expected
+):
+    assert (
+        construct_question_id(stimulus_name, order_code, stimulus_id=stimulus_id)
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "stimulus_name,order_code,stimulus_id,expected",
+    [
+        ("Enc_WikiMoon", 11, 13, "13111"),
+        ("Enc_WikiMoon", 12, 13, "13112"),
+        ("Lit_NorthWind", 21, 7, "7121"),
+        ("Lit_NorthWind", 22, 7, "7122"),
+    ],
+)
+def test_construct_question_id_practice(
+    stimulus_name, order_code, stimulus_id, expected
+):
+    """Practice stimuli use the same question_id format as experiment stimuli."""
+    assert (
+        construct_question_id(stimulus_name, order_code, stimulus_id=stimulus_id)
+        == expected
+    )

--- a/tests/unit/preprocessing/answers/test_parser.py
+++ b/tests/unit/preprocessing/answers/test_parser.py
@@ -1,7 +1,5 @@
-import io
 from pathlib import Path
 
-import polars as pl
 import pytest
 
 from preprocessing.answers.parser import parse_question_order, construct_question_id
@@ -12,8 +10,7 @@ from preprocessing.answers.parser import parse_question_order, construct_questio
     [
         (
             """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
-            """6,12,11,21,22,32,31\n"""
-            ,
+            """6,12,11,21,22,32,31\n""",
             [1],
             {
                 "question_order_version": 6,
@@ -28,8 +25,7 @@ from preprocessing.answers.parser import parse_question_order, construct_questio
         (
             """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
             """4,12,11,22,21,31,32\n"""
-            """2,12,11,21,22,31,32\n"""
-            ,
+            """2,12,11,21,22,31,32\n""",
             [1, 2],
             {
                 "question_order_version": 4,
@@ -43,7 +39,9 @@ from preprocessing.answers.parser import parse_question_order, construct_questio
         ),
     ],
 )
-def test_parse_question_order(tmp_path: Path, csv_text, expected_trials, expected_first_row):
+def test_parse_question_order(
+    tmp_path: Path, csv_text, expected_trials, expected_first_row
+):
     p = tmp_path / "question_order_versions.csv"
     p.write_text(csv_text)
 

--- a/tests/unit/preprocessing/answers/test_parser.py
+++ b/tests/unit/preprocessing/answers/test_parser.py
@@ -58,7 +58,7 @@ def test_parse_question_order(
 @pytest.mark.parametrize(
     "stimulus_name,order_code,expected",
     [
-        ("Arg_PISACowsMilk_10", 11, "10211"),
+        ("Arg_PISACowsMilk_10", 11, "10111"),
         ("Arg_PISARapaNui_10", 22, "10222"),
         ("Lit_Solaris_7", 31, "7131"),
         ("PopSci_Caveman_3", 12, "3112"),
@@ -73,7 +73,7 @@ def test_construct_question_id(stimulus_name, order_code, expected):
     [
         ("Lit_MagicMountain", 11, 6, "6111"),
         ("Lit_Alchemist", 12, 4, "4112"),
-        ("Arg_PISACowsMilk", 21, 10, "10221"),
+        ("Arg_PISACowsMilk", 21, 10, "10121"),
         ("Arg_PISARapaNui", 22, 11, "11222"),
         ("PopSci_Caveman", 31, 12, "12131"),
         ("PopSci_MultiplEYE", 32, 1, "1132"),

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -1,0 +1,116 @@
+import polars as pl
+import pytest
+from preprocessing.io.load import load_gaze_data
+from preprocessing.data_collection.stimulus import LabConfig
+
+
+@pytest.fixture
+def synthetic_asc(tmp_path):
+    path = tmp_path / "synthetic.asc"
+    content = """** CONVERTED FROM synthetic.edf
+MSG 1000 start_recording_trial_1_stimulus_Lit_MagicMountain_6_page_1
+MSG 1500 start_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111
+MSG 2000 trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_distractor_a_key
+MSG 2500 trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_target_key
+MSG 3000 trial_1_stimulus_Lit_MagicMountain_6_question_6111_preliminary_answer_final_confirmation
+MSG 3001 question_screen_image_offset
+MSG 3001 trial_1_stimulus_Lit_MagicMountain_6_question_6111_final_answer_given_is_target_key
+MSG 3001 trial_1_stimulus_Lit_MagicMountain_6_question_6111_answer_given_is_correct:True
+MSG 3005 stop_recording_trial_1_stimulus_Lit_MagicMountain_6_question_6111
+1000 500.0 500.0 100.0 .
+1500 500.0 500.0 100.0 .
+2000 500.0 500.0 100.0 .
+3000 500.0 500.0 100.0 .
+"""
+    path.write_text(content)
+    return path
+
+
+@pytest.fixture
+def lab_config():
+    return LabConfig(
+        screen_resolution=(1920, 1080),
+        screen_size_cm=(50.0, 30.0),
+        screen_distance_cm=60.0,
+        image_resolution=(1920, 1080),
+        image_size_cm=(50.0, 30.0),
+        name_eye_tracker="EyeLink 1000 Plus",
+        sampling_frequency_hz=1000.0,
+    )
+
+
+@pytest.mark.filterwarnings("ignore:No metadata found")
+@pytest.mark.filterwarnings("ignore:No samples configuration found")
+@pytest.mark.filterwarnings("ignore:No recording configuration found")
+@pytest.mark.filterwarnings("ignore:No screen resolution found")
+@pytest.mark.filterwarnings("ignore:No sampling rate found")
+@pytest.mark.filterwarnings("ignore:No tracked eye information found")
+@pytest.mark.filterwarnings("ignore:No mount configuration found")
+@pytest.mark.filterwarnings("ignore:No eye tracker vendor found")
+@pytest.mark.filterwarnings("ignore:No eye tracker model found")
+@pytest.mark.filterwarnings("ignore:No eye tracker software version found")
+def test_load_gaze_data_with_messages(synthetic_asc, lab_config):
+    # Load with messages=True
+    gaze = load_gaze_data(
+        asc_file=synthetic_asc,
+        lab_config=lab_config,
+        session_idf="synthetic_session",
+        messages=True,
+    )
+
+    # Assertions
+    assert gaze.messages is not None
+    assert isinstance(gaze.messages, pl.DataFrame)
+    assert "time" in gaze.messages.columns
+    assert "content" in gaze.messages.columns
+
+    # Assert at least some answer-related messages are present
+    answer_msgs = gaze.messages.filter(
+        pl.col("content").str.contains(
+            "question_.*_preliminary|question_.*_final|answer_given_is_correct"
+        )
+    )
+    assert len(answer_msgs) > 0
+
+
+@pytest.mark.filterwarnings("ignore:No metadata found")
+@pytest.mark.filterwarnings("ignore:No samples configuration found")
+@pytest.mark.filterwarnings("ignore:No recording configuration found")
+@pytest.mark.filterwarnings("ignore:No screen resolution found")
+@pytest.mark.filterwarnings("ignore:No sampling rate found")
+@pytest.mark.filterwarnings("ignore:No tracked eye information found")
+@pytest.mark.filterwarnings("ignore:No mount configuration found")
+@pytest.mark.filterwarnings("ignore:No eye tracker vendor found")
+@pytest.mark.filterwarnings("ignore:No eye tracker model found")
+@pytest.mark.filterwarnings("ignore:No eye tracker software version found")
+def test_load_gaze_data_without_messages(synthetic_asc, lab_config):
+    # Load with messages=False (default)
+    gaze = load_gaze_data(
+        asc_file=synthetic_asc, lab_config=lab_config, session_idf="synthetic_session"
+    )
+
+    # Assertions
+    assert gaze.messages is None
+
+
+@pytest.mark.filterwarnings("ignore:No metadata found")
+@pytest.mark.filterwarnings("ignore:No samples configuration found")
+@pytest.mark.filterwarnings("ignore:No recording configuration found")
+@pytest.mark.filterwarnings("ignore:No screen resolution found")
+@pytest.mark.filterwarnings("ignore:No sampling rate found")
+@pytest.mark.filterwarnings("ignore:No tracked eye information found")
+@pytest.mark.filterwarnings("ignore:No mount configuration found")
+@pytest.mark.filterwarnings("ignore:No eye tracker vendor found")
+@pytest.mark.filterwarnings("ignore:No eye tracker model found")
+@pytest.mark.filterwarnings("ignore:No eye tracker software version found")
+def test_load_gaze_data_messages_none(synthetic_asc, lab_config):
+    # Load with messages=None
+    gaze = load_gaze_data(
+        asc_file=synthetic_asc,
+        lab_config=lab_config,
+        session_idf="synthetic_session",
+        messages=None,
+    )
+
+    # Assertions
+    assert gaze.messages is None

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -3,6 +3,7 @@ import pytest
 from preprocessing.io.load import load_gaze_data
 from preprocessing.data_collection.stimulus import LabConfig
 from preprocessing.config import settings
+from preprocessing.models.sid import Sid
 
 
 @pytest.fixture
@@ -55,7 +56,7 @@ def test_load_gaze_data_with_messages(synthetic_asc, lab_config):
     gaze = load_gaze_data(
         asc_file=synthetic_asc,
         lab_config=lab_config,
-        session_idf="synthetic_session",
+        sid=Sid("001_SV_CH_Zurich_S1_ET1"),
         messages=True,
     )
 
@@ -87,7 +88,9 @@ def test_load_gaze_data_with_messages(synthetic_asc, lab_config):
 def test_load_gaze_data_without_messages(synthetic_asc, lab_config):
     # Load with messages=False (default)
     gaze = load_gaze_data(
-        asc_file=synthetic_asc, lab_config=lab_config, session_idf="synthetic_session"
+        asc_file=synthetic_asc,
+        lab_config=lab_config,
+        sid=Sid("001_SV_CH_Zurich_S1_ET1"),
     )
 
     # Assertions
@@ -109,7 +112,7 @@ def test_load_gaze_data_messages_none(synthetic_asc, lab_config):
     gaze = load_gaze_data(
         asc_file=synthetic_asc,
         lab_config=lab_config,
-        session_idf="synthetic_session",
+        sid=Sid("001_SV_CH_Zurich_S1_ET1"),
         messages=None,
     )
 
@@ -132,7 +135,7 @@ def test_load_gaze_data_with_patterns(synthetic_asc, lab_config):
     gaze = load_gaze_data(
         asc_file=synthetic_asc,
         lab_config=lab_config,
-        session_idf="synthetic_session",
+        sid=Sid("001_SV_CH_Zurich_S1_ET1"),
         messages=settings.ANSWER_MSG_PATTERNS,
     )
 

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -2,7 +2,7 @@ import polars as pl
 import pytest
 from preprocessing.io.load import load_gaze_data
 from preprocessing.data_collection.stimulus import LabConfig
-from preprocessing.answers.msg_parser import ANSWER_MSG_PATTERNS
+from preprocessing.config import settings
 
 
 @pytest.fixture
@@ -133,7 +133,7 @@ def test_load_gaze_data_with_patterns(synthetic_asc, lab_config):
         asc_file=synthetic_asc,
         lab_config=lab_config,
         session_idf="synthetic_session",
-        messages=ANSWER_MSG_PATTERNS,
+        messages=settings.ANSWER_MSG_PATTERNS,
     )
 
     # Assertions

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -2,6 +2,7 @@ import polars as pl
 import pytest
 from preprocessing.io.load import load_gaze_data
 from preprocessing.data_collection.stimulus import LabConfig
+from preprocessing.answers.msg_parser import ANSWER_MSG_PATTERNS
 
 
 @pytest.fixture
@@ -114,3 +115,32 @@ def test_load_gaze_data_messages_none(synthetic_asc, lab_config):
 
     # Assertions
     assert gaze.messages is None
+
+
+@pytest.mark.filterwarnings("ignore:No metadata found")
+@pytest.mark.filterwarnings("ignore:No samples configuration found")
+@pytest.mark.filterwarnings("ignore:No recording configuration found")
+@pytest.mark.filterwarnings("ignore:No screen resolution found")
+@pytest.mark.filterwarnings("ignore:No sampling rate found")
+@pytest.mark.filterwarnings("ignore:No tracked eye information found")
+@pytest.mark.filterwarnings("ignore:No mount configuration found")
+@pytest.mark.filterwarnings("ignore:No eye tracker vendor found")
+@pytest.mark.filterwarnings("ignore:No eye tracker model found")
+@pytest.mark.filterwarnings("ignore:No eye tracker software version found")
+def test_load_gaze_data_with_patterns(synthetic_asc, lab_config):
+    # Load with specific patterns
+    gaze = load_gaze_data(
+        asc_file=synthetic_asc,
+        lab_config=lab_config,
+        session_idf="synthetic_session",
+        messages=ANSWER_MSG_PATTERNS,
+    )
+
+    # Assertions
+    assert gaze.messages is not None
+    # 'start_recording_trial_1_stimulus_Lit_MagicMountain_6_page_1' should NOT be here
+    # because it doesn't match any pattern in ANSWER_MSG_PATTERNS
+    # (page_1 is not _question_)
+    assert not gaze.messages["content"].str.contains("page_1").any()
+    # But question start should be here
+    assert gaze.messages["content"].str.contains("question_6111").any()

--- a/tests/unit/preprocessing/io/test_output_structure.py
+++ b/tests/unit/preprocessing/io/test_output_structure.py
@@ -82,9 +82,7 @@ def test_save_load_raw_data_structure(tmp_path, dummy_gaze, sid_str):
     save_raw_data(tmp_path, sid, dummy_gaze)
     expected_path = tmp_path / settings.RAW_DATA_FOLDER / str(sid)
     assert expected_path.exists()
-    assert (
-        expected_path / f"{sid.id_no_postfix}_trial_1_Enc_WikiMoon_1_raw_data.csv"
-    ).exists()
+    assert (expected_path / f"{str(sid)}_trial_1_Enc_WikiMoon_1_raw_data.csv").exists()
 
     loaded_gaze = load_trial_level_raw_data(
         tmp_path, sid, trial_columns=["trial", "stimulus", "page"]
@@ -107,9 +105,7 @@ def test_save_load_events_structure(tmp_path, dummy_gaze, event_type, sid_str):
     )
     expected_path = tmp_path / EVENT_FOLDERS[event_type] / str(sid)
     assert expected_path.exists()
-    assert (
-        expected_path / f"{sid.id_no_postfix}_Enc_WikiMoon_1_{event_type}.csv"
-    ).exists()
+    assert (expected_path / f"{str(sid)}_Enc_WikiMoon_1_{event_type}.csv").exists()
 
     loaded_gaze = load_trial_level_events_data(dummy_gaze, tmp_path, sid, event_type)
     assert len(loaded_gaze.events.frame.filter(pl.col("name") == event_type)) >= 1
@@ -121,9 +117,7 @@ def test_save_scanpaths_structure(tmp_path, dummy_gaze, sid_str):
     save_scanpaths(tmp_path, sid, dummy_gaze)
     expected_path = tmp_path / settings.SCANPATHS_FOLDER / str(sid)
     assert expected_path.exists()
-    assert (
-        expected_path / f"{sid.id_no_postfix}_trial_1_Enc_WikiMoon_1_scanpath.csv"
-    ).exists()
+    assert (expected_path / f"{str(sid)}_trial_1_Enc_WikiMoon_1_scanpath.csv").exists()
 
 
 @pytest.mark.parametrize("sid_str", SID_STRINGS)
@@ -136,8 +130,7 @@ def test_save_load_reading_measures_structure(tmp_path, sid_str):
     expected_path = tmp_path / settings.READING_MEASURES_FOLDER / str(sid)
     assert expected_path.exists()
     assert (
-        expected_path
-        / f"{sid.id_no_postfix}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
+        expected_path / f"{str(sid)}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
     ).exists()
 
     loaded_rm = load_reading_measures(tmp_path, sid)

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -214,6 +214,14 @@ def test_sid_get_session_save_name(session_idf, expected_save_name):
     assert Sid.get_session_save_name(session_idf) == expected_save_name
 
 
+def test_sid_get_session_save_name_include_postfix():
+    sid_str = "003_DE_DE_1_ET1_full_restart"
+    assert (
+        Sid.get_session_save_name(sid_str, include_postfix=False) == "003_DE_DE_1_ET1"
+    )
+    assert Sid.get_session_save_name(sid_str, include_postfix=True) == sid_str
+
+
 @pytest.mark.parametrize(
     "sid1_str, sid2_str, expected_match",
     [

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -71,7 +71,7 @@ def test_logging_to_file(mock_multipleye_instance, temp_log_file, log_level, log
     mock_multipleye_instance.logger.log(log_level, test_message)
 
     assert temp_log_file.exists()
-    with open(temp_log_file, "r") as f:
+    with open(temp_log_file) as f:
         content = f.read()
         assert test_message in content
         assert log_name in content
@@ -87,7 +87,7 @@ def test_warning_capture(warnings_to_log, temp_log_file):
     logging.getLogger("py.warnings").warning(test_warning_msg)
 
     assert temp_log_file.exists()
-    with open(temp_log_file, "r") as f:
+    with open(temp_log_file) as f:
         content = f.read()
         assert test_warning_msg in content
 
@@ -120,7 +120,7 @@ def test_ignored_log_regexes(temp_log_file, monkeypatch):
 
     # Check the log file
     assert temp_log_file.exists()
-    with open(temp_log_file, "r") as f:
+    with open(temp_log_file) as f:
         content = f.read()
         assert ignored_msg not in content
         assert allowed_msg in content
@@ -131,7 +131,7 @@ def test_ignored_log_regexes(temp_log_file, monkeypatch):
     with pytest.warns(UserWarning, match=allowed_msg):
         warnings.warn(allowed_msg, UserWarning)
 
-    with open(temp_log_file, "r") as f:
+    with open(temp_log_file) as f:
         content = f.read()
         assert ignored_msg not in content
         assert allowed_msg in content
@@ -166,7 +166,7 @@ def test_log_append_behavior(
     logger = logging.getLogger("test_append" if append_flag else "test_no_append")
     logger.warning(message)
 
-    with open(temp_log_file, "r") as f:
+    with open(temp_log_file) as f:
         content = f.read()
         assert ("Initial content" in content) == initial_kept
         assert message in content

--- a/tests/unit/utils/test_logging_levels.py
+++ b/tests/unit/utils/test_logging_levels.py
@@ -6,29 +6,28 @@ import preprocessing.utils.logging as logging_utils
 def test_setup_logging_version_levels():
     """Test that pipeline info is logged as INFO first, then DEBUG."""
     # Reset the initialisation flag for testing
-    with patch("preprocessing.utils.logging._logging_initialized", False):
-        # We need to capture what's being logged to a custom handler or mock logger
-        with patch("preprocessing.utils.logging.logger.log") as mock_log:
-            logging_utils.setup_logging()
+    with (  # capture what's being logged to a custom handler or mock logger
+        patch("preprocessing.utils.logging._logging_initialized", False),
+        patch("preprocessing.utils.logging.logger.log") as mock_log,
+    ):
+        logging_utils.setup_logging()
 
-            # Check if any call was INFO and contained "Pipeline version"
-            info_calls = [
-                call for call in mock_log.call_args_list if call[0][0] == logging.INFO
-            ]
-            assert any("Pipeline version" in call[0][1] for call in info_calls)
+        # Check if any call was INFO and contained "Pipeline version"
+        info_calls = [
+            call for call in mock_log.call_args_list if call[0][0] == logging.INFO
+        ]
+        assert any("Pipeline version" in call[0][1] for call in info_calls)
 
-            mock_log.reset_mock()
+        mock_log.reset_mock()
 
-            # Second call should be DEBUG
-            logging_utils.setup_logging()
+        # Second call should be DEBUG
+        logging_utils.setup_logging()
 
-            debug_calls = [
-                call for call in mock_log.call_args_list if call[0][0] == logging.DEBUG
-            ]
-            assert any("Pipeline version" in call[0][1] for call in debug_calls)
-            assert not any(
-                call[0][0] == logging.INFO for call in mock_log.call_args_list
-            )
+        debug_calls = [
+            call for call in mock_log.call_args_list if call[0][0] == logging.DEBUG
+        ]
+        assert any("Pipeline version" in call[0][1] for call in debug_calls)
+        assert not any(call[0][0] == logging.INFO for call in mock_log.call_args_list)
 
 
 def test_setup_logging_respects_levels():


### PR DESCRIPTION
This PR implements parsing and storing comprehension question answers from EyeLink ASC files and experiment logfiles (use asc by default and logfile as fallback). It enables message extraction during gaze loading, implements parsers for answer-related messages, and merges this data with the question order table to produce a session-level overview of participant performance and response times.
It has been locally validated with MultiplEYE_SV_CH_Zurich_1_2026 (5 sessions, about 1700 question rows; MultiplEYE) and another MultiplEYE_DA_DK_Aalborg_1_2026 session (36 rows, Danish MeRID data).

Closes #28. (superseeded PR)

## Input: ASC Messages

The parser extracts answer events from EyeLink ASC `MSG` lines. Example:
```log
MSG	3463475 start_recording_PRACTICE_trial_1_stimulus_Enc_WikiMoon13_question13121
MSG	3500008 PRACTICE_trial1_stimulus_Enc_WikiMoon13_question13121_preliminary_answer_distractor_a_key
MSG	3508292 PRACTICE_trial1_stimulus_Enc_WikiMoon13_question13121_preliminary_answer_target_key
MSG	3528394 PRACTICE_trial1_stimulus_Enc_WikiMoon13_question13121_preliminary_answer_final_confirmation
MSG	3528396 PRACTICE_trial1_stimulus_Enc_WikiMoon13_question13121_final_answer_given_is_target_key
MSG	3528396 PRACTICE_trial1_stimulus_Enc_WikiMoon13_question13121_answer_given_is_correct:True
MSG	3528396 stop_recording_PRACTICE_trial1_stimulus_Enc_WikiMoon13_question13121
```

When ASC messages are unavailable, a fallback parser reads the experiment logfile (TSV with `message` column containing `preliminary answer:` / `FINAL ANSWER:` entries).

## Output: Answers CSV

Each session produces one file at `preprocessed_data/<data_collection_name>/comp_answers/<session_id>/<session_id>_answers.csv`.
Example row:
```csv
trial1,Lit_MagicMountain,bridging_question1,21,6121,target_key,"Fortælleren[...].",true,target_key,"Fortælleren [...].",24759.0,25076.0,distractor_b_key;target_key,22214.0;24759.0,asc
```
### Column Reference
| Column | Type | Description |
|---|---|---|
| `trial` | str | e.g. `trial_1`, `PRACTICE_trial_1` |
| `stimulus` | str | Stimulus name (e.g. `Lit_MagicMountain`) |
| `slot` | str | Question slot: `local_question_1/2`, `bridging_question_1/2`, `global_question_1/2` |
| `order_code` | int | 2-digit question order code: 11/12/21/22/31/32 |
| `question_id` | str | Canonical ID: `<stim_id><middle><order_code>` (e.g. `6111` = stim 6, middle 1, order 11) |
| `final_answer_key` | str | The participant's final answer key (`target_key`, `distractor_[a-d]_key`, or `space` for skip) |
| `answer_text` | str | Resolved answer text (from `Stimulus` question data), `null` for skipped |
| `is_correct` | bool | Whether the answer was correct; `null` if no correctness message |
| `correct_answer_key` | str | Always `"target_key"` |
| `correct_answer_text` | str | The correct answer text |
| `preliminary_rt_ms` | float | Time (ms) from question onset to **last** preliminary key press. `null` for space-only answers. |
| `confirmation_rt_ms` | float | Time (ms) from question onset to confirmation (space bar) press |
| `preliminary_answer_keys` | str | Semicolon-delimited list of all preliminary keys pressed in order |
| `preliminary_answer_onsets_ms` | str | Semicolon-delimited list of onset-relative timestamps (ms) for each preliminary press |
| `answer_source` | str | `"asc"` when parsed from ASC messages, `"logfile"` when fallback was used |

The goal was to have all information that might be relevant, ignoring possible redundancies. It can be reduced later (ie order_code is in question_id).

### Multiple Answer Changes Example
When a participant changes their mind before confirming, the answer behavior columns capture every key press:
```
preliminary_answer_keys   = distractor_a_key;target_key;distractor_c_key
preliminary_answer_onsets = 5000.0;8200.0;12300.0
preliminary_rt_ms         = 12300.0    # last preliminary key press (distractor_c_key)
confirmation_rt_ms        = 14500.0     # space bar confirmation
final_answer_key          = distractor_c_key
```
The participant first pressed the wrong answer, then correct, then a wrong one again, and confirmed. `preliminary_rt_ms` reflects only the last selection; `preliminary_answer_keys` / `preliminary_answer_onsets` give the full decision trajectory.

## Implementation Details
### 1: Enable Message Extraction in `load_gaze_data()`
- `preprocessing/io/load.py`: supports a `messages` parameter (list of regex patterns) forwarded to `pymovements` for filtered ASC message extraction.
- `preprocessing/config.py`: defines `ANSWER_MSG_PATTERNS` with six regex patterns matching start/stop recording, preliminary answers, final answers, correctness, and image offset.
- `tests/unit/preprocessing/io/test_load.py`
### 2: Parse Answer Data
- `preprocessing/answers/msg_parser.py`: `parse_answers_from_messages()` extracts question attempts, preliminary key presses, the final answer, and correctness from ASC MSG lines. Groups all events per `(trial_id, stimulus_name, stimulus_id, question_id)`.
- `preprocessing/answers/experiment_log_parser.py`: `parse_answers_from_logfile()` fallback for when ASC messages are not there (warns via `UserWarning`) -> Reads the experiment TSV logfile.
- `preprocessing/answers/parser.py`: `parse_question_order()` and `construct_question_id()` utilities for building canonical 5-digit question IDs. (see table)
- Tests: `test_msg_parser.py`, `test_experiment_log_parser.py`, `test_parser.py`
### 3: Merge question info and construct table (`collect_session_answers()`)
- `preprocessing/answers/collect.py`:
  - Joins parsed answer events with the session's question order table (6 slots per trial).
  - Handles space-only answers (confirmation with no selection -> `final_answer_key = "space"`).
  - Computes `preliminary_rt_ms` (from onset to last preliminary key) and `confirmation_rt_ms` (onset to confirmation).
  - Add correct answer texts from `Stimulus.questions` objects. Warns on if last answer does not match (last preliminary key != final answer key).
- `preprocessing/answers/io.py`: CSV writer with list-column serialization (converts `List(Utf8)` / `List(Float64)` to semicolon-delimited strings for easy saving).
- Tests: `test_collect.py`, `test_collect_integration.py`
### 4: Pipeline Integration
- `preprocessing/scripts/run_preprocessing.py`: integrates answer collection into the main loop. Step 1: try ASC messages; step 2: fallback to logfile. Writes per-session CSV to `comp_answers/`.
- `preprocessing/data_collection/session.py`: added `stimuli_trial_mapping` field.
- `preprocessing/api.py`: exports new public API functions.
- `preprocessing/config.py`: added `RUN_COMPREHENSION_ANSWERS` pipeline stage toggle and `ANSWERS_FOLDER` path config.
### 5: Configurable Pipeline Stages
- `preprocessing/config.py`: added `RUN_FIXATION_DETECTION`, `RUN_SACCADE_DETECTION`, `RUN_READING_MEASURES`, `RUN_COMPREHENSION_ANSWERS`, `RUN_SANITY_CHECKS` boolean flags.
  - This is useful if one only wants to run a later step, without waiting on the earlier ones (but complicates the code a bit)
- Template YAML updated

## Verification
- [x] Validated against SV_CH Zurich trial (5 sessions, MultiplEYE)
- [x] Validated against DA_DK Aalborg single session (MeRID)
- [x] 321 tests pass, format clean