### PR TITLE
feat: Notebook update: preflight check, config inspection, output docs

### DIFF
--- a/preprocessing.ipynb
+++ b/preprocessing.ipynb
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "# If you have a specific config file, load it here:\n",
-    "# settings.load_from_yaml(\"path/to/your_config.yaml\")"
+    "# settings.load_from_yaml(\"data/MultiplEYE_<...>/multipleye_settings_preprocessing.yaml\")"
    ]
   },
   {
@@ -240,28 +240,28 @@
    "outputs": [],
    "source": [
     "# pick only one session as an example to work with in the next steps\n",
-    "sessions = [s for s in multipleye]\n",
-    "sess = sessions[0]\n",
-    "idf = sess.session_identifier"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "20",
-   "metadata": {},
-   "source": [
-    "### Creating Gaze Frame from ASCII File"
+    "sessions = list(multipleye)  # list of Session objects\n",
+    "sess = sessions[0]  # a real Session\n",
+    "sid = sess.sid  # get the session ID (Sid) from the Session\n",
+    "sid"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# get the path to the .asc file for the session\n",
-    "asc = sess.asc_path"
+    "type(sess)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "### Creating Gaze Frame from ASCII File"
    ]
   },
   {
@@ -272,9 +272,9 @@
    "outputs": [],
    "source": [
     "gaze = preprocessing.load_gaze_data(\n",
-    "    asc_file=asc,\n",
+    "    asc_file=sess.asc_path,\n",
     "    lab_config=sess.lab_config,\n",
-    "    session_idf=idf,\n",
+    "    sid=sess.sid,\n",
     "    trial_cols=settings.TRIAL_COLS,\n",
     ")"
    ]
@@ -287,13 +287,23 @@
    "outputs": [],
    "source": [
     "# save gaze and metadata\n",
-    "preprocessing.save_raw_data(settings.OUTPUT_DIR, idf, gaze)\n",
-    "preprocessing.save_session_metadata(settings.OUTPUT_DIR, idf, gaze)"
+    "preprocessing.save_raw_data(sid, gaze)\n",
+    "preprocessing.save_session_metadata(sid, gaze)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sid.raw_data_dir, sid.metadata_dir"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "In order to have the metadata which is extracted by pymovements available to create out session overview, we get this information from pymovements and store it in our session object."
@@ -302,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Coordinate and Velocity Preprocessing\n",
@@ -326,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "## Stage 2a: Detect Events and Compute Their Properties\n",
@@ -376,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "We use the `I-VT` algorithm with the following key deafault parameters:\n",
@@ -389,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Saccades\n",
@@ -415,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "Save our events data."
@@ -435,14 +445,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
     "preprocessing.save_events_data(\n",
     "    settings.FIXATION,\n",
-    "    settings.OUTPUT_DIR,\n",
-    "    idf,\n",
+    "    sess.sid,\n",
     "    split_column=\"trial\",\n",
     "    name_columns=[\"trial\", \"stimulus\"],\n",
     "    file_columns=[\"onset\", \"duration\", \"location_x\", \"location_y\", \"page\"],\n",
@@ -451,8 +460,7 @@
     "\n",
     "preprocessing.save_events_data(\n",
     "    settings.SACCADE,\n",
-    "    settings.OUTPUT_DIR,\n",
-    "    idf,\n",
+    "    sess.sid,\n",
     "    split_column=\"trial\",\n",
     "    name_columns=[\"trial\", \"stimulus\"],\n",
     "    file_columns=[\n",
@@ -470,16 +478,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sess.session_identifier"
+    "str(sess.sid), sess.sid"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "## Stage 2b: Map Fixations to AOIs\n",
@@ -490,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,28 +508,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
     "# The resulting mapping can be stored as a scanpath, which is a sequence of AOIs that were fixated in the order they were fixated.\n",
-    "preprocessing.save_scanpaths(settings.OUTPUT_DIR, idf, gaze)"
+    "preprocessing.save_scanpaths(sid, gaze)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
     "# save metadata again\n",
-    "preprocessing.save_session_metadata(settings.OUTPUT_DIR, idf, gaze)"
+    "preprocessing.save_session_metadata(sid, gaze)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Stage 3: Calculate AOI-based Measures\n",
@@ -531,7 +539,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Fixation-based Metrics\n",
@@ -549,22 +557,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rm_df = preprocessing.calculate_reading_measures(gaze, sess.stimuli)\n",
-    "preprocessing.save_reading_measures(settings.OUTPUT_DIR, idf, rm_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
-    "idf"
+    "rm_df = preprocessing.calculate_reading_measures(gaze, sess.stimuli)\n",
+    "preprocessing.save_reading_measures(sid, rm_df)"
    ]
   },
   {
@@ -640,7 +638,25 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/preprocessing.ipynb
+++ b/preprocessing.ipynb
@@ -116,6 +116,35 @@
    "id": "8",
    "metadata": {},
    "source": [
+    "### Inspecting and overriding configuration\n",
+    "\n",
+    "After loading the config, you can inspect which sessions are included or excluded, and override these values for the current session without modifying the YAML file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Include pilots:  {settings.INCLUDE_PILOTS}\")\n",
+    "print(f\"Included:        {settings.INCLUDE_SESSIONS}\")\n",
+    "print(f\"Excluded:        {settings.EXCLUDE_SESSIONS}\")\n",
+    "print(f\"Output dir:      {settings.OUTPUT_DIR}\")\n",
+    "print(f\"Run preflight:   {settings.RUN_PREFLIGHT_CHECK}\")\n",
+    "print(f\"Overwrite:       {settings.OVERWRITE}\")\n",
+    "\n",
+    "# Override example (uncomment to limit processing to specific sessions):\n",
+    "# settings.INCLUDE_SESSIONS = [\"014_DE_DE_1_ET1\", \"023_DE_DE_1_ET1\"]\n",
+    "# settings.EXCLUDE_SESSIONS = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
     "## MultiplEYE-specific preprocessing & cleaning\n",
     "\n",
     "In order to be able to run a more generic preprocessing, the MultiplEYE data folder for one language needs to be cleaned and organized in a specific way. Running the script below will:\n",
@@ -130,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "source": [
     "Note that executing the cell below for the first time can take very long. ONce you did it one, it will run through quickly."
@@ -139,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "Next, we create a `MultipleyeDataCollection` object from the data folder. This will allow us to easily access the sessions and their information in the next steps."
@@ -158,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +201,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "### Preflight check\n",
+    "\n",
+    "Before processing, run a preflight check to validate the dataset structure and catch common issues (missing files, incorrect folder layout, etc.). In case EDF files are missing, you can use `settings.EXCLUDE_SESSIONS = []` to exclude them, as shown a few cells above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preprocessing.run_preflight_check(multipleye)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Stage 0: Converting EDF to ASC and Preparing Session-Level Information\n",
@@ -183,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "19",
    "metadata": {},
    "source": [
     "Once this conversion has been completed, we can load all sessions and parse the .asc files."
@@ -201,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Stage 1: Extracting Gaze Samples\n",
@@ -235,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Creating Gaze Frame from ASCII File"
@@ -267,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +352,62 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "### Output directory structure\n",
+    "\n",
+    "All preprocessed data is organised by data type under `preprocessed_data/<data_collection_name>/`. Each data type folder contains one subfolder per session:\n",
+    "\n",
+    "```\n",
+    "preprocessed_data/<dcn>/\n",
+    "├── raw_data/\n",
+    "│   └── <session_save_name>/\n",
+    "├── fixations/\n",
+    "│   └── <session_save_name>/\n",
+    "├── saccades/\n",
+    "│   └── <session_save_name>/\n",
+    "├── scanpaths/\n",
+    "│   └── <session_save_name>/\n",
+    "├── reading_measures/\n",
+    "│   └── <session_save_name>/\n",
+    "├── sanity_checks/\n",
+    "│   └── <session_save_name>/\n",
+    "├── metadata/\n",
+    "│   └── <session_save_name>/\n",
+    "│       ├── gaze_metadata.json\n",
+    "│       ├── experiment.yaml\n",
+    "│       ├── calibrations.tsv\n",
+    "│       ├── calibrations.feather\n",
+    "│       ├── validations.tsv\n",
+    "│       ├── validations.feather\n",
+    "│       └── <session_idf>_overview.yaml\n",
+    "├── participant_data.csv\n",
+    "├── <dcn>_overview.yaml\n",
+    "└── stimuli_<dcn>/\n",
+    "```\n",
+    "\n",
+    "The `Sid` object provides convenient properties to access each path:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Raw data:        {sid.raw_data_dir}\")\n",
+    "print(f\"Metadata:        {sid.metadata_dir}\")\n",
+    "print(f\"Fixations:       {sid.fixations_dir}\")\n",
+    "print(f\"Saccades:        {sid.saccades_dir}\")\n",
+    "print(f\"Scanpaths:       {sid.scanpaths_dir}\")\n",
+    "print(f\"Reading measures: {sid.reading_measures_dir}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31",
    "metadata": {},
    "source": [
     "In order to have the metadata which is extracted by pymovements available to create out session overview, we get this information from pymovements and store it in our session object."
@@ -312,11 +416,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# saving the ._metadata like this is just a temporary solution, this will be changed soon\n",
     "sess.pm_gaze_metadata = gaze._metadata\n",
     "sess.calibrations = gaze.calibrations\n",
     "sess.validations = gaze.validations"
@@ -324,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Coordinate and Velocity Preprocessing\n",
@@ -336,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Stage 2a: Detect Events and Compute Their Properties\n",
@@ -386,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "38",
    "metadata": {},
    "source": [
     "We use the `I-VT` algorithm with the following key deafault parameters:\n",
@@ -399,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Saccades\n",
@@ -425,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +539,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "42",
    "metadata": {},
    "source": [
     "Save our events data."
@@ -445,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "45",
    "metadata": {},
    "source": [
     "## Stage 2b: Map Fixations to AOIs\n",
@@ -498,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "49",
    "metadata": {},
    "source": [
     "## Stage 3: Calculate AOI-based Measures\n",
@@ -539,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Fixation-based Metrics\n",
@@ -557,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "53",
    "metadata": {},
    "source": [
     "## Final Steps\n",
@@ -590,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,14 +731,6 @@
     "\n",
     "preprocess_all_sessions()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "51",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/preprocessing.ipynb
+++ b/preprocessing.ipynb
@@ -206,7 +206,7 @@
    "source": [
     "### Preflight check\n",
     "\n",
-    "Before processing, run a preflight check to validate the dataset structure and catch common issues (missing files, incorrect folder layout, etc.). In case EDF files are missing, you can use `settings.EXCLUDE_SESSIONS = []` to exclude them, as shown a few cells above."
+    "Before processing, run a preflight check to validate the dataset structure and catch common issues (missing files, incorrect folder layout, etc.). In case EDF files are missing, you can use `settings.EXCLUDE_SESSIONS = []` to exclude specific sessions, as shown a few cells above."
    ]
   },
   {
@@ -325,6 +325,7 @@
     "    lab_config=sess.lab_config,\n",
     "    sid=sess.sid,\n",
     "    trial_cols=settings.TRIAL_COLS,\n",
+    "    messages=settings.ANSWER_MSG_PATTERNS,  # for comprehension questions later - see Stage 4.\n",
     ")"
    ]
   },
@@ -683,6 +684,59 @@
    "id": "53",
    "metadata": {},
    "source": [
+    "## Stage 4: Comprehension Question Answers\n",
+    "In addition to gaze data, each session contains answers to comprehension questions.\n",
+    "These are extracted from the ASC messages. The answers are matched to the stimulus order using the `question_order_versions.csv` file in the session's logfiles folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "answers_csv = sid.answers_dir / f\"{sid}_answers.csv\"\n",
+    "question_order_csv = (\n",
+    "    sess.session_folder_path / \"logfiles\" / \"question_order_versions.csv\"\n",
+    ")\n",
+    "parsed_answers = preprocessing.parse_answers_from_messages(gaze.messages)\n",
+    "source = \"asc\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parsed_answers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preprocessing.collect_session_answers(\n",
+    "    question_order_csv=question_order_csv,\n",
+    "    stimuli_trial_map=sess.stimuli_trial_mapping,\n",
+    "    stimuli=sess.stimuli,\n",
+    "    parsed_answers=parsed_answers,\n",
+    "    out_path=answers_csv,\n",
+    "    source=source,\n",
+    "    completed_stimuli_ids=sess.completed_stimuli_ids,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57",
+   "metadata": {},
+   "source": [
     "## Final Steps\n",
     "\n",
     "In the very end, we can create the session and dataset overview and store them as well. In addition, the participant data can be parsed and stored.\n",
@@ -693,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,7 +775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/preprocessing/api.py
+++ b/preprocessing/api.py
@@ -21,6 +21,7 @@ from .io.load import (
 from .answers.msg_parser import parse_answers_from_messages
 from .answers.experiment_log_parser import parse_answers_from_logfile
 from .answers.collect import collect_session_answers
+from .checks.preflight import run_preflight_check
 
 from .scripts.prepare_language_folder import prepare_language_folder
 from .scripts.restructure_psycho_tests import fix_psycho_tests_structure
@@ -46,4 +47,5 @@ __all__ = [
     "parse_answers_from_messages",
     "parse_answers_from_logfile",
     "collect_session_answers",
+    "run_preflight_check",
 ]

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -226,14 +226,12 @@ def run_preprocessing(config_path: str | None = None):
                 logger.info(f"Using existing event data for {sess.sid}")
                 gaze = preprocessing.load_trial_level_events_data(
                     gaze,
-                    settings.OUTPUT_DIR,
                     sess.sid,
                     event_type=settings.FIXATION,
                     file_pattern=None,
                 )
                 gaze = preprocessing.load_trial_level_events_data(
                     gaze,
-                    settings.OUTPUT_DIR,
                     sess.sid,
                     event_type=settings.SACCADE,
                     file_pattern=None,


### PR DESCRIPTION
- Update notebook to use the current preprocessing API (`sess.sid`, `(sid, gaze)` save signatures, sid= in load functions)
- Remove stale `settings.OUTPUT_DIR` argument from `load_trial_level_events_data` calls in `run_preprocessing.py` (would crash when event detection flags are off but existing data folders exist)
- Export `run_preflight_check` through `preprocessing.api` so it's accessible as `preprocessing.run_preflight_check()`
- Add post-config-load inspection cell showing key settings (INCLUDE_SESSIONS, EXCLUDE_SESSIONS, INCLUDE_PILOTS, OUTPUT_DIR, etc.) with commented-out override example
- Add preflight check cell after data collection creation
- Add output directory structure documentation (markdown file tree from PR #105) with code cell showing all Sid path properties
- Remove outdated "temporary solution" comment from metadata assignment cel