### PR TITLE
chore: Trigger docs rebuild after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.repository_owner == 'MultiplEYE-COST'
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout code
@@ -70,6 +71,18 @@ jobs:
             git commit -m "chore: bump version to ${{ steps.date.outputs.today }}"
             git push origin main
           fi
+
+      - name: Trigger documentation rebuild
+        if: steps.check_tag.outputs.exists == 'false' && steps.check_changes.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docs.yml',
+              ref: 'main',
+            });
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false' && steps.check_changes.outputs.has_changes == 'true'


### PR DESCRIPTION
Currently, after the release version update, the GitHub Pages are not updated, resulting in an outdated version number in the docs, even though it has all changes of the current release.

- Add `actions: write` permission to the release job
- After the version bump push, use `actions/github-script@v7` to dispatch the `docs.yml` workflow via `workflow_dispatch`
- This ensures GitHub Pages is rebuilt after each automated CalVer release