### PR TITLE
refactor: Centralise output folder paths on `Sid` properties

### DIFF
--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -87,7 +87,6 @@ def load_gaze_data(
 
 
 def load_trial_level_raw_data(
-    directory: Path,
     sid: Sid,
     trial_columns: list[str],
     file_pattern: str | None = None,
@@ -99,8 +98,6 @@ def load_trial_level_raw_data(
 
     Parameters
     ----------
-    directory : Path
-        The base directory for preprocessed data.
     sid : Sid
         The session identifier.
     trial_columns : list of str
@@ -117,7 +114,7 @@ def load_trial_level_raw_data(
         A gaze object containing the trial-level aggregated gaze data along with
         any associated metadata, validations, calibrations, and experiment settings, if provided.
     """
-    data_folder = Path(directory) / settings.RAW_DATA_FOLDER / str(sid)
+    data_folder = sid.raw_data_dir
     if file_pattern is None:
         file_pattern = settings.RAW_DATA_FILE_GLOB
 
@@ -156,7 +153,7 @@ def load_trial_level_raw_data(
     )
 
     if load_metadata:
-        metadata_path = Path(directory) / settings.METADATA_FOLDER / str(sid)
+        metadata_path = sid.metadata_dir
 
         with open(metadata_path / "gaze_metadata.json", encoding="utf8") as f:
             metadata = json.load(f)
@@ -185,7 +182,6 @@ def load_trial_level_raw_data(
 
 def load_trial_level_events_data(
     gaze: pm.Gaze,
-    directory: Path,
     sid: Sid,
     event_type: str,
     file_pattern: str | None = None,
@@ -201,8 +197,6 @@ def load_trial_level_events_data(
     ----------
     gaze : pm.Gaze
         An object containing gaze data and associated event information.
-    directory : Path
-        The base directory for preprocessed data.
     sid : Sid
         The session identifier.
     event_type : str
@@ -217,9 +211,9 @@ def load_trial_level_events_data(
         The updated gaze object with the loaded and integrated event data.
     """
     if event_type == "fixation":
-        data_folder = Path(directory) / settings.FIXATIONS_FOLDER / str(sid)
+        data_folder = sid.fixations_dir
     elif event_type == "saccade":
-        data_folder = Path(directory) / settings.SACCADES_FOLDER / str(sid)
+        data_folder = sid.saccades_dir
     else:
         raise ValueError(
             f"event_type must be {list(settings.EVENT_PROPERTIES.keys())}, got {event_type}"
@@ -287,7 +281,6 @@ def load_trial_level_events_data(
 
 
 def load_reading_measures(
-    directory: Path,
     sid: Sid,
     file_pattern: str = r".+?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv",
 ) -> pl.DataFrame:
@@ -295,8 +288,6 @@ def load_reading_measures(
 
     Parameters
     ----------
-    directory : Path
-        The base directory for preprocessed data.
     sid : Sid
         The session identifier.
     file_pattern : str, optional
@@ -307,7 +298,7 @@ def load_reading_measures(
     pl.DataFrame
         A DataFrame containing the concatenated reading measures data.
     """
-    data_folder = Path(directory) / settings.READING_MEASURES_FOLDER / str(sid)
+    data_folder = sid.reading_measures_dir
     # Use glob to find all csv files first, as Path.glob() does not support regex
     files = [f for f in data_folder.glob("*.csv") if re.match(file_pattern, f.name)]
 

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -1,30 +1,26 @@
 """Functions for saving data."""
 
 import json
-from pathlib import Path
 
 import polars as pl
 
 import pymovements as pm
-from ..config import settings
 from ..models.sid import Sid
 import contextlib
 
 
-def save_raw_data(directory: Path, sid: Sid, data: pm.Gaze) -> None:
+def save_raw_data(sid: Sid, data: pm.Gaze) -> None:
     """
     Saves raw gaze data in separate csv files per trial.
 
     Parameters
     ----------
-    directory : Path
-        The base directory for preprocessed data.
     sid : Sid
         The session identifier.
     data : pm.Gaze
         The gaze data as a pymovements Gaze object.
     """
-    directory = Path(directory) / settings.RAW_DATA_FOLDER / str(sid)
+    directory = sid.raw_data_dir
     directory.mkdir(parents=True, exist_ok=True)
 
     new_data = data.clone()
@@ -44,7 +40,6 @@ def save_raw_data(directory: Path, sid: Sid, data: pm.Gaze) -> None:
 
 def save_events_data(
     event_type: str,
-    directory: Path,
     sid: Sid,
     split_column: str,
     name_columns: list[str],
@@ -59,8 +54,6 @@ def save_events_data(
     ----------
     event_type : str
         What type of event should be stored. Either "fixation" or "saccade".
-    directory : Path
-        The directory where the events data should be stored.
     sid : Sid
         The session identifier.
     split_column : str
@@ -79,11 +72,7 @@ def save_events_data(
             "Only fixations and saccades are currently supported as events."
         )
 
-    directory = (
-        Path(directory) / settings.FIXATIONS_FOLDER / str(sid)
-        if event_type == "fixation"
-        else Path(directory) / settings.SACCADES_FOLDER / str(sid)
-    )
+    directory = sid.fixations_dir if event_type == "fixation" else sid.saccades_dir
     directory.mkdir(parents=True, exist_ok=True)
 
     data_copy = data.clone()
@@ -104,20 +93,18 @@ def save_events_data(
         df.write_csv(directory / name)
 
 
-def save_scanpaths(directory: Path, sid: Sid, data: pm.Gaze) -> None:
+def save_scanpaths(sid: Sid, data: pm.Gaze) -> None:
     """
     Saves scanpaths in separate csv files per trial.
 
     Parameters
     ----------
-    directory : Path
-        The base directory for preprocessed data.
     sid : Sid
         The session identifier.
     data : pm.Gaze
         The gaze data as a pymovements Gaze object.
     """
-    directory = Path(directory) / settings.SCANPATHS_FOLDER / str(sid)
+    directory = sid.scanpaths_dir
     directory.mkdir(parents=True, exist_ok=True)
 
     new_data = data.clone()
@@ -164,20 +151,18 @@ def save_scanpaths(directory: Path, sid: Sid, data: pm.Gaze) -> None:
         df.write_csv(directory / name)
 
 
-def save_reading_measures(directory: Path, sid: Sid, data: pl.DataFrame) -> None:
+def save_reading_measures(sid: Sid, data: pl.DataFrame) -> None:
     """
     Saves reading measures in separate csv files per trial.
 
     Parameters
     ----------
-    directory : Path
-        The base directory for preprocessed data.
     sid : Sid
         The session identifier.
     data : pl.DataFrame
         The reading measures as a polars DataFrame.
     """
-    directory = Path(directory) / settings.READING_MEASURES_FOLDER / str(sid)
+    directory = sid.reading_measures_dir
     directory.mkdir(parents=True, exist_ok=True)
 
     trials = data.partition_by(by="trial", as_dict=False)
@@ -190,20 +175,18 @@ def save_reading_measures(directory: Path, sid: Sid, data: pl.DataFrame) -> None
         trial.write_csv(directory / name)
 
 
-def save_session_metadata(directory: Path, gaze: pm.Gaze, sid: Sid) -> None:
+def save_session_metadata(gaze: pm.Gaze, sid: Sid) -> None:
     """
     Saves session metadata in a json file and also saves the gaze object's metadata.
 
     Parameters
     ----------
-    directory : Path
-        The base directory for preprocessed data.
     gaze : pm.Gaze
         The gaze data as a pymovements Gaze object.
     sid : Sid
         The session identifier.
     """
-    metadata_directory = Path(directory) / settings.METADATA_FOLDER / str(sid)
+    metadata_directory = sid.metadata_dir
     metadata_directory.mkdir(parents=True, exist_ok=True)
 
     metadata = gaze._metadata

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -154,16 +154,6 @@ class Sid:
 
         return _settings.OUTPUT_DIR / _settings.ANSWERS_FOLDER / str(self)
 
-    @staticmethod
-    def get_session_save_name(session_idf: str, include_postfix: bool = False) -> str:
-        """Get a consistent session name for file names, optionally including restart postfixes."""
-        try:
-            sid = Sid(session_idf)
-            return str(sid) if include_postfix else sid.id_no_postfix
-        except (ValueError, TypeError):
-            # Fallback for non-compliant identifiers
-            return "_".join(session_idf.split("_")[:5])
-
     def __str__(self) -> str:
         base = self.id_no_postfix
         if self.postfix:

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from pathlib import Path
 import re
 
 __all__ = ["Sid"]
@@ -111,11 +112,47 @@ class Sid:
         """Returns the SID string without the restart postfix."""
         return f"{self.pid}_{self.lang}_{self.country}_{self.lab}_{self.session}"
 
-    def __str__(self) -> str:
-        base = self.id_no_postfix
-        if self.postfix:
-            return f"{base}_{self.postfix}"
-        return base
+    @property
+    def raw_data_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.RAW_DATA_FOLDER / str(self)
+
+    @property
+    def fixations_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.FIXATIONS_FOLDER / str(self)
+
+    @property
+    def saccades_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.SACCADES_FOLDER / str(self)
+
+    @property
+    def scanpaths_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.SCANPATHS_FOLDER / str(self)
+
+    @property
+    def reading_measures_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.READING_MEASURES_FOLDER / str(self)
+
+    @property
+    def metadata_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.METADATA_FOLDER / str(self)
+
+    @property
+    def answers_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.ANSWERS_FOLDER / str(self)
 
     @staticmethod
     def get_session_save_name(session_idf: str, include_postfix: bool = False) -> str:
@@ -126,6 +163,12 @@ class Sid:
         except (ValueError, TypeError):
             # Fallback for non-compliant identifiers
             return "_".join(session_idf.split("_")[:5])
+
+    def __str__(self) -> str:
+        base = self.id_no_postfix
+        if self.postfix:
+            return f"{base}_{self.postfix}"
+        return base
 
     @staticmethod
     def is_valid_pid(pid: str) -> bool:

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -95,7 +95,6 @@ def run_preprocessing(config_path: str | None = None):
 
             pbar.set_description(f"Loading samples {idf}:")
             gaze = preprocessing.load_trial_level_raw_data(
-                settings.OUTPUT_DIR,
                 sid,
                 trial_columns=settings.TRIAL_COLS,
                 load_metadata=True,
@@ -116,12 +115,8 @@ def run_preprocessing(config_path: str | None = None):
                 pl.col("stimulus").is_in(sess.completed_stimuli_names)
             )
 
-            preprocessing.save_raw_data(
-                settings.OUTPUT_DIR,
-                sid,
-                gaze,
-            )
-            preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, sid)
+            preprocessing.save_raw_data(sid, gaze)
+            preprocessing.save_session_metadata(gaze, sid)
 
         sess.pm_gaze_metadata = gaze._metadata
         sess.calibrations = gaze.calibrations
@@ -167,7 +162,6 @@ def run_preprocessing(config_path: str | None = None):
                 pbar.set_description(f"Loading events {idf}:")
                 gaze = preprocessing.load_trial_level_events_data(
                     gaze,
-                    settings.OUTPUT_DIR,
                     sid,
                     event_type=settings.FIXATION,
                     file_pattern=None,
@@ -175,7 +169,6 @@ def run_preprocessing(config_path: str | None = None):
 
                 gaze = preprocessing.load_trial_level_events_data(
                     gaze,
-                    settings.OUTPUT_DIR,
                     sid,
                     event_type=settings.SACCADE,
                     file_pattern=None,
@@ -192,7 +185,6 @@ def run_preprocessing(config_path: str | None = None):
                 if settings.RUN_FIXATION_DETECTION:
                     preprocessing.save_events_data(
                         settings.FIXATION,
-                        settings.OUTPUT_DIR,
                         sid,
                         "trial",
                         ["trial", "stimulus"],
@@ -203,7 +195,6 @@ def run_preprocessing(config_path: str | None = None):
                 if settings.RUN_SACCADE_DETECTION:
                     preprocessing.save_events_data(
                         settings.SACCADE,
-                        settings.OUTPUT_DIR,
                         sid,
                         "trial",
                         ["trial", "stimulus"],
@@ -264,9 +255,9 @@ def run_preprocessing(config_path: str | None = None):
                     gaze,
                     sess.stimuli,
                 )
-                preprocessing.save_scanpaths(settings.OUTPUT_DIR, sid, gaze)
+                preprocessing.save_scanpaths(sid, gaze)
 
-                preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, sid)
+                preprocessing.save_session_metadata(gaze, sid)
 
         rm_folder = sid.reading_measures_dir
 
@@ -293,10 +284,7 @@ def run_preprocessing(config_path: str | None = None):
                     )
 
                 pbar.set_description(f"Loading reading measures {idf}:")
-                reading_measures = preprocessing.load_reading_measures(
-                    settings.OUTPUT_DIR,
-                    sid,
-                )
+                reading_measures = preprocessing.load_reading_measures(sid)
 
                 data_collection[sess.session_identifier].reading_measures = True
 
@@ -307,9 +295,7 @@ def run_preprocessing(config_path: str | None = None):
                     sess.stimuli,
                 )
 
-                preprocessing.save_reading_measures(
-                    settings.OUTPUT_DIR, sid, reading_measures
-                )
+                preprocessing.save_reading_measures(sid, reading_measures)
                 data_collection[sess.session_identifier].reading_measures = True
         else:
             pbar.set_description(f"Skipping reading measures {idf}:")

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -82,7 +82,7 @@ def run_preprocessing(config_path: str | None = None):
         asc = sess.asc_path
 
         # create or load raw data
-        raw_data_folder = settings.OUTPUT_DIR / settings.RAW_DATA_FOLDER / str(sid)
+        raw_data_folder = sid.raw_data_dir
         if raw_data_folder.exists() and not settings.OVERWRITE:
             # check if the folder contains the expected number of files, if not, we will overwrite
             num_expected_files = len(sess.completed_stimuli_ids)
@@ -134,10 +134,8 @@ def run_preprocessing(config_path: str | None = None):
         )
 
         # create or load fixation data
-        fixation_data_folder = (
-            settings.OUTPUT_DIR / settings.FIXATIONS_FOLDER / str(sid)
-        )
-        saccade_data_folder = settings.OUTPUT_DIR / settings.SACCADES_FOLDER / str(sid)
+        fixation_data_folder = sid.fixations_dir
+        saccade_data_folder = sid.saccades_dir
 
         if settings.RUN_FIXATION_DETECTION or settings.RUN_SACCADE_DETECTION:
             if gaze is None:
@@ -237,14 +235,14 @@ def run_preprocessing(config_path: str | None = None):
                 gaze = preprocessing.load_trial_level_events_data(
                     gaze,
                     settings.OUTPUT_DIR,
-                    idf,
+                    sid,
                     event_type=settings.FIXATION,
                     file_pattern=None,
                 )
                 gaze = preprocessing.load_trial_level_events_data(
                     gaze,
                     settings.OUTPUT_DIR,
-                    idf,
+                    sid,
                     event_type=settings.SACCADE,
                     file_pattern=None,
                 )
@@ -270,7 +268,7 @@ def run_preprocessing(config_path: str | None = None):
 
                 preprocessing.save_session_metadata(settings.OUTPUT_DIR, gaze, sid)
 
-        rm_folder = settings.OUTPUT_DIR / settings.READING_MEASURES_FOLDER / str(sid)
+        rm_folder = sid.reading_measures_dir
 
         if settings.RUN_READING_MEASURES:
             if (
@@ -318,12 +316,7 @@ def run_preprocessing(config_path: str | None = None):
 
         # === COMPREHENSION QUESTION ANSWERS ===
         if settings.RUN_COMPREHENSION_ANSWERS:
-            answers_csv = (
-                settings.OUTPUT_DIR
-                / settings.ANSWERS_FOLDER
-                / str(sid)
-                / f"{str(sid)}_answers.csv"
-            )
+            answers_csv = sid.answers_dir / f"{sid}_answers.csv"
 
             if answers_csv.exists() and not settings.OVERWRITE:
                 pbar.set_description(f"Loading comprehension answers {idf}")

--- a/tests/unit/preprocessing/io/test_output_structure.py
+++ b/tests/unit/preprocessing/io/test_output_structure.py
@@ -18,10 +18,10 @@ from preprocessing.models.sid import Sid
 
 SID_STRINGS = ["001_EN_UK_1_S1", "017_DA_DK_1_ET1_start_after_trial_3"]
 
-EVENT_FOLDERS = {
-    "fixation": settings.FIXATIONS_FOLDER,
-    "saccade": settings.SACCADES_FOLDER,
-}
+
+@pytest.fixture(autouse=True)
+def _set_output_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(type(settings), "OUTPUT_DIR", tmp_path)
 
 
 @pytest.fixture
@@ -79,13 +79,14 @@ def dummy_gaze():
 @pytest.mark.parametrize("sid_str", SID_STRINGS)
 def test_save_load_raw_data_structure(tmp_path, dummy_gaze, sid_str):
     sid = Sid(sid_str)
-    save_raw_data(tmp_path, sid, dummy_gaze)
-    expected_path = tmp_path / settings.RAW_DATA_FOLDER / str(sid)
-    assert expected_path.exists()
-    assert (expected_path / f"{str(sid)}_trial_1_Enc_WikiMoon_1_raw_data.csv").exists()
+    save_raw_data(sid, dummy_gaze)
+    assert sid.raw_data_dir.exists()
+    assert (
+        sid.raw_data_dir / f"{str(sid)}_trial_1_Enc_WikiMoon_1_raw_data.csv"
+    ).exists()
 
     loaded_gaze = load_trial_level_raw_data(
-        tmp_path, sid, trial_columns=["trial", "stimulus", "page"]
+        sid, trial_columns=["trial", "stimulus", "page"]
     )
     assert len(loaded_gaze.samples) == 3
 
@@ -96,28 +97,28 @@ def test_save_load_events_structure(tmp_path, dummy_gaze, event_type, sid_str):
     sid = Sid(sid_str)
     save_events_data(
         event_type,
-        tmp_path,
         sid,
         "trial",
         ["stimulus"],
         ["name", "start", "end", "trial", "stimulus", "page"],
         dummy_gaze,
     )
-    expected_path = tmp_path / EVENT_FOLDERS[event_type] / str(sid)
-    assert expected_path.exists()
-    assert (expected_path / f"{str(sid)}_Enc_WikiMoon_1_{event_type}.csv").exists()
+    expected_dir = sid.fixations_dir if event_type == "fixation" else sid.saccades_dir
+    assert expected_dir.exists()
+    assert (expected_dir / f"{str(sid)}_Enc_WikiMoon_1_{event_type}.csv").exists()
 
-    loaded_gaze = load_trial_level_events_data(dummy_gaze, tmp_path, sid, event_type)
+    loaded_gaze = load_trial_level_events_data(dummy_gaze, sid, event_type)
     assert len(loaded_gaze.events.frame.filter(pl.col("name") == event_type)) >= 1
 
 
 @pytest.mark.parametrize("sid_str", SID_STRINGS)
 def test_save_scanpaths_structure(tmp_path, dummy_gaze, sid_str):
     sid = Sid(sid_str)
-    save_scanpaths(tmp_path, sid, dummy_gaze)
-    expected_path = tmp_path / settings.SCANPATHS_FOLDER / str(sid)
-    assert expected_path.exists()
-    assert (expected_path / f"{str(sid)}_trial_1_Enc_WikiMoon_1_scanpath.csv").exists()
+    save_scanpaths(sid, dummy_gaze)
+    assert sid.scanpaths_dir.exists()
+    assert (
+        sid.scanpaths_dir / f"{str(sid)}_trial_1_Enc_WikiMoon_1_scanpath.csv"
+    ).exists()
 
 
 @pytest.mark.parametrize("sid_str", SID_STRINGS)
@@ -126,37 +127,35 @@ def test_save_load_reading_measures_structure(tmp_path, sid_str):
     df_rm = pl.DataFrame(
         {"trial": ["trial_1"], "stimulus": ["Enc_WikiMoon_1"], "val": [1.0]}
     )
-    save_reading_measures(tmp_path, sid, df_rm)
-    expected_path = tmp_path / settings.READING_MEASURES_FOLDER / str(sid)
-    assert expected_path.exists()
+    save_reading_measures(sid, df_rm)
+    assert sid.reading_measures_dir.exists()
     assert (
-        expected_path / f"{str(sid)}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
+        sid.reading_measures_dir
+        / f"{str(sid)}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
     ).exists()
 
-    loaded_rm = load_reading_measures(tmp_path, sid)
+    loaded_rm = load_reading_measures(sid)
     assert len(loaded_rm) == 1
 
 
 @pytest.mark.parametrize("sid_str", SID_STRINGS)
 def test_save_load_metadata_structure(tmp_path, dummy_gaze, sid_str):
     sid = Sid(sid_str)
-    save_raw_data(tmp_path, sid, dummy_gaze)
-    save_session_metadata(tmp_path, dummy_gaze, sid)
-    expected_path = tmp_path / settings.METADATA_FOLDER / str(sid)
-    assert expected_path.exists()
-    assert (expected_path / "gaze_metadata.json").exists()
-    assert (expected_path / "calibrations.feather").exists()
-    assert (expected_path / "validations.feather").exists()
-    assert (expected_path / "calibrations.tsv").exists()
-    assert (expected_path / "validations.tsv").exists()
+    save_raw_data(sid, dummy_gaze)
+    save_session_metadata(dummy_gaze, sid)
+    assert sid.metadata_dir.exists()
+    assert (sid.metadata_dir / "gaze_metadata.json").exists()
+    assert (sid.metadata_dir / "calibrations.feather").exists()
+    assert (sid.metadata_dir / "validations.feather").exists()
+    assert (sid.metadata_dir / "calibrations.tsv").exists()
+    assert (sid.metadata_dir / "validations.tsv").exists()
 
     # Ensure experiment.yaml exists (usually saved by gaze.save)
-    if not (expected_path / "experiment.yaml").exists():
-        with open(expected_path / "experiment.yaml", "w") as f:
+    if not (sid.metadata_dir / "experiment.yaml").exists():
+        with open(sid.metadata_dir / "experiment.yaml", "w") as f:
             f.write("sampling_rate: 100")
 
     loaded_gaze = load_trial_level_raw_data(
-        tmp_path,
         sid,
         trial_columns=["trial", "stimulus", "page"],
         load_metadata=True,
@@ -174,7 +173,6 @@ def test_save_events_data_invalid_event_type(tmp_path, dummy_gaze, invalid_type)
     ):
         save_events_data(
             invalid_type,
-            tmp_path,
             sid,
             "trial",
             ["stimulus"],
@@ -189,13 +187,12 @@ def test_load_trial_level_events_data_invalid_event_type(
 ):
     sid = Sid("001_EN_UK_1_S1")
     with pytest.raises(ValueError, match="event_type must be "):
-        load_trial_level_events_data(dummy_gaze, tmp_path, sid, invalid_type)
+        load_trial_level_events_data(dummy_gaze, sid, invalid_type)
 
 
 def test_load_reading_measures_with_actual_filenames(tmp_path):
     sid = Sid("017_DA_DK_1_ET1")
-    reading_measures_dir = tmp_path / settings.READING_MEASURES_FOLDER / str(sid)
-    reading_measures_dir.mkdir(parents=True)
+    sid.reading_measures_dir.mkdir(parents=True)
 
     # Files as reported in the issue
     filenames = [
@@ -206,10 +203,10 @@ def test_load_reading_measures_with_actual_filenames(tmp_path):
 
     for filename in filenames:
         df = pl.DataFrame({"measure": [1.0], "trial": ["dummy"], "stimulus": ["dummy"]})
-        df.write_csv(reading_measures_dir / filename)
+        df.write_csv(sid.reading_measures_dir / filename)
 
     # Test loading
-    df_loaded = load_reading_measures(tmp_path, sid)
+    df_loaded = load_reading_measures(sid)
 
     assert len(df_loaded) == 3
     assert set(df_loaded["trial"].unique()) == {

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -1,5 +1,6 @@
 import pytest
 from preprocessing.models.sid import Sid
+from preprocessing.config import settings
 
 
 @pytest.mark.parametrize(
@@ -243,3 +244,26 @@ def test_sid_equals_soft(sid1_str, sid2_str, expected_match):
     sid2 = Sid(sid2_str)
     assert sid1.equals_soft(sid2) == expected_match
     assert sid2.equals_soft(sid1) == expected_match
+
+
+FOLDER_PROPERTIES = [
+    ("raw_data_dir", settings.RAW_DATA_FOLDER),
+    ("fixations_dir", settings.FIXATIONS_FOLDER),
+    ("saccades_dir", settings.SACCADES_FOLDER),
+    ("scanpaths_dir", settings.SCANPATHS_FOLDER),
+    ("reading_measures_dir", settings.READING_MEASURES_FOLDER),
+    ("metadata_dir", settings.METADATA_FOLDER),
+    ("answers_dir", settings.ANSWERS_FOLDER),
+]
+
+
+@pytest.mark.parametrize("prop_name, subfolder", FOLDER_PROPERTIES)
+@pytest.mark.parametrize(
+    "sid_str",
+    ["001_EN_UK_1_S1", "003_DE_DE_1_ET1_full_restart"],
+)
+def test_sid_dir_properties(monkeypatch, tmp_path, prop_name, subfolder, sid_str):
+    monkeypatch.setattr(type(settings), "OUTPUT_DIR", tmp_path)
+    sid = Sid(sid_str)
+    expected = tmp_path / subfolder / str(sid)
+    assert getattr(sid, prop_name) == expected

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -198,32 +198,6 @@ def test_sid_id_no_postfix(sid_str, expected_no_postfix):
 
 
 @pytest.mark.parametrize(
-    "session_idf, expected_save_name",
-    [
-        ("001_EN_UK_1_PT1", "001_EN_UK_1_PT1"),
-        ("002_ZH_CH_LAB2_S2_restart", "002_ZH_CH_LAB2_S2"),
-        ("003_DE_DE_1_ET1_full_restart", "003_DE_DE_1_ET1"),
-        (
-            "004_FR_FR_1_PT1_start_after_trial_10",
-            "004_FR_FR_1_PT1",
-        ),
-        ("non_compliant_id_extra_part", "non_compliant_id_extra_part"),
-        ("short", "short"),
-    ],
-)
-def test_sid_get_session_save_name(session_idf, expected_save_name):
-    assert Sid.get_session_save_name(session_idf) == expected_save_name
-
-
-def test_sid_get_session_save_name_include_postfix():
-    sid_str = "003_DE_DE_1_ET1_full_restart"
-    assert (
-        Sid.get_session_save_name(sid_str, include_postfix=False) == "003_DE_DE_1_ET1"
-    )
-    assert Sid.get_session_save_name(sid_str, include_postfix=True) == sid_str
-
-
-@pytest.mark.parametrize(
     "sid1_str, sid2_str, expected_match",
     [
         ("001_EN_UK_1_S1", "001_EN_UK_1_PT1", True),

--- a/tests/unit/scripts/test_run_multipleye_preprocessing.py
+++ b/tests/unit/scripts/test_run_multipleye_preprocessing.py
@@ -6,9 +6,9 @@ from pathlib import Path
 def test_reading_measures_uses_sid_consistently():
     """Test that reading measures check and save use the same Sid instance.
 
-    The Sid refactoring ensures `str(sid)` is used for folder names and
-    `sid.id_no_postfix` for filenames, eliminating the old bug where
-    folder checks used a different identifier than saves.
+    The Sid refactoring centralises folder path construction on `Sid`
+    properties, so `sid.reading_measures_dir` is the single source of truth
+    for folder lookups and save destinations.
     """
     source_file = Path("preprocessing/scripts/run_preprocessing.py")
     source_code = source_file.read_text()
@@ -19,18 +19,18 @@ def test_reading_measures_uses_sid_consistently():
     save_reading_measures_line = None
 
     for i, line in enumerate(lines):
-        if "settings.READING_MEASURES_FOLDER / str(sid)" in line:
+        if "rm_folder = sid.reading_measures_dir" in line:
             rm_folder_line = i
         if "preprocessing.save_reading_measures(" in line:
             save_reading_measures_line = i
 
-    assert rm_folder_line is not None, "Could not find rm_folder check line"
+    assert rm_folder_line is not None, "Could not find rm_folder assignment"
     assert save_reading_measures_line is not None, (
         "Could not find save_reading_measures call"
     )
 
     assert rm_folder_line < save_reading_measures_line, (
-        "rm_folder check should be defined before the save call"
+        "rm_folder should be assigned before the save call"
     )
 
 


### PR DESCRIPTION
## Summary
Get rid of ad-hoc `settings.OUTPUT_DIR / settings.FOO_FOLDER / str(sid)` patterns repeated throughout the session loop by centralising them on `Sid`.

## Changes
`class Sid`
- Add path properties: `raw_data_dir`, `fixations_dir`, `saccades_dir`, `scanpaths_dir`, `reading_measures_dir`, `metadata_dir`, `answers_dir`
- Each returns `settings.OUTPUT_DIR / settings.FOO_FOLDER / str(self)`
- Remove dead code `get_session_save_name` static method
`run_preprocessing.py`
- Replace all `settings.OUTPUT_DIR / settings.FOO_FOLDER / str(sid)` with `sid.foo_dir`
- pass `sid` object instead of raw `idf` string to `load_trial_level_events_data` in the skip-event-detection branch (lines 240, 247)
`tests/unit/preprocessing/models/test_sid.py`
- Remove tests for removed `get_session_save_name`
- Add parametrized tests for all path properties
`test_run_multipleye_preprocessing.py`
- Update consistency test to check for `sid.reading_measures_dir` instead of old `str(sid)` pattern

Acceptance criteria:
- [x] All manual `OUTPUT_DIR / FOO_FOLDER / str(sid)` replaced with `sid.abc_dir`
- [x] `get_session_save_name` removed
- [x] All existing tests pass

Closes #112