### PR TITLE
chore: Unify I/O signature

### DIFF
--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -195,10 +195,6 @@ class MultipleyeDataCollection:
     def __getitem__(self, item):
         return self.sessions[item]
 
-    def _get_session_save_name(self, session_idf: str) -> str:
-        """Get a consistent session name for file names, excluding restart postfixes."""
-        return Sid.get_session_save_name(session_idf)
-
     def add_recorded_sessions(
         self,
         data_root: Path,

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -12,12 +12,13 @@ import pymovements as pm
 
 from ..config import settings
 from ..data_collection.stimulus import LabConfig
+from ..models.sid import Sid
 
 
 def load_gaze_data(
     asc_file: Path,
     lab_config: LabConfig,
-    session_idf: str,
+    sid: Sid,
     trial_cols: list[str] = None,
 ) -> pm.Gaze:
     """Load sample gaze data from an ASC file.
@@ -34,8 +35,8 @@ def load_gaze_data(
         Configuration object containing details about the lab environment,
         including screen resolution, screen size (in cm),
         and the eye-tracking device's sampling rate.
-    session_idf : str
-        Identifier for the session the gaze data corresponds to.
+    sid : Sid
+        The session identifier.
     trial_cols : list of str, optional
         List of columns to be associated with trial-level metadata. Default is None.
 
@@ -63,7 +64,7 @@ def load_gaze_data(
         asc_file,
         patterns=settings.GAZE_PATTERNS,
         trial_columns=trial_cols,
-        add_columns={"session": session_idf},
+        add_columns={"session": str(sid)},
         experiment=experiment,
     )
 
@@ -78,7 +79,7 @@ def load_gaze_data(
 
 def load_trial_level_raw_data(
     directory: Path,
-    session: str,
+    sid: Sid,
     trial_columns: list[str],
     file_pattern: str | None = None,
     load_metadata: bool = False,
@@ -91,7 +92,7 @@ def load_trial_level_raw_data(
     ----------
     directory : Path
         The base directory for preprocessed data.
-    session : str
+    sid : Sid
         The session identifier.
     trial_columns : list of str
         Column names that uniquely identify a trial within the data.
@@ -107,7 +108,7 @@ def load_trial_level_raw_data(
         A gaze object containing the trial-level aggregated gaze data along with
         any associated metadata, validations, calibrations, and experiment settings, if provided.
     """
-    data_folder = Path(directory) / settings.RAW_DATA_FOLDER / session
+    data_folder = Path(directory) / settings.RAW_DATA_FOLDER / str(sid)
     if file_pattern is None:
         file_pattern = settings.RAW_DATA_FILE_GLOB
 
@@ -146,7 +147,7 @@ def load_trial_level_raw_data(
     )
 
     if load_metadata:
-        metadata_path = Path(directory) / settings.METADATA_FOLDER / session
+        metadata_path = Path(directory) / settings.METADATA_FOLDER / str(sid)
 
         with open(metadata_path / "gaze_metadata.json", "r", encoding="utf8") as f:
             metadata = json.load(f)
@@ -176,7 +177,7 @@ def load_trial_level_raw_data(
 def load_trial_level_events_data(
     gaze: pm.Gaze,
     directory: Path,
-    idf: str,
+    sid: Sid,
     event_type: str,
     file_pattern: str | None = None,
 ) -> pm.Gaze:
@@ -193,8 +194,8 @@ def load_trial_level_events_data(
         An object containing gaze data and associated event information.
     directory : Path
         The base directory for preprocessed data.
-    idf : str
-        The full session identifier (used for folder names).
+    sid : Sid
+        The session identifier.
     event_type : str
         The type of event to load, must be one of the keys in `DEFAULT_EVENT_PROPERTIES`.
     file_pattern : str, optional
@@ -207,9 +208,9 @@ def load_trial_level_events_data(
         The updated gaze object with the loaded and integrated event data.
     """
     if event_type == "fixation":
-        data_folder = Path(directory) / settings.FIXATIONS_FOLDER / idf
+        data_folder = Path(directory) / settings.FIXATIONS_FOLDER / str(sid)
     elif event_type == "saccade":
-        data_folder = Path(directory) / settings.SACCADES_FOLDER / idf
+        data_folder = Path(directory) / settings.SACCADES_FOLDER / str(sid)
     else:
         raise ValueError(
             f"event_type must be {list(settings.EVENT_PROPERTIES.keys())}, got {event_type}"
@@ -278,7 +279,7 @@ def load_trial_level_events_data(
 
 def load_reading_measures(
     directory: Path,
-    session: str,
+    sid: Sid,
     file_pattern: str = r".*?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv",
 ) -> pl.DataFrame:
     """Load reading measures from CSV files.
@@ -287,7 +288,7 @@ def load_reading_measures(
     ----------
     directory : Path
         The base directory for preprocessed data.
-    session : str
+    sid : Sid
         The session identifier.
     file_pattern : str, optional
         Regex pattern to extract trial and stimulus from filenames.
@@ -297,7 +298,7 @@ def load_reading_measures(
     pl.DataFrame
         A DataFrame containing the concatenated reading measures data.
     """
-    data_folder = Path(directory) / settings.READING_MEASURES_FOLDER / session
+    data_folder = Path(directory) / settings.READING_MEASURES_FOLDER / str(sid)
     # Use glob to find all csv files first, as Path.glob() does not support regex
     files = [f for f in data_folder.glob("*.csv") if re.match(file_pattern, f.name)]
 

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -7,25 +7,23 @@ import polars as pl
 
 import pymovements as pm
 from ..config import settings
+from ..models.sid import Sid
 
 
-def save_raw_data(
-    directory: Path,
-    session: str,
-    data: pm.Gaze,
-) -> None:
+def save_raw_data(directory: Path, sid: Sid, data: pm.Gaze) -> None:
     """
     Saves raw gaze data in separate csv files per trial.
 
     Parameters
     ----------
     directory : Path
-        The directory where the raw data should be stored.
-    session : str
-        The name of the session (used for filenames).
+        The base directory for preprocessed data.
+    sid : Sid
+        The session identifier.
     data : pm.Gaze
         The gaze data as a pymovements Gaze object.
     """
+    directory = Path(directory) / settings.RAW_DATA_FOLDER / str(sid)
     directory.mkdir(parents=True, exist_ok=True)
 
     new_data = data.clone()
@@ -40,7 +38,7 @@ def save_raw_data(
         df = trial.samples
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]
-        name = f"{session}_{trial}_{stimulus}_raw_data.csv"
+        name = f"{sid.id_no_postfix}_{trial}_{stimulus}_raw_data.csv"
         df = df["time", "pixel_x", "pixel_y", "pupil", "page"]
         df.write_csv(directory / name)
 
@@ -48,8 +46,7 @@ def save_raw_data(
 def save_events_data(
     event_type: str,
     directory: Path,
-    session: str,
-    session_idf: str,
+    sid: Sid,
     split_column: str,
     name_columns: list[str],
     file_columns: list[str],
@@ -64,12 +61,9 @@ def save_events_data(
     event_type : str
         What type of event should be stored. Either "fixation" or "saccade".
     directory : Path
-        The directory where the events data should be stored. The function will create a subfolder
-        for the session and event type (fixations or saccades).
-    session : str
-        The name of the session (used for filenames).
-    session_idf : str
-        The full session identifier (used for folder names).
+        The directory where the events data should be stored.
+    sid : Sid
+        The session identifier.
     split_column : str
         What column to split the events data by. The function will create a separate file for each
         unique value in this column.
@@ -87,9 +81,9 @@ def save_events_data(
         )
 
     directory = (
-        Path(directory) / settings.FIXATIONS_FOLDER / session_idf
+        Path(directory) / settings.FIXATIONS_FOLDER / str(sid)
         if event_type == "fixation"
-        else Path(directory) / settings.SACCADES_FOLDER / session_idf
+        else Path(directory) / settings.SACCADES_FOLDER / str(sid)
     )
     directory.mkdir(parents=True, exist_ok=True)
 
@@ -99,7 +93,7 @@ def save_events_data(
     events = data_copy.events.frame.filter(pl.col("name") == event_type)
 
     for group in events.partition_by(split_column):
-        name = f"{session}"
+        name = f"{sid.id_no_postfix}"
         for col in name_columns:
             if col not in group.columns:
                 raise ValueError(f"Column {col} not found in events data.")
@@ -111,24 +105,20 @@ def save_events_data(
         df.write_csv(directory / name)
 
 
-def save_scanpaths(
-    directory: Path, session: str, session_idf: str, data: pm.Gaze
-) -> None:
+def save_scanpaths(directory: Path, sid: Sid, data: pm.Gaze) -> None:
     """
     Saves scanpaths in separate csv files per trial.
 
     Parameters
     ----------
     directory : Path
-        The directory where the scanpaths should be stored.
-    session : str
-        The name of the session (used for filenames).
-    session_idf : str
-        The full session identifier (used for folder names).
+        The base directory for preprocessed data.
+    sid : Sid
+        The session identifier.
     data : pm.Gaze
         The gaze data as a pymovements Gaze object.
     """
-    directory = Path(directory) / settings.SCANPATHS_FOLDER / session_idf
+    directory = Path(directory) / settings.SCANPATHS_FOLDER / str(sid)
     directory.mkdir(parents=True, exist_ok=True)
 
     new_data = data.clone()
@@ -151,7 +141,7 @@ def save_scanpaths(
             continue
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]
-        name = f"{session}_{trial}_{stimulus}_scanpath.csv"
+        name = f"{sid.id_no_postfix}_{trial}_{stimulus}_scanpath.csv"
 
         df = df[
             "onset",
@@ -175,24 +165,20 @@ def save_scanpaths(
         df.write_csv(directory / name)
 
 
-def save_reading_measures(
-    directory: Path, session: str, session_idf: str, data: pl.DataFrame
-) -> None:
+def save_reading_measures(directory: Path, sid: Sid, data: pl.DataFrame) -> None:
     """
     Saves reading measures in separate csv files per trial.
 
     Parameters
     ----------
     directory : Path
-        The directory where the reading measures should be stored.
-    session : str
-        The name of the session (used for filenames).
-    session_idf : str
-        The full session identifier (used for folder names).
+        The base directory for preprocessed data.
+    sid : Sid
+        The session identifier.
     data : pl.DataFrame
         The reading measures as a polars DataFrame.
     """
-    directory = Path(directory) / settings.READING_MEASURES_FOLDER / session_idf
+    directory = Path(directory) / settings.READING_MEASURES_FOLDER / str(sid)
     directory.mkdir(parents=True, exist_ok=True)
 
     trials = data.partition_by(by="trial", as_dict=False)
@@ -200,25 +186,25 @@ def save_reading_measures(
     for trial in trials:
         trial_id = trial["trial"][0]
         stimulus = trial["stimulus"][0]
-        name = f"{session}_{trial_id}_{stimulus}_reading_measures.csv"
+        name = f"{sid.id_no_postfix}_{trial_id}_{stimulus}_reading_measures.csv"
         trial = trial.drop("stimulus", "trial")
         trial.write_csv(directory / name)
 
 
-def save_session_metadata(directory: Path, gaze: pm.Gaze, session_idf: str) -> None:
+def save_session_metadata(directory: Path, gaze: pm.Gaze, sid: Sid) -> None:
     """
     Saves session metadata in a json file and also saves the gaze object's metadata.
 
     Parameters
     ----------
     directory : Path
-        The directory where the metadata should be stored.
+        The base directory for preprocessed data.
     gaze : pm.Gaze
         The gaze data as a pymovements Gaze object.
-    session_idf : str
-        The full session identifier (used for folder names).
+    sid : Sid
+        The session identifier.
     """
-    metadata_directory = Path(directory) / settings.METADATA_FOLDER / session_idf
+    metadata_directory = Path(directory) / settings.METADATA_FOLDER / str(sid)
     metadata_directory.mkdir(parents=True, exist_ok=True)
 
     metadata = gaze._metadata

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -74,15 +74,14 @@ def run_preprocessing(config_path: str | None = None):
 
     for sess in (pbar := tqdm(sessions)):
         idf = sess.session_identifier
-        # Use Sid to get a consistent session name for file names, excluding restart postfixes
-        session_save_name = Sid.get_session_save_name(idf)
+        sid = Sid(idf)
 
         pbar.set_description(f"Preprocessing session {idf}:")
 
         asc = sess.asc_path
 
         # create or load raw data
-        raw_data_folder = settings.OUTPUT_DIR / settings.RAW_DATA_FOLDER / idf
+        raw_data_folder = settings.OUTPUT_DIR / settings.RAW_DATA_FOLDER / str(sid)
         if raw_data_folder.exists() and not settings.OVERWRITE:
             # check if the folder contains the expected number of files, if not, we will overwrite
             num_expected_files = len(sess.completed_stimuli_ids)
@@ -96,7 +95,7 @@ def run_preprocessing(config_path: str | None = None):
             pbar.set_description(f"Loading samples {idf}:")
             gaze = preprocessing.load_trial_level_raw_data(
                 settings.OUTPUT_DIR,
-                idf,
+                sid,
                 trial_columns=settings.TRIAL_COLS,
                 load_metadata=True,
             )
@@ -106,7 +105,7 @@ def run_preprocessing(config_path: str | None = None):
             gaze = preprocessing.load_gaze_data(
                 asc_file=asc,
                 lab_config=sess.lab_config,
-                session_idf=idf,
+                sid=sid,
                 trial_cols=settings.TRIAL_COLS,
             )
 
@@ -116,11 +115,11 @@ def run_preprocessing(config_path: str | None = None):
             )
 
             preprocessing.save_raw_data(
-                raw_data_folder,
-                session_save_name,
+                settings.OUTPUT_DIR,
+                sid,
                 gaze,
             )
-            preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, idf)
+            preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, sid)
 
         sess.pm_gaze_metadata = gaze._metadata
         sess.calibrations = gaze.calibrations
@@ -133,8 +132,10 @@ def run_preprocessing(config_path: str | None = None):
         )
 
         # create or load fixation data
-        fixation_data_folder = settings.OUTPUT_DIR / settings.FIXATIONS_FOLDER / idf
-        saccade_data_folder = settings.OUTPUT_DIR / settings.SACCADES_FOLDER / idf
+        fixation_data_folder = (
+            settings.OUTPUT_DIR / settings.FIXATIONS_FOLDER / str(sid)
+        )
+        saccade_data_folder = settings.OUTPUT_DIR / settings.SACCADES_FOLDER / str(sid)
 
         if (
             fixation_data_folder.exists()
@@ -162,7 +163,7 @@ def run_preprocessing(config_path: str | None = None):
             gaze = preprocessing.load_trial_level_events_data(
                 gaze,
                 settings.OUTPUT_DIR,
-                idf,
+                sid,
                 event_type=settings.FIXATION,
                 file_pattern=None,
             )
@@ -170,7 +171,7 @@ def run_preprocessing(config_path: str | None = None):
             gaze = preprocessing.load_trial_level_events_data(
                 gaze,
                 settings.OUTPUT_DIR,
-                idf,
+                sid,
                 event_type=settings.SACCADE,
                 file_pattern=None,
             )
@@ -184,8 +185,7 @@ def run_preprocessing(config_path: str | None = None):
             preprocessing.save_events_data(
                 settings.FIXATION,
                 settings.OUTPUT_DIR,
-                session_save_name,
-                idf,
+                sid,
                 "trial",
                 ["trial", "stimulus"],
                 ["onset", "duration", "location_x", "location_y", "page"],
@@ -195,8 +195,7 @@ def run_preprocessing(config_path: str | None = None):
             preprocessing.save_events_data(
                 settings.SACCADE,
                 settings.OUTPUT_DIR,
-                session_save_name,
-                idf,
+                sid,
                 "trial",
                 ["trial", "stimulus"],
                 [
@@ -215,11 +214,11 @@ def run_preprocessing(config_path: str | None = None):
             gaze,
             sess.stimuli,
         )
-        preprocessing.save_scanpaths(settings.OUTPUT_DIR, session_save_name, idf, gaze)
+        preprocessing.save_scanpaths(settings.OUTPUT_DIR, sid, gaze)
 
-        preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, idf)
+        preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, sid)
 
-        rm_folder = settings.OUTPUT_DIR / settings.READING_MEASURES_FOLDER / idf
+        rm_folder = settings.OUTPUT_DIR / settings.READING_MEASURES_FOLDER / str(sid)
 
         if rm_folder.exists() and not settings.OVERWRITE:
             # check if the folder contains the expected number of files, if not, we will overwrite
@@ -234,7 +233,7 @@ def run_preprocessing(config_path: str | None = None):
             pbar.set_description(f"Loading reading measures {idf}:")
             reading_measures = preprocessing.load_reading_measures(
                 settings.OUTPUT_DIR,
-                idf,
+                sid,
             )
 
             data_collection[sess.session_identifier].reading_measures = True
@@ -247,7 +246,7 @@ def run_preprocessing(config_path: str | None = None):
             )
 
             preprocessing.save_reading_measures(
-                settings.OUTPUT_DIR, session_save_name, idf, reading_measures
+                settings.OUTPUT_DIR, sid, reading_measures
             )
             data_collection[sess.session_identifier].reading_measures = True
 

--- a/tests/unit/data_collection/test_edf2asc_conversion.py
+++ b/tests/unit/data_collection/test_edf2asc_conversion.py
@@ -102,3 +102,85 @@ def test_convert_edf_to_asc_conversion_logic(
                 assert mock_run.call_args[0][0][0] == "edf2asc"
             else:
                 mock_run.assert_not_called()
+
+
+def test_convert_edf_to_asc_conversion_failure(data_collection, mock_session):
+    """Test error handling when ASC file is not created after conversion."""
+    output_dir = Path("/fake/output")
+    asc_folder = Path("asc")
+
+    with patch(
+        "preprocessing.data_collection.multipleye_data_collection.settings"
+    ) as mock_settings:
+        mock_settings.OUTPUT_DIR = output_dir
+        mock_settings.ASC_FOLDER = asc_folder
+        mock_settings.FORCE_RECONVERT_ASC = False
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/edf2asc"),
+            patch.object(Path, "exists", return_value=False),
+            patch("subprocess.run"),
+            patch("shutil.copy2") as mock_copy,
+            patch.object(Path, "mkdir"),
+            patch(
+                "preprocessing.data_collection.multipleye_data_collection.tqdm",
+                side_effect=lambda x, **kwargs: x,
+            ),
+        ):
+            data_collection.convert_edf_to_asc()
+
+            data_collection.logger.error.assert_called_once_with(
+                "Failed to convert EDF to ASC for S001"
+            )
+            mock_copy.assert_not_called()
+
+
+def test_convert_edf_to_asc_postfix_identifier():
+    """Test session identifiers with postfixes are preserved in ASC folder paths."""
+    postfix_session_id = "001_EN_UK_1_ET1_start_after_trial_4"
+    output_dir = Path("/fake/output")
+    asc_folder = Path("asc")
+    expected_asc_path = (
+        output_dir / asc_folder / postfix_session_id / f"{postfix_session_id}.asc"
+    )
+
+    mock_ses = MagicMock(spec=Session)
+    mock_ses.session_file_path = Path("/fake/data/001/001.edf")
+
+    with patch("preprocessing.data_collection.multipleye_data_collection.get_logger"):
+        dc = MultipleyeDataCollection.__new__(MultipleyeDataCollection)
+        dc.sessions = {postfix_session_id: mock_ses}
+        dc.eye_tracker = "eyelink"
+        dc.logger = MagicMock()
+
+    def exists_side_effect(self_path):
+        path_str = str(self_path)
+        if path_str == str(expected_asc_path):
+            return False  # output asc missing, trigger conversion
+        if path_str.endswith(".asc"):
+            return True  # local asc exists after conversion
+        return False
+
+    with patch(
+        "preprocessing.data_collection.multipleye_data_collection.settings"
+    ) as mock_settings:
+        mock_settings.OUTPUT_DIR = output_dir
+        mock_settings.ASC_FOLDER = asc_folder
+        mock_settings.FORCE_RECONVERT_ASC = False
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/edf2asc"),
+            patch.object(Path, "exists", autospec=True) as mock_exists,
+            patch("subprocess.run"),
+            patch("shutil.copy2"),
+            patch.object(Path, "mkdir"),
+            patch(
+                "preprocessing.data_collection.multipleye_data_collection.tqdm",
+                side_effect=lambda x, **kwargs: x,
+            ),
+        ):
+            mock_exists.side_effect = exists_side_effect
+
+            dc.convert_edf_to_asc()
+
+            assert mock_ses.asc_path == expected_asc_path

--- a/tests/unit/preprocessing/io/test_output_structure.py
+++ b/tests/unit/preprocessing/io/test_output_structure.py
@@ -14,6 +14,14 @@ from preprocessing.io.load import (
     load_reading_measures,
 )
 from preprocessing.config import settings
+from preprocessing.models.sid import Sid
+
+SID_STRINGS = ["001_EN_UK_1_S1", "017_DA_DK_1_ET1_start_after_trial_3"]
+
+EVENT_FOLDERS = {
+    "fixation": settings.FIXATIONS_FOLDER,
+    "saccade": settings.SACCADES_FOLDER,
+}
 
 
 @pytest.fixture
@@ -68,99 +76,80 @@ def dummy_gaze():
     return gaze
 
 
-def test_save_load_raw_data_structure(tmp_path, dummy_gaze):
-    session = "test_session"
-    raw_data_folder = tmp_path / settings.RAW_DATA_FOLDER / session
-    save_raw_data(raw_data_folder, session, dummy_gaze)
-    assert raw_data_folder.exists()
-    assert (raw_data_folder / f"{session}_trial_1_Enc_WikiMoon_1_raw_data.csv").exists()
+@pytest.mark.parametrize("sid_str", SID_STRINGS)
+def test_save_load_raw_data_structure(tmp_path, dummy_gaze, sid_str):
+    sid = Sid(sid_str)
+    save_raw_data(tmp_path, sid, dummy_gaze)
+    expected_path = tmp_path / settings.RAW_DATA_FOLDER / str(sid)
+    assert expected_path.exists()
+    assert (
+        expected_path / f"{sid.id_no_postfix}_trial_1_Enc_WikiMoon_1_raw_data.csv"
+    ).exists()
 
     loaded_gaze = load_trial_level_raw_data(
-        tmp_path, session, trial_columns=["trial", "stimulus", "page"]
+        tmp_path, sid, trial_columns=["trial", "stimulus", "page"]
     )
     assert len(loaded_gaze.samples) == 3
 
 
-def test_save_load_fixations_structure(tmp_path, dummy_gaze):
-    session = "test_session"
-    session_idf = "001_EN_UK_1_S1"
+@pytest.mark.parametrize("event_type", ["fixation", "saccade"])
+@pytest.mark.parametrize("sid_str", SID_STRINGS)
+def test_save_load_events_structure(tmp_path, dummy_gaze, event_type, sid_str):
+    sid = Sid(sid_str)
     save_events_data(
-        "fixation",
+        event_type,
         tmp_path,
-        session,
-        session_idf,
+        sid,
         "trial",
         ["stimulus"],
         ["name", "start", "end", "trial", "stimulus", "page"],
         dummy_gaze,
     )
-    expected_path = tmp_path / settings.FIXATIONS_FOLDER / session_idf
+    expected_path = tmp_path / EVENT_FOLDERS[event_type] / str(sid)
     assert expected_path.exists()
-    assert (expected_path / f"{session}_Enc_WikiMoon_1_fixation.csv").exists()
+    assert (
+        expected_path / f"{sid.id_no_postfix}_Enc_WikiMoon_1_{event_type}.csv"
+    ).exists()
 
-    loaded_gaze = load_trial_level_events_data(
-        dummy_gaze, tmp_path, session_idf, "fixation"
-    )
-    assert len(loaded_gaze.events.frame.filter(pl.col("name") == "fixation")) >= 1
+    loaded_gaze = load_trial_level_events_data(dummy_gaze, tmp_path, sid, event_type)
+    assert len(loaded_gaze.events.frame.filter(pl.col("name") == event_type)) >= 1
 
 
-def test_save_load_saccades_structure(tmp_path, dummy_gaze):
-    session = "test_session"
-    session_idf = "001_EN_UK_1_S1"
-    save_events_data(
-        "saccade",
-        tmp_path,
-        session,
-        session_idf,
-        "trial",
-        ["stimulus"],
-        ["name", "start", "end", "trial", "stimulus", "page"],
-        dummy_gaze,
-    )
-    expected_path = tmp_path / settings.SACCADES_FOLDER / session_idf
+@pytest.mark.parametrize("sid_str", SID_STRINGS)
+def test_save_scanpaths_structure(tmp_path, dummy_gaze, sid_str):
+    sid = Sid(sid_str)
+    save_scanpaths(tmp_path, sid, dummy_gaze)
+    expected_path = tmp_path / settings.SCANPATHS_FOLDER / str(sid)
     assert expected_path.exists()
-    assert (expected_path / f"{session}_Enc_WikiMoon_1_saccade.csv").exists()
-
-    loaded_gaze = load_trial_level_events_data(
-        dummy_gaze, tmp_path, session_idf, "saccade"
-    )
-    assert len(loaded_gaze.events.frame.filter(pl.col("name") == "saccade")) >= 1
+    assert (
+        expected_path / f"{sid.id_no_postfix}_trial_1_Enc_WikiMoon_1_scanpath.csv"
+    ).exists()
 
 
-def test_save_scanpaths_structure(tmp_path, dummy_gaze):
-    session = "test_session"
-    session_idf = "001_EN_UK_1_S1"
-    save_scanpaths(tmp_path, session, session_idf, dummy_gaze)
-    expected_path = tmp_path / settings.SCANPATHS_FOLDER / session_idf
-    assert expected_path.exists()
-    assert (expected_path / f"{session}_trial_1_Enc_WikiMoon_1_scanpath.csv").exists()
-
-
-def test_save_load_reading_measures_structure(tmp_path):
-    session = "test_session"
-    session_idf = "001_EN_UK_1_S1"
+@pytest.mark.parametrize("sid_str", SID_STRINGS)
+def test_save_load_reading_measures_structure(tmp_path, sid_str):
+    sid = Sid(sid_str)
     df_rm = pl.DataFrame(
         {"trial": ["trial_1"], "stimulus": ["Enc_WikiMoon_1"], "val": [1.0]}
     )
-    save_reading_measures(tmp_path, session, session_idf, df_rm)
-    expected_path = tmp_path / settings.READING_MEASURES_FOLDER / session_idf
+    save_reading_measures(tmp_path, sid, df_rm)
+    expected_path = tmp_path / settings.READING_MEASURES_FOLDER / str(sid)
     assert expected_path.exists()
     assert (
-        expected_path / f"{session}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
+        expected_path
+        / f"{sid.id_no_postfix}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
     ).exists()
 
-    loaded_rm = load_reading_measures(tmp_path, session_idf)
+    loaded_rm = load_reading_measures(tmp_path, sid)
     assert len(loaded_rm) == 1
 
 
-def test_save_load_metadata_structure(tmp_path, dummy_gaze):
-    session = "test_session"
-    session_idf = "001_EN_UK_1_S1"
-    raw_data_folder = tmp_path / settings.RAW_DATA_FOLDER / session_idf
-    # First save raw data because load_trial_level_raw_data expects it
-    save_raw_data(raw_data_folder, session, dummy_gaze)
-    save_session_metadata(tmp_path, dummy_gaze, session_idf)
-    expected_path = tmp_path / settings.METADATA_FOLDER / session_idf
+@pytest.mark.parametrize("sid_str", SID_STRINGS)
+def test_save_load_metadata_structure(tmp_path, dummy_gaze, sid_str):
+    sid = Sid(sid_str)
+    save_raw_data(tmp_path, sid, dummy_gaze)
+    save_session_metadata(tmp_path, dummy_gaze, sid)
+    expected_path = tmp_path / settings.METADATA_FOLDER / str(sid)
     assert expected_path.exists()
     assert (expected_path / "gaze_metadata.json").exists()
     assert (expected_path / "calibrations.feather").exists()
@@ -175,7 +164,7 @@ def test_save_load_metadata_structure(tmp_path, dummy_gaze):
 
     loaded_gaze = load_trial_level_raw_data(
         tmp_path,
-        session_idf,
+        sid,
         trial_columns=["trial", "stimulus", "page"],
         load_metadata=True,
     )
@@ -184,15 +173,16 @@ def test_save_load_metadata_structure(tmp_path, dummy_gaze):
     assert len(loaded_gaze.validations) > 0
 
 
-def test_save_events_data_invalid_event_type(tmp_path, dummy_gaze):
+@pytest.mark.parametrize("invalid_type", ["", "blinks", "INVALID"])
+def test_save_events_data_invalid_event_type(tmp_path, dummy_gaze, invalid_type):
+    sid = Sid("001_EN_UK_1_S1")
     with pytest.raises(
         ValueError, match="Only fixations and saccades are currently supported"
     ):
         save_events_data(
-            "invalid_event",
+            invalid_type,
             tmp_path,
-            "session",
-            "session_idf",
+            sid,
             "trial",
             ["stimulus"],
             ["name"],
@@ -200,24 +190,25 @@ def test_save_events_data_invalid_event_type(tmp_path, dummy_gaze):
         )
 
 
-def test_load_trial_level_events_data_invalid_event_type(tmp_path, dummy_gaze):
+@pytest.mark.parametrize("invalid_type", ["", "blinks", "INVALID"])
+def test_load_trial_level_events_data_invalid_event_type(
+    tmp_path, dummy_gaze, invalid_type
+):
+    sid = Sid("001_EN_UK_1_S1")
     with pytest.raises(ValueError, match="event_type must be "):
-        load_trial_level_events_data(
-            dummy_gaze, tmp_path, "session_idf", "invalid_event"
-        )
+        load_trial_level_events_data(dummy_gaze, tmp_path, sid, invalid_type)
 
 
 def test_load_reading_measures_with_actual_filenames(tmp_path):
-    # Setup: Create dummy reading measures files with the reported naming convention
-    session = "017_DA_DK_1_ET1"
-    reading_measures_dir = tmp_path / settings.READING_MEASURES_FOLDER / session
+    sid = Sid("017_DA_DK_1_ET1")
+    reading_measures_dir = tmp_path / settings.READING_MEASURES_FOLDER / str(sid)
     reading_measures_dir.mkdir(parents=True)
 
     # Files as reported in the issue
     filenames = [
-        f"{session}_PRACTICE_trial_1_Enc_WikiMoon_reading_measures.csv",
-        f"{session}_trial_1_Lit_MagicMountain_reading_measures.csv",
-        f"{session}_trial_5_PopSci_MultiplEYE_reading_measures.csv",
+        f"{sid.id_no_postfix}_PRACTICE_trial_1_Enc_WikiMoon_reading_measures.csv",
+        f"{sid.id_no_postfix}_trial_1_Lit_MagicMountain_reading_measures.csv",
+        f"{sid.id_no_postfix}_trial_5_PopSci_MultiplEYE_reading_measures.csv",
     ]
 
     for filename in filenames:
@@ -225,7 +216,7 @@ def test_load_reading_measures_with_actual_filenames(tmp_path):
         df.write_csv(reading_measures_dir / filename)
 
     # Test loading
-    df_loaded = load_reading_measures(tmp_path, session)
+    df_loaded = load_reading_measures(tmp_path, sid)
 
     assert len(df_loaded) == 3
     assert set(df_loaded["trial"].unique()) == {

--- a/tests/unit/preprocessing/io/test_output_structure.py
+++ b/tests/unit/preprocessing/io/test_output_structure.py
@@ -184,6 +184,29 @@ def test_save_load_metadata_structure(tmp_path, dummy_gaze):
     assert len(loaded_gaze.validations) > 0
 
 
+def test_save_events_data_invalid_event_type(tmp_path, dummy_gaze):
+    with pytest.raises(
+        ValueError, match="Only fixations and saccades are currently supported"
+    ):
+        save_events_data(
+            "invalid_event",
+            tmp_path,
+            "session",
+            "session_idf",
+            "trial",
+            ["stimulus"],
+            ["name"],
+            dummy_gaze,
+        )
+
+
+def test_load_trial_level_events_data_invalid_event_type(tmp_path, dummy_gaze):
+    with pytest.raises(ValueError, match="event_type must be "):
+        load_trial_level_events_data(
+            dummy_gaze, tmp_path, "session_idf", "invalid_event"
+        )
+
+
 def test_load_reading_measures_with_actual_filenames(tmp_path):
     # Setup: Create dummy reading measures files with the reported naming convention
     session = "017_DA_DK_1_ET1"

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -181,6 +181,40 @@ def test_sid_base_id():
 
 
 @pytest.mark.parametrize(
+    "sid_str, expected_no_postfix",
+    [
+        ("001_EN_UK_1_PT1", "001_EN_UK_1_PT1"),
+        ("002_ZH_CH_LAB2_S2_restart", "002_ZH_CH_LAB2_S2"),
+        ("003_DE_DE_1_ET1_full_restart", "003_DE_DE_1_ET1"),
+        (
+            "004_FR_FR_1_PT1_start_after_trial_10",
+            "004_FR_FR_1_PT1",
+        ),
+    ],
+)
+def test_sid_id_no_postfix(sid_str, expected_no_postfix):
+    assert Sid(sid_str).id_no_postfix == expected_no_postfix
+
+
+@pytest.mark.parametrize(
+    "session_idf, expected_save_name",
+    [
+        ("001_EN_UK_1_PT1", "001_EN_UK_1_PT1"),
+        ("002_ZH_CH_LAB2_S2_restart", "002_ZH_CH_LAB2_S2"),
+        ("003_DE_DE_1_ET1_full_restart", "003_DE_DE_1_ET1"),
+        (
+            "004_FR_FR_1_PT1_start_after_trial_10",
+            "004_FR_FR_1_PT1",
+        ),
+        ("non_compliant_id_extra_part", "non_compliant_id_extra_part"),
+        ("short", "short"),
+    ],
+)
+def test_sid_get_session_save_name(session_idf, expected_save_name):
+    assert Sid.get_session_save_name(session_idf) == expected_save_name
+
+
+@pytest.mark.parametrize(
     "sid1_str, sid2_str, expected_match",
     [
         ("001_EN_UK_1_S1", "001_EN_UK_1_PT1", True),

--- a/tests/unit/preprocessing/test_config.py
+++ b/tests/unit/preprocessing/test_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import logging
 import pytest
 import yaml
@@ -18,6 +20,10 @@ def settings_obj():
         ("EXPECTED_SAMPLING_RATE_HZ", 1000),
         ("FIXATION", "fixation"),
         ("SACCADE", "saccade"),
+        ("ASC_FOLDER", Path("asc/")),
+        ("FORCE_RECONVERT_ASC", False),
+        ("SANITY_CHECKS_FOLDER", Path("sanity_checks/")),
+        ("METADATA_FOLDER", Path("metadata/")),
     ],
 )
 def test_settings_default_values(settings_obj, attr, expected):

--- a/tests/unit/scripts/test_run_multipleye_preprocessing.py
+++ b/tests/unit/scripts/test_run_multipleye_preprocessing.py
@@ -3,38 +3,47 @@
 from pathlib import Path
 
 
-def test_reading_measures_check_uses_session_save_name():
-    """Test that reading measures folder check uses session_save_name, not session_idf.
+def test_reading_measures_uses_sid_consistently():
+    """Test that reading measures check and save use the same Sid instance.
 
-    This test verifies the bug fix where the check for existing reading measures
-    was using `output_folder` (per-session directory with full idf) but save was using
-    `session_save_name` (which differs when sessions have _restart suffixes).
-
-    When session_idf = "001_ET_EE_1_ET1_restart_1" and session_save_name = "001_ET_EE_1_ET1",
-    the check should use session_save_name to match what save uses.
+    The Sid refactoring ensures `str(sid)` is used for folder names and
+    `sid.id_no_postfix` for filenames, eliminating the old bug where
+    folder checks used a different identifier than saves.
     """
     source_file = Path("preprocessing/scripts/run_preprocessing.py")
     source_code = source_file.read_text()
 
     lines = source_code.split("\n")
 
-    output_folder_line = None
+    rm_folder_line = None
     save_reading_measures_line = None
 
     for i, line in enumerate(lines):
-        if "settings.READING_MEASURES_FOLDER / idf" in line:
-            output_folder_line = i
+        if "settings.READING_MEASURES_FOLDER / str(sid)" in line:
+            rm_folder_line = i
         if "preprocessing.save_reading_measures(" in line:
             save_reading_measures_line = i
 
-    assert output_folder_line is not None, "Could not find rm_folder check line"
+    assert rm_folder_line is not None, "Could not find rm_folder check line"
     assert save_reading_measures_line is not None, (
         "Could not find save_reading_measures call"
     )
 
-    context_around_check = "\n".join(lines[output_folder_line : output_folder_line + 5])
+    assert rm_folder_line < save_reading_measures_line, (
+        "rm_folder check should be defined before the save call"
+    )
 
-    assert "idf" in context_around_check, (
-        "The check for existing reading measures should use idf (full session identifier) for the folder. "
-        f"Found:\n{context_around_check}\n\nExpected 'idf' in the check."
+
+def test_sid_is_single_instance_per_session():
+    """Test that only one Sid is created per session (no repeated parsing).
+
+    Sid should be constructed once per session loop iteration, not
+    re-constructed inside each helper function call.
+    """
+    source_file = Path("preprocessing/scripts/run_preprocessing.py")
+    source_code = source_file.read_text()
+
+    sid_assignment_count = source_code.count("sid = Sid(")
+    assert sid_assignment_count == 1, (
+        f"Expected exactly 1 Sid assignment in run_preprocessing, found {sid_assignment_count}"
     )


### PR DESCRIPTION
Refactors all IO save/load functions to accept `Sid` objects instead of raw string session identifiers. This eliminates the ambiguity between `session` (stripped), `session_idf`/`idf` (full identifier), and `directory` (pre-built path). All callers now pass a single `Sid` instance, and the functions internally use `str(sid)` for folder names and `sid.id_no_postfix` for file names.

### Refactoring (save.py, load.py, run_preprocessing.py):
- All `save_*` functions: replace `session: str` parameter with `sid: Sid`
- All `load_*` functions: replace `session: str` / `idf: str` parameter with `sid: Sid`
- `run_preprocessing.py`: create `sid = Sid(idf)` once per session loop, passes sid everywhere. No more `session_save_name` string preparation.
- Removed dead `_get_session_save_name` method from `multipleye_data_collection.py`

### Added Tests:
- `test_output_structure.py`: merge fixations/saccades tests into one parametrized test
- `test_run_multipleye_preprocessing.py`: rewritten to verify Sid consistency
- `test_sid.py`: add `test_sid_id_no_postfix` cases and `test_sid_get_session_save_name` cases
- `test_config.py`: add `ASC_FOLDER`, `FORCE_RECONVERT_ASC`, `SANITY_CHECKS_FOLDER`, `METADATA_FOLDER` to default settings test
- `test_edf2asc_conversion.py`: add error logging and postfix handling