### PR TITLE
feat: Add preflight input file check pipeline stage

### DIFF
--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -7,6 +7,7 @@ consolidated error instead of triggering mid-loop failures one at a time.
 
 from __future__ import annotations
 
+import fnmatch
 import os
 import sys
 from pathlib import Path
@@ -118,8 +119,8 @@ def run_preflight_check(data_collection) -> None:
 
 
 def _require_file(path: Path, label: str, groups: dict[str, list[str]]) -> None:
-    """Record a missing file or directory."""
-    if not path.exists():
+    """Record a missing file or directory (case-insensitive existence check)."""
+    if not _ci_exists(path):
         groups.setdefault(label, []).append(str(path))
 
 
@@ -129,9 +130,100 @@ def _require_glob(
     label: str,
     groups: dict[str, list[str]],
 ) -> None:
-    """Record if no files match a glob pattern in the given directory."""
-    if not list(directory.glob(pattern)):
+    """Record if no files match a glob pattern (case-insensitive)."""
+    if not _ci_glob(directory, pattern):
         groups.setdefault(label, []).append(str(directory / pattern))
+
+
+def _ci_exists(path: Path) -> bool:
+    """Check if a path exists, falling back to case-insensitive comparison."""
+    if path.exists():
+        return True
+    parent = path.parent
+    if not parent.exists():
+        return False
+    try:
+        entries = os.listdir(parent)
+    except OSError:
+        return False
+    target = path.name.casefold()
+    return any(entry.casefold() == target for entry in entries)
+
+
+def _ci_resolve(path: Path) -> Path:
+    """Resolve a path to its actual on-disk spelling (case correction)."""
+    if path.exists():
+        return path
+    parent = path.parent
+    if not parent.exists():
+        return path
+    try:
+        entries = os.listdir(parent)
+    except OSError:
+        return path
+    target = path.name.casefold()
+    for entry in entries:
+        if entry.casefold() == target:
+            return parent / entry
+    return path
+
+
+def _ci_glob(directory: Path, pattern: str) -> list[Path]:
+    """Case-insensitive glob, returning actual on-disk paths."""
+    if not directory.exists():
+        return []
+    try:
+        entries = os.listdir(directory)
+    except OSError:
+        return []
+    pattern_cf = pattern.casefold()
+    return [
+        directory / entry
+        for entry in entries
+        if fnmatch.fnmatch(entry.casefold(), pattern_cf)
+    ]
+
+
+def _find_archives(directory: Path) -> list[str]:
+    """Find common archive files in the given directory."""
+    patterns = ["*.zip", "*.tar.gz", "*.tar", "*.tgz", "*.7z", "*.rar"]
+    archives: list[str] = []
+    for pattern in patterns:
+        for p in _ci_glob(directory, pattern):
+            archives.append(p.name)
+    return archives
+
+
+def _stim_dir_empty_check(stim_dir: Path, groups: dict[str, list[str]]) -> bool:
+    """Check the stimulus directory is usable.
+
+    Returns True if usable, False if missing or empty
+    (caller can skip further shared-file checks).
+    """
+    if not _ci_exists(stim_dir):
+        groups.setdefault("Stimulus folder", []).append(
+            f"Stimulus folder does not exist: {stim_dir}"
+        )
+        return False
+
+    try:
+        entries = [e for e in os.listdir(stim_dir) if not e.startswith(".")]
+    except OSError:
+        entries = []
+
+    if not entries:
+        msg = f"Stimulus folder is empty: {stim_dir}"
+        archives = _find_archives(stim_dir.parent)
+        if archives:
+            archive_list = ", ".join(sorted(archives))
+            msg += (
+                f"\n  Found archive(s) in parent directory: {archive_list}"
+                f"\n  Extract the archive into the stimulus folder first."
+            )
+        groups.setdefault("Stimulus folder", []).append(msg)
+        return False
+
+    return True
 
 
 def _check_shared_files(
@@ -149,6 +241,10 @@ def _check_shared_files(
 
     lang_lower = lang.lower()
     country_lower = country.lower()
+
+    # --- Stimulus directory empty check -----------------------------------
+    if not _stim_dir_empty_check(stim_dir, errors):
+        return
 
     # --- Stimulus definition files (errors) -------------------------------
     _require_file(
@@ -228,22 +324,22 @@ def _check_sessions(data_collection, groups: dict[str, list[str]]) -> None:
         sid = session.session_identifier
 
         # 1. EDF data file
-        if not session.session_file_path.exists():
+        if not _ci_exists(session.session_file_path):
             groups.setdefault("EDF data file", []).append(sid)
 
         # 2. Logfiles folder
         logfiles: Path = session.session_folder_path / "logfiles"
-        if not logfiles.exists():
+        if not _ci_exists(logfiles):
             groups.setdefault("Logfiles folder", []).append(sid)
             continue
 
         # 3. EXPERIMENT_*.txt
-        experiment_logs = list(logfiles.glob("EXPERIMENT_*.txt"))
+        experiment_logs = _ci_glob(logfiles, "EXPERIMENT_*.txt")
         if len(experiment_logs) == 0:
             groups.setdefault("EXPERIMENT_*.txt", []).append(sid)
 
         # 4. GENERAL_LOGFILE_*.txt
-        general_logs = list(logfiles.glob("GENERAL_LOGFILE_*.txt"))
+        general_logs = _ci_glob(logfiles, "GENERAL_LOGFILE_*.txt")
         if len(general_logs) == 0:
             groups.setdefault("GENERAL_LOGFILE_*.txt", []).append(sid)
 
@@ -273,13 +369,13 @@ def _check_parseable_csv(
     sid: str,
     required_cols: set[str],
 ) -> None:
-    """Check a CSV exists, is parseable, and has the expected columns."""
-    if not path.exists():
+    """Check a CSV exists, is parseable, and has the expected columns (case-insensitive)."""
+    if not _ci_exists(path):
         groups.setdefault(label, []).append(f"{sid} (missing)")
         return
 
     try:
-        df = pl.read_csv(path, infer_schema_length=0)
+        df = pl.read_csv(_ci_resolve(path), infer_schema_length=0)
     except Exception as e:
         groups.setdefault(label, []).append(f"{sid} ({e})")
         return
@@ -316,11 +412,14 @@ def _format_message(groups: dict[str, list[str]]) -> str:
         for path in groups[label]:
             lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
 
-    # Image folders (shared, but with dynamic names)
+    # Image folders and stimulus folder (shared, with dynamic messages)
     for label in list(groups.keys()):
         if label.startswith("Image folder:"):
             for path in groups[label]:
                 lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
+    if "Stimulus folder" in groups:
+        for msg in groups["Stimulus folder"]:
+            lines.append(f"\n  {msg}")
 
     # Per-session file-type groups
     for label in [

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -1,0 +1,341 @@
+"""Preflight input file validation for the preprocessing pipeline.
+
+Verifies all required input files exist and are parseable for each session
+*before* any processing begins, so that missing files are caught in one
+consolidated error instead of triggering mid-loop failures one at a time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import polars as pl
+
+from ..utils.logging import get_logger
+
+logger = get_logger()
+
+# Expected columns for format validation
+COMPLETED_STIMULI_COLS = {"stimulus_id", "stimulus_name", "trial_id", "completed"}
+QUESTION_ORDER_COLS = {
+    "question_order_version",
+    "local_question_1",
+    "local_question_2",
+    "bridging_question_1",
+    "bridging_question_2",
+    "global_question_1",
+    "global_question_2",
+}
+
+
+class PreflightError(Exception):
+    """Raised with ALL preflight failures consolidated."""
+
+    def __init__(self, groups: dict[str, list[str]]) -> None:
+        self.groups = groups
+        self.num_errors = sum(len(v) for v in groups.values())
+        self._message = _format_message(groups)
+        super().__init__(self._message)
+
+    def __str__(self) -> str:
+        return self._message
+
+
+def _print_warnings(warnings: dict[str, list[str]]) -> None:
+    """Print a prominent warnings-only banner to stderr."""
+    n_total = sum(len(v) for v in warnings.values())
+    lines: list[str] = [
+        f"\n{'=' * 56}",
+        f"  Preflight check \u2014 {n_total} warning(s)",
+        f"{'=' * 56}",
+    ]
+
+    shared_labels = [
+        "Stimulus definition xlsx",
+        "Comprehension questions xlsx",
+        "Participant instructions CSV",
+        "Config python file",
+        "Lab configuration JSON",
+        "Stimulus order versions CSV",
+        "Metadata form JSON",
+    ]
+    for label in shared_labels:
+        if label not in warnings:
+            continue
+        for path in warnings[label]:
+            lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
+
+    for label in list(warnings.keys()):
+        if label.startswith("Image folder:"):
+            for path in warnings[label]:
+                lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
+
+    print("\n".join(lines), file=sys.stderr)
+
+
+def run_preflight_check(data_collection) -> None:
+    """Verify all required input files exist for the data collection.
+
+    Checks EDF files, logfiles, CSVs, and stimulus definition files
+    across all included sessions.
+
+    Flaky files (those that may legitimately be absent) are logged as
+    warnings.  Hard-required files raise ``PreflightError`` with ALL
+    failures consolidated in a file-type-grouped message.
+
+    Parameters
+    ----------
+    data_collection : MultipleyeDataCollection | MeridDataCollection
+        A data-collection instance whose ``.sessions`` dict is populated.
+    """
+    errors: dict[str, list[str]] = {}
+    warnings: dict[str, list[str]] = {}
+
+    _check_shared_files(data_collection, errors, warnings)
+    _check_skipped_sessions(data_collection, errors)
+    _check_sessions(data_collection, errors)
+
+    if errors:
+        combined = {}
+        combined.update(warnings)
+        combined.update(errors)
+        raise PreflightError(combined)
+
+    if warnings:
+        _print_warnings(warnings)
+        return
+
+    logger.info(
+        f"\n{'=' * 56}\n  Preflight check \u2014 all input files found\n{'=' * 56}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_file(path: Path, label: str, groups: dict[str, list[str]]) -> None:
+    """Record a missing file or directory."""
+    if not path.exists():
+        groups.setdefault(label, []).append(str(path))
+
+
+def _require_glob(
+    directory: Path,
+    pattern: str,
+    label: str,
+    groups: dict[str, list[str]],
+) -> None:
+    """Record if no files match a glob pattern in the given directory."""
+    if not list(directory.glob(pattern)):
+        groups.setdefault(label, []).append(str(directory / pattern))
+
+
+def _check_shared_files(
+    data_collection,
+    errors: dict[str, list[str]],
+    warnings: dict[str, list[str]] | None = None,
+) -> None:
+    """Check files that are shared across all sessions (data-collection level)."""
+    stim_dir = data_collection.stimulus_dir
+    lang = data_collection.language
+    country = data_collection.country
+    labnum = data_collection.lab_number
+    city = data_collection.city
+    year = data_collection.year
+
+    lang_lower = lang.lower()
+    country_lower = country.lower()
+
+    # --- Stimulus definition files (errors) -------------------------------
+    _require_file(
+        stim_dir / f"multipleye_stimuli_experiment_{lang}.xlsx",
+        "Stimulus definition xlsx",
+        errors,
+    )
+    _require_file(
+        stim_dir / f"multipleye_comprehension_questions_{lang}.xlsx",
+        "Comprehension questions xlsx",
+        errors,
+    )
+    _require_file(
+        stim_dir
+        / f"multipleye_participant_instructions_{lang_lower}_with_img_paths.csv",
+        "Participant instructions CSV",
+        errors,
+    )
+
+    # --- Config folder (errors) -------------------------------------------
+    config_dir = stim_dir / "config"
+    _require_glob(
+        config_dir,
+        f"config_{lang_lower}_{country_lower}_*_{labnum}_*.py",
+        "Config python file",
+        errors,
+    )
+    _require_file(
+        config_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_lab_configuration.json",
+        "Lab configuration JSON",
+        errors,
+    )
+    _require_file(
+        config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv",
+        "Stimulus order versions CSV",
+        errors,
+    )
+
+    # --- Image/AOI folders (errors) ---------------------------------------
+    for folder_name in [
+        f"stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_{lang_lower}_{country_lower}_{labnum}",
+        f"question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"participant_instructions_images_{lang_lower}_{country_lower}_{labnum}",
+    ]:
+        _require_file(stim_dir / folder_name, f"Image folder: {folder_name}", errors)
+
+    # --- Image/AOI folders (warnings — flaky, code handles absence) -------
+    _warnings = warnings or {}
+    for folder_name in [
+        f"aoi_stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_question_images_{lang_lower}_{country_lower}_{labnum}",
+    ]:
+        _require_file(stim_dir / folder_name, f"Image folder: {folder_name}", _warnings)
+
+    # --- Documentation folder (warning — flaky, code handles absence) -----
+    doc_dir = stim_dir.parent / "documentation"
+    _require_file(
+        doc_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_metadata_form.json",
+        "Metadata form JSON",
+        _warnings,
+    )
+
+
+def _check_skipped_sessions(data_collection, groups: dict[str, list[str]]) -> None:
+    """Record sessions that were skipped during discovery (missing EDF)."""
+    skipped: list[str] = getattr(data_collection, "skipped_session_ids", [])
+    if skipped:
+        groups["EDF data file"] = sorted(skipped)
+
+
+def _check_sessions(data_collection, groups: dict[str, list[str]]) -> None:
+    """Run per-session input file checks."""
+    for session in data_collection.sessions.values():
+        sid = session.session_identifier
+
+        # 1. EDF data file
+        if not session.session_file_path.exists():
+            groups.setdefault("EDF data file", []).append(sid)
+
+        # 2. Logfiles folder
+        logfiles: Path = session.session_folder_path / "logfiles"
+        if not logfiles.exists():
+            groups.setdefault("Logfiles folder", []).append(sid)
+            continue
+
+        # 3. EXPERIMENT_*.txt
+        experiment_logs = list(logfiles.glob("EXPERIMENT_*.txt"))
+        if len(experiment_logs) == 0:
+            groups.setdefault("EXPERIMENT_*.txt", []).append(sid)
+
+        # 4. GENERAL_LOGFILE_*.txt
+        general_logs = list(logfiles.glob("GENERAL_LOGFILE_*.txt"))
+        if len(general_logs) == 0:
+            groups.setdefault("GENERAL_LOGFILE_*.txt", []).append(sid)
+
+        # 5. completed_stimuli.csv
+        _check_parseable_csv(
+            logfiles / "completed_stimuli.csv",
+            "completed_stimuli.csv",
+            groups,
+            sid,
+            COMPLETED_STIMULI_COLS,
+        )
+
+        # 6. question_order_versions.csv
+        _check_parseable_csv(
+            logfiles / "question_order_versions.csv",
+            "question_order_versions.csv",
+            groups,
+            sid,
+            QUESTION_ORDER_COLS,
+        )
+
+
+def _check_parseable_csv(
+    path: Path,
+    label: str,
+    groups: dict[str, list[str]],
+    sid: str,
+    required_cols: set[str],
+) -> None:
+    """Check a CSV exists, is parseable, and has the expected columns."""
+    if not path.exists():
+        groups.setdefault(label, []).append(f"{sid} (missing)")
+        return
+
+    try:
+        df = pl.read_csv(path, infer_schema_length=0)
+    except Exception as e:
+        groups.setdefault(label, []).append(f"{sid} ({e})")
+        return
+
+    missing_cols = required_cols - set(df.columns)
+    if missing_cols:
+        groups.setdefault(label, []).append(
+            f"{sid} (missing columns: {', '.join(sorted(missing_cols))})"
+        )
+
+
+def _format_message(groups: dict[str, list[str]]) -> str:
+    """Transform the grouped error dict into a human-readable message."""
+    n_total = sum(len(v) for v in groups.values())
+    lines: list[str] = [
+        f"\n{'=' * 56}",
+        f"  Preflight check FAILED \u2014 {n_total} error(s)",
+        f"{'=' * 56}",
+    ]
+
+    # Shared files first (data-collection-level, one path per label)
+    shared_labels = [
+        "Stimulus definition xlsx",
+        "Comprehension questions xlsx",
+        "Participant instructions CSV",
+        "Config python file",
+        "Lab configuration JSON",
+        "Stimulus order versions CSV",
+        "Metadata form JSON",
+    ]
+    for label in shared_labels:
+        if label not in groups:
+            continue
+        for path in groups[label]:
+            lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
+
+    # Image folders (shared, but with dynamic names)
+    for label in list(groups.keys()):
+        if label.startswith("Image folder:"):
+            for path in groups[label]:
+                lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
+
+    # Per-session file-type groups
+    for label in [
+        "EDF data file",
+        "Logfiles folder",
+        "EXPERIMENT_*.txt",
+        "GENERAL_LOGFILE_*.txt",
+        "completed_stimuli.csv",
+        "question_order_versions.csv",
+    ]:
+        if label not in groups:
+            continue
+        entries = groups[label]
+        lines.append(f"\n  {label} \u2014 {len(entries)}:")
+        for entry in entries:
+            lines.append(f"      {entry}")
+
+    return "\n".join(lines)

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -429,6 +429,8 @@ class Settings:
         self.RUN_COMPREHENSION_ANSWERS = True
         #: Whether to create sanity check reports.
         self.RUN_SANITY_CHECKS = True
+        #: Whether to run the preflight input file check before processing.
+        self.RUN_PREFLIGHT_CHECK = True
 
         #: Column name for the trial identifier.
         self.TRIAL_COL = "trial"

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -58,6 +58,7 @@ def eyelink(method):
 class MultipleyeDataCollection:
     participant_data_path: Path | str | None
     crashed_session_ids: list[str] = []
+    skipped_session_ids: list[str] = []
     num_sessions = 1
     overview = {}
 
@@ -91,6 +92,7 @@ class MultipleyeDataCollection:
         **kwargs,
     ):
         self.sessions: dict[str, Session] = {}
+        self.skipped_session_ids: list[str] = []
         # TODO: in theory this can be multiple languages for the stimuli..
         self.language = stimulus_language
         self.country = country
@@ -230,29 +232,6 @@ class MultipleyeDataCollection:
                 pilots = list(os.scandir(self.data_root / self.pilot_folder))
                 items = items + pilots
 
-            # Check for sessions without a data file
-            sessions_missing_data = []
-            for item in items:
-                if item.is_dir() and re.match(
-                    session_folder_regex, item.name, re.IGNORECASE
-                ):
-                    # check if the session is excluded or included
-                    if self.included_sessions:
-                        if item.name not in self.included_sessions:
-                            continue
-                    elif self.excluded_sessions and item.name in self.excluded_sessions:
-                        continue
-
-                    session_file = list(Path(item.path).glob("*" + session_file_suffix))
-                    if len(session_file) == 0:
-                        sessions_missing_data.append(item.name)
-
-            if sessions_missing_data:
-                raise ValueError(
-                    f"The following sessions are missing a data file matching '{session_file_suffix}' "
-                    f"and will be skipped: {sorted(sessions_missing_data)}"
-                )
-
             for item in items:
                 if item.is_dir():
                     if re.match(session_folder_regex, item.name, re.IGNORECASE):
@@ -270,10 +249,11 @@ class MultipleyeDataCollection:
                             )
 
                             if len(session_file) == 0:
-                                raise ValueError(
-                                    f"No files found in folder {item.name} that match "
-                                    f"the pattern {session_file_suffix}"
+                                self.logger.warning(
+                                    f"No EDF file found for {item.name}, skipping."
                                 )
+                                self.skipped_session_ids.append(item.name)
+                                continue
 
                             elif len(session_file) > 1:
                                 raise ValueError(

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -64,6 +64,11 @@ def run_preprocessing(config_path: str | None = None):
             f"Invalid experiment type: {settings.EXPERIMENT_TYPE}. Supported types: [MultiplEYE, MeRID]"
         )
 
+    if settings.RUN_PREFLIGHT_CHECK:
+        from ..checks.preflight import run_preflight_check
+
+        run_preflight_check(data_collection)
+
     data_collection.convert_edf_to_asc()
     data_collection.prepare_session_level_information()
 

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -84,6 +84,8 @@ RUN_READING_MEASURES: true
 RUN_COMPREHENSION_ANSWERS: true
 # Whether to create sanity check reports.
 RUN_SANITY_CHECKS: true
+# Whether to run the preflight input file check before processing.
+RUN_PREFLIGHT_CHECK: true
 
 # --- INTERNAL (do not change) ---
 # Whether to force reconversion of EDF files to ASC even if output exists.

--- a/tests/unit/preprocessing/checks/test_preflight.py
+++ b/tests/unit/preprocessing/checks/test_preflight.py
@@ -1,0 +1,518 @@
+"""Unit tests for the preflight input file check."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from preprocessing.checks.preflight import (
+    PreflightError,
+    run_preflight_check,
+)
+
+
+@dataclass
+class FakeSession:
+    session_identifier: str
+    session_file_path: Path
+    session_folder_path: Path
+
+
+@dataclass
+class FakeDataCollection:
+    stimulus_dir: Path
+    language: str
+    country: str
+    lab_number: int
+    city: str = "City"
+    year: int = 2024
+    sessions: dict[str, FakeSession] = field(default_factory=dict)
+
+
+def _write_csv(path: Path, columns: list[str], rows: list[list[str]]) -> None:
+    """Write a tiny CSV with the given columns and rows."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = ",".join(columns)
+    lines = [header] + [",".join(row) for row in rows]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def preflight_env(tmp_path: Path):
+    """Build a data-collection-like environment with one session.
+
+    Returns a ``(data_collection, session_id)`` tuple.  The caller can remove / corrupt files
+    **after** receiving the environment and **before** calling ``run_preflight_check``.
+    """
+    session_id = "001_EN_UK_1_ET1"
+
+    # --- data-collection-level files -----------------------------------
+    stim_dir = tmp_path / "stimuli"
+    stim_dir.mkdir()
+    lang = "EN"
+    lang_lower = lang.lower()
+    country = "UK"
+    country_lower = country.lower()
+    labnum = 1
+    city = "city"
+    year = 2024
+
+    # Stimulus definition files (dummy — just a file, not a real xlsx/csv)
+    (stim_dir / "multipleye_stimuli_experiment_EN.xlsx").write_text(
+        "dummy", encoding="utf-8"
+    )
+    (stim_dir / "multipleye_comprehension_questions_EN.xlsx").write_text(
+        "dummy", encoding="utf-8"
+    )
+    (
+        stim_dir
+        / f"multipleye_participant_instructions_{lang_lower}_with_img_paths.csv"
+    ).write_text("dummy", encoding="utf-8")
+
+    # Config folder
+    config_dir = stim_dir / "config"
+    config_dir.mkdir()
+    (
+        config_dir / f"config_{lang_lower}_{country_lower}_city_{labnum}_{year}.py"
+    ).write_text("dummy", encoding="utf-8")
+    (
+        config_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_lab_configuration.json"
+    ).write_text("{}", encoding="utf-8")
+    (config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv").write_text(
+        "participant_id,version_number\n001,1\n", encoding="utf-8"
+    )
+
+    # Image/AOI folders
+    for folder_name in [
+        f"stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"participant_instructions_images_{lang_lower}_{country_lower}_{labnum}",
+    ]:
+        (stim_dir / folder_name).mkdir()
+
+    # Documentation folder
+    doc_dir = stim_dir.parent / "documentation"
+    doc_dir.mkdir()
+    (
+        doc_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_metadata_form.json"
+    ).write_text("{}", encoding="utf-8")
+
+    # --- session folder ------------------------------------------------
+    sess_folder = tmp_path / "sessions" / session_id
+    sess_folder.mkdir(parents=True)
+
+    edf_path = sess_folder / "data.edf"
+    edf_path.write_text("edf data", encoding="utf-8")
+
+    logfiles = sess_folder / "logfiles"
+    logfiles.mkdir()
+
+    (logfiles / "EXPERIMENT_LOGFILE_001.txt").write_text(
+        "experiment data", encoding="utf-8"
+    )
+    (logfiles / "GENERAL_LOGFILE_001.txt").write_text("general data", encoding="utf-8")
+
+    _write_csv(
+        logfiles / "completed_stimuli.csv",
+        ["stimulus_id", "stimulus_name", "trial_id", "completed"],
+        [["1", "Arg_PISACowsMilk", "1", "1"]],
+    )
+    _write_csv(
+        logfiles / "question_order_versions.csv",
+        [
+            "question_order_version",
+            "local_question_1",
+            "local_question_2",
+            "bridging_question_1",
+            "bridging_question_2",
+            "global_question_1",
+            "global_question_2",
+        ],
+        [["1", "101", "102", "201", "202", "301", "302"]],
+    )
+
+    session = FakeSession(
+        session_identifier=session_id,
+        session_file_path=edf_path,
+        session_folder_path=sess_folder,
+    )
+
+    dc = FakeDataCollection(
+        stimulus_dir=stim_dir,
+        language="EN",
+        country="UK",
+        lab_number=1,
+        sessions={session_id: session},
+    )
+
+    return dc, session_id
+
+
+# ---------------------------------------------------------------------------
+# Parametrized scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "scenario, modify_env, expected_errors",
+    [
+        # ---- pass ----------------------------------------------------------
+        (
+            "all_files_exist",
+            lambda env: None,
+            0,
+        ),
+        # ---- EDF -----------------------------------------------------------
+        (
+            "edf_missing",
+            lambda env: env[0].sessions[env[1]].session_file_path.unlink(),
+            1,
+        ),
+        # ---- logfiles folder -----------------------------------------------
+        (
+            "logfiles_folder_missing",
+            lambda env: _rmtree(
+                env[0].sessions[env[1]].session_folder_path / "logfiles"
+            ),
+            1,
+        ),
+        # ---- EXPERIMENT_*.txt ----------------------------------------------
+        (
+            "experiment_log_missing",
+            lambda env: _remove_glob(
+                env[0].sessions[env[1]].session_folder_path / "logfiles",
+                "EXPERIMENT_*.txt",
+            ),
+            1,
+        ),
+        # ---- GENERAL_LOGFILE_*.txt -----------------------------------------
+        (
+            "general_log_missing",
+            lambda env: _remove_glob(
+                env[0].sessions[env[1]].session_folder_path / "logfiles",
+                "GENERAL_LOGFILE_*.txt",
+            ),
+            1,
+        ),
+        # ---- completed_stimuli.csv -----------------------------------------
+        (
+            "completed_stimuli_missing",
+            lambda env: (
+                env[0].sessions[env[1]].session_folder_path
+                / "logfiles"
+                / "completed_stimuli.csv"
+            ).unlink(),
+            1,
+        ),
+        (
+            "completed_stimuli_unparseable",
+            lambda env: (
+                env[0].sessions[env[1]].session_folder_path
+                / "logfiles"
+                / "completed_stimuli.csv"
+            ).write_text("not,a,csv\n"),
+            1,
+        ),
+        (
+            "completed_stimuli_wrong_columns",
+            lambda env: _write_csv(
+                env[0].sessions[env[1]].session_folder_path
+                / "logfiles"
+                / "completed_stimuli.csv",
+                ["foo", "bar"],
+                [["1", "2"]],
+            ),
+            1,
+        ),
+        # ---- question_order_versions.csv ------------------------------------
+        (
+            "question_order_missing",
+            lambda env: (
+                env[0].sessions[env[1]].session_folder_path
+                / "logfiles"
+                / "question_order_versions.csv"
+            ).unlink(),
+            1,
+        ),
+        (
+            "question_order_unparseable",
+            lambda env: (
+                env[0].sessions[env[1]].session_folder_path
+                / "logfiles"
+                / "question_order_versions.csv"
+            ).write_text("broken"),
+            1,
+        ),
+        (
+            "question_order_wrong_columns",
+            lambda env: _write_csv(
+                env[0].sessions[env[1]].session_folder_path
+                / "logfiles"
+                / "question_order_versions.csv",
+                ["a", "b"],
+                [["1", "2"]],
+            ),
+            1,
+        ),
+        # ---- stimulus xlsx --------------------------------------------------
+        (
+            "stimulus_xlsx_missing",
+            lambda env: (
+                env[0].stimulus_dir / "multipleye_stimuli_experiment_EN.xlsx"
+            ).unlink(),
+            1,
+        ),
+        (
+            "questions_xlsx_missing",
+            lambda env: (
+                env[0].stimulus_dir / "multipleye_comprehension_questions_EN.xlsx"
+            ).unlink(),
+            1,
+        ),
+        # ---- participant instructions CSV ------------------------------------
+        (
+            "participant_instructions_csv_missing",
+            lambda env: (
+                env[0].stimulus_dir
+                / "multipleye_participant_instructions_en_with_img_paths.csv"
+            ).unlink(),
+            1,
+        ),
+        # ---- config python file (glob) --------------------------------------
+        (
+            "config_py_missing",
+            lambda env: _remove_glob(env[0].stimulus_dir / "config", "config_*.py"),
+            1,
+        ),
+        # ---- lab configuration JSON -----------------------------------------
+        (
+            "lab_config_json_missing",
+            lambda env: (
+                env[0].stimulus_dir
+                / "config"
+                / "MultiplEYE_EN_UK_city_1_2024_lab_configuration.json"
+            ).unlink(),
+            1,
+        ),
+        # ---- stimulus order versions CSV ------------------------------------
+        (
+            "stimulus_order_versions_csv_missing",
+            lambda env: (
+                env[0].stimulus_dir / "config" / "stimulus_order_versions_EN_UK_1.csv"
+            ).unlink(),
+            1,
+        ),
+        # ---- image folders ---------------------------------------------------
+        (
+            "stimuli_images_folder_missing",
+            lambda env: _rmtree(env[0].stimulus_dir / "stimuli_images_en_uk_1"),
+            1,
+        ),
+        (
+            "aoi_stimuli_folder_missing",
+            lambda env: _rmtree(env[0].stimulus_dir / "aoi_stimuli_en_uk_1"),
+            1,
+        ),
+        # ---- documentation metadata form (warning, not error) ---------------
+        (
+            "metadata_form_json_missing",
+            lambda env: _rmtree(env[0].stimulus_dir.parent / "documentation"),
+            0,
+        ),
+        # ---- multiple failures ----------------------------------------------
+        (
+            "multiple_failures",
+            lambda env: (
+                (
+                    env[0].stimulus_dir / "multipleye_stimuli_experiment_EN.xlsx"
+                ).unlink(),
+                env[0].sessions[env[1]].session_file_path.unlink(),
+                (
+                    env[0].sessions[env[1]].session_folder_path
+                    / "logfiles"
+                    / "completed_stimuli.csv"
+                ).unlink(),
+            ),
+            3,
+        ),
+    ],
+)
+def test_preflight_scenarios(preflight_env, scenario, modify_env, expected_errors):
+    """Verify that the preflight check reports the correct number of errors."""
+    modify_env(preflight_env)
+    dc = preflight_env[0]
+
+    if expected_errors == 0:
+        # Should not raise
+        run_preflight_check(dc)
+    else:
+        with pytest.raises(PreflightError) as exc_info:
+            run_preflight_check(dc)
+        assert exc_info.value.num_errors == expected_errors, (
+            f"Scenario {scenario!r}: expected {expected_errors} error(s), "
+            f"got {exc_info.value.num_errors}: {exc_info.value}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-session test
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_multiple_sessions(tmp_path: Path):
+    """Three sessions with different failures — all reported in one error."""
+    stim_dir = tmp_path / "stimuli"
+    stim_dir.mkdir()
+    lang = "EN"
+    lang_lower = lang.lower()
+    country = "UK"
+    country_lower = country.lower()
+    labnum = 1
+    city = "city"
+    year = 2024
+
+    (stim_dir / "multipleye_stimuli_experiment_EN.xlsx").write_text(
+        "dummy", encoding="utf-8"
+    )
+    (stim_dir / "multipleye_comprehension_questions_EN.xlsx").write_text(
+        "dummy", encoding="utf-8"
+    )
+    (
+        stim_dir
+        / f"multipleye_participant_instructions_{lang_lower}_with_img_paths.csv"
+    ).write_text("dummy", encoding="utf-8")
+
+    config_dir = stim_dir / "config"
+    config_dir.mkdir()
+    (
+        config_dir / f"config_{lang_lower}_{country_lower}_{city}_{labnum}_{year}.py"
+    ).write_text("dummy", encoding="utf-8")
+    (
+        config_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_lab_configuration.json"
+    ).write_text("{}", encoding="utf-8")
+    (config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv").write_text(
+        "participant_id,version_number\n001,1\n", encoding="utf-8"
+    )
+
+    for folder_name in [
+        f"stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"participant_instructions_images_{lang_lower}_{country_lower}_{labnum}",
+    ]:
+        (stim_dir / folder_name).mkdir()
+
+    doc_dir = stim_dir.parent / "documentation"
+    doc_dir.mkdir()
+    (
+        doc_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_metadata_form.json"
+    ).write_text("{}", encoding="utf-8")
+
+    sessions: dict[str, FakeSession] = {}
+    for idx, missing in enumerate(["edf", "experiment_log", "question_order"]):
+        sid = f"{idx:03d}_EN_UK_1_ET1"
+        sess_dir = tmp_path / "sessions" / sid
+        sess_dir.mkdir(parents=True)
+
+        edf = sess_dir / "data.edf"
+        if missing != "edf":
+            edf.write_text("data", encoding="utf-8")
+
+        logfiles = sess_dir / "logfiles"
+        logfiles.mkdir()
+
+        if missing != "experiment_log":
+            (logfiles / "EXPERIMENT_LOGFILE_001.txt").write_text(
+                "data", encoding="utf-8"
+            )
+        (logfiles / "GENERAL_LOGFILE_001.txt").write_text("data", encoding="utf-8")
+        _write_csv(
+            logfiles / "completed_stimuli.csv",
+            ["stimulus_id", "stimulus_name", "trial_id", "completed"],
+            [["1", "Arg_PISACowsMilk", "1", "1"]],
+        )
+
+        if missing != "question_order":
+            _write_csv(
+                logfiles / "question_order_versions.csv",
+                [
+                    "question_order_version",
+                    "local_question_1",
+                    "local_question_2",
+                    "bridging_question_1",
+                    "bridging_question_2",
+                    "global_question_1",
+                    "global_question_2",
+                ],
+                [["1", "101", "102", "201", "202", "301", "302"]],
+            )
+
+        sessions[sid] = FakeSession(
+            session_identifier=sid,
+            session_file_path=edf,
+            session_folder_path=sess_dir,
+        )
+
+    dc = FakeDataCollection(
+        stimulus_dir=stim_dir,
+        language="EN",
+        country="UK",
+        lab_number=1,
+        city=city,
+        year=year,
+        sessions=sessions,
+    )
+
+    with pytest.raises(PreflightError) as exc_info:
+        run_preflight_check(dc)
+    # Expect 3 errors: 1 × edf, 1 × experiment_log, 1 × question_order
+    assert exc_info.value.num_errors == 3, exc_info.value
+
+
+# ---------------------------------------------------------------------------
+# Warning-only scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_warnings_only(preflight_env):
+    """Items that are warnings (metadata JSON, flaky AOI folders) should
+    be logged but NOT raise ``PreflightError``."""
+    dc, _ = preflight_env
+
+    # Remove all warning-level items — should NOT raise
+    import shutil
+
+    shutil.rmtree(dc.stimulus_dir.parent / "documentation", ignore_errors=True)
+    shutil.rmtree(dc.stimulus_dir / "aoi_stimuli_images_en_uk_1", ignore_errors=True)
+    shutil.rmtree(dc.stimulus_dir / "aoi_question_images_en_uk_1", ignore_errors=True)
+
+    run_preflight_check(dc)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rmtree(path: Path) -> None:
+    """Remove a directory and all its contents."""
+    import shutil
+
+    shutil.rmtree(path)
+
+
+def _remove_glob(directory: Path, pattern: str) -> None:
+    """Remove all files matching a glob pattern in the given directory."""
+    for p in directory.glob(pattern):
+        p.unlink()

--- a/tests/unit/preprocessing/checks/test_preflight.py
+++ b/tests/unit/preprocessing/checks/test_preflight.py
@@ -326,6 +326,12 @@ def preflight_env(tmp_path: Path):
             lambda env: _rmtree(env[0].stimulus_dir.parent / "documentation"),
             0,
         ),
+        # ---- empty stimulus folder ------------------------------------------
+        (
+            "stimulus_folder_empty",
+            lambda env: _make_empty(env[0].stimulus_dir),
+            1,
+        ),
         # ---- multiple failures ----------------------------------------------
         (
             "multiple_failures",
@@ -481,6 +487,80 @@ def test_preflight_multiple_sessions(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
+# Empty stimulus directory
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_stimulus_dir_empty_message(preflight_env):
+    """Empty stimulus directory produces a descriptive message."""
+    dc, _ = preflight_env
+    _make_empty(dc.stimulus_dir)
+
+    with pytest.raises(PreflightError) as exc_info:
+        run_preflight_check(dc)
+
+    msg = str(exc_info.value)
+    assert "Stimulus folder is empty" in msg
+    assert exc_info.value.num_errors == 1
+
+
+def test_preflight_stimulus_dir_empty_with_archive(tmp_path: Path):
+    """If an archive sits next to the empty stim dir, mention it."""
+    stim_dir = tmp_path / "stimuli"
+    stim_dir.mkdir()
+    # Create a dummy archive
+    (tmp_path / "stimuli_data.zip").write_text("fake zip", encoding="utf-8")
+    # Session still works
+    sid = "001_EN_UK_1_ET1"
+    sess_folder = tmp_path / "sessions" / sid
+    sess_folder.mkdir(parents=True)
+    (sess_folder / "data.edf").write_text("data", encoding="utf-8")
+    logfiles = sess_folder / "logfiles"
+    logfiles.mkdir()
+    (logfiles / "EXPERIMENT_001.txt").write_text("data", encoding="utf-8")
+    (logfiles / "GENERAL_001.txt").write_text("data", encoding="utf-8")
+    _write_csv(
+        logfiles / "completed_stimuli.csv",
+        ["stimulus_id", "stimulus_name", "trial_id", "completed"],
+        [["1", "Arg_PISACowsMilk", "1", "1"]],
+    )
+    _write_csv(
+        logfiles / "question_order_versions.csv",
+        [
+            "question_order_version",
+            "local_question_1",
+            "local_question_2",
+            "bridging_question_1",
+            "bridging_question_2",
+            "global_question_1",
+            "global_question_2",
+        ],
+        [["1", "101", "102", "201", "202", "301", "302"]],
+    )
+
+    session = FakeSession(
+        session_identifier=sid,
+        session_file_path=sess_folder / "data.edf",
+        session_folder_path=sess_folder,
+    )
+    dc = FakeDataCollection(
+        stimulus_dir=stim_dir,
+        language="EN",
+        country="UK",
+        lab_number=1,
+        sessions={sid: session},
+    )
+
+    with pytest.raises(PreflightError) as exc_info:
+        run_preflight_check(dc)
+
+    msg = str(exc_info.value)
+    assert "Stimulus folder is empty" in msg
+    assert "stimuli_data.zip" in msg
+    assert "Extract the archive" in msg
+
+
+# ---------------------------------------------------------------------------
 # Warning-only scenarios
 # ---------------------------------------------------------------------------
 
@@ -516,3 +596,14 @@ def _remove_glob(directory: Path, pattern: str) -> None:
     """Remove all files matching a glob pattern in the given directory."""
     for p in directory.glob(pattern):
         p.unlink()
+
+
+def _make_empty(path: Path) -> None:
+    """Remove all contents of a directory, leaving it empty."""
+    import shutil
+
+    for child in list(path.iterdir()):
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()


### PR DESCRIPTION
Adds a **preflight input file check** stage that runs early in the preprocessing pipeline, before EDF conversion. All required input files are validated at once; missing files are reported in a single consolidated grouped error message instead of one-at-a-time mid-loop failures.

All file and folder checks are **case-insensitive**.

This reduces time spent on running the pipeline then failing, because this allows an automatic scan of the needed input files, instead of running into the knife, changing config and rerunning.

## Files checked
There are some checks that stop the pipeline (errors) and some that only show a warning (see below).

### Errors (pipeline stops)

| File type | Scope |
|---|---|
| `stimulus/` folder (not empty, exists) | shared |
| `data.edf` (or matching `*.<suffix>`) | per session |
| `logfiles/` folder | per session |
| `EXPERIMENT_*.txt` inside logfiles | per session |
| `GENERAL_LOGFILE_*.txt` inside logfiles | per session |
| `completed_stimuli.csv` (parseable, correct columns) | per session |
| `question_order_versions.csv` (parseable, correct columns) | per session |
| `multipleye_stimuli_experiment_{lang}.xlsx` | shared |
| `multipleye_comprehension_questions_{lang}.xlsx` | shared |
| `multipleye_participant_instructions_{lang}_with_img_paths.csv` | shared |
| `config/config_{lang}_{country}_*_{lab}_*.py` (glob match) | shared |
| `config/MultiplEYE_{lang}_{country}_{city}_{lab}_{year}_lab_configuration.json` | shared |
| `config/stimulus_order_versions_{lang}_{country}_{lab}.csv` | shared |
| `stimuli_images_{lang}_{country}_{lab}/` | shared |
| `aoi_stimuli_{lang}_{country}_{lab}/` | shared |
| `question_images_{lang}_{country}_{lab}/` | shared |
| `participant_instructions_images_{lang}_{country}_{lab}/` | shared |

When the `stimulus/` folder is empty and an archive (`.zip`, `.tar.gz`, etc.) is found in the parent directory, the error message includes the archive name and suggests extracting it first.

### Warnings (pipeline continues, banner printed)

| File type | Reason |
|---|---|
| `aoi_stimuli_images_{lang}_{country}_{lab}/` | Might be uploaded or not |
| `aoi_question_images_{lang}_{country}_{lab}/` | Might be uploaded or not |
| `documentation/MultiplEYE_{...}_metadata_form.json` | Might be uploaded or not |

### When everything is clean
A confirmation banner is logged at INFO level.

## Output examples
**Errors:**
```
========================================================
  Preflight check FAILED -- 3 error(s)
========================================================
  Stimulus definition xlsx not found:
      data/.../multipleye_stimuli_experiment_DE.xlsx
  Config python file not found:
      data/.../config/config_de_de_*_1_*.py
  EDF data file -- 1:
      001_DE_DE_1_ET1
```
**Warnings-only:**
```
========================================================
  Preflight check -- 2 warning(s)
========================================================
  Metadata form JSON not found:
      data/MultiplEYE_DE_DE_Lueneburg_1_2025/...
  Image folder: aoi_stimuli_images_de_de_1 not found:
      data/MultiplEYE_DE_DE_Lueneburg_1_2025/...
```
**Success:**
```
INFO  =====  Preflight check -- all input files found  =====
```

## Other changes
- `MultipleyeDataCollection.skipped_session_ids`: sessions without an EDF file are now skipped with a warning instead of raising `ValueError`. The preflight check reports them as part of the errors anyways and stops the pipeline before.
- `RUN_PREFLIGHT_CHECK` config option (default: `true`) to enable/disable the check.
  A user can deliberately deactivate this check, which should not happen normally.

## Feedback requested
- Are the checked file types correct and complete?
- Are the warning-level checks appropriate or too strict/lenient?
- Should any additional files or validations be added? @theDebbister 

#### Relates to
- #116