### PR TITLE
fix: Change `INFO` log color to blue for readability on light backgrounds

### DIFF
--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -132,7 +132,7 @@ def setup_logging(
     RESET = "\033[0m"
     COLORS = {
         logging.DEBUG: "\033[36m",  # Cyan
-        logging.INFO: "\033[37m",  # Light gray
+        logging.INFO: "\033[34m",  # Blue
         logging.WARNING: "\033[33m",  # Yellow
         logging.ERROR: "\033[31m",  # Red
         logging.CRITICAL: "\033[1;41m",  # Bold on red background


### PR DESCRIPTION
This PR changes the ANSI color for INFO messages from `\033[37m` (light gray) to `\033[34m` (blue). Light gray is nearly invisible on bright backgrounds (e.g., Jupyter Lab light theme). Blue is readable on both light and dark backgrounds without requiring environment detection.