### PR TITLE
feat: Integrate psychometric tests into pipeline

### DIFF
--- a/preprocessing/api.py
+++ b/preprocessing/api.py
@@ -24,10 +24,12 @@ from .answers.collect import collect_session_answers
 
 from .scripts.prepare_language_folder import prepare_language_folder
 from .scripts.restructure_psycho_tests import fix_psycho_tests_structure
+from .psychometric_tests.preprocess_psychometric_tests import preprocess_all_sessions
 
 __all__ = [
     "prepare_language_folder",
     "fix_psycho_tests_structure",
+    "preprocess_all_sessions",
     "preprocess_gaze",
     "compute_event_properties",  # needed in API? - not directly used in the preprocessing pipeline
     "calculate_reading_measures",

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -238,7 +238,20 @@ def _check_shared_files(
     warnings: dict[str, list[str]] | None = None,
 ) -> None:
     """Check files that are shared across all sessions (data-collection level)."""
-    stim_dir = data_collection.stimulus_dir
+    from ..config import settings
+
+    # Always validate the source stimulus folder in data/, not the OUTPUT_DIR copy that
+    # prepare_language_folder may have created.
+    source_stim_dir = getattr(
+        data_collection,
+        "data_collection_name",
+        None,
+    )
+    if source_stim_dir:
+        source_stim_dir = settings.DATASET_DIR / f"stimuli_{source_stim_dir}"
+    if not source_stim_dir or not source_stim_dir.exists():
+        source_stim_dir = data_collection.stimulus_dir
+    stim_dir = source_stim_dir
     lang = data_collection.language
     country = data_collection.country
     labnum = data_collection.lab_number

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -73,6 +73,10 @@ def _print_warnings(warnings: dict[str, list[str]]) -> None:
             for path in warnings[label]:
                 lines.append(f"\n  {label} not found:\n      {os.path.relpath(path)}")
 
+    if "Psychometric tests" in warnings:
+        for msg in warnings["Psychometric tests"]:
+            lines.append(f"\n  {msg}")
+
     print("\n".join(lines), file=sys.stderr)
 
 
@@ -98,12 +102,14 @@ def run_preflight_check(data_collection) -> None:
     _check_skipped_sessions(data_collection, errors)
     _check_sessions(data_collection, errors)
 
-    if errors:
-        combined = {}
-        combined.update(warnings)
-        combined.update(errors)
-        raise PreflightError(combined)
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(data_collection, pt_warnings)
 
+    if errors:
+        raise PreflightError(errors)
+
+    if pt_warnings:
+        warnings["Psychometric tests"] = pt_warnings
     if warnings:
         _print_warnings(warnings)
         return
@@ -438,3 +444,135 @@ def _format_message(groups: dict[str, list[str]]) -> str:
             lines.append(f"      {entry}")
 
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Psychometric tests
+# ---------------------------------------------------------------------------
+
+
+def _check_psychometric_tests(
+    data_collection,
+    pt_warnings: list[str],
+) -> None:
+    """Check psychometric tests data availability (warn-only).
+
+    Detects the format of psychometric test data and auto-restructures if
+    task-first format is found.
+    All issues are appended to *pt_warnings*: the batch processing has its own logging.
+    """
+    from ..config import settings
+
+    if not settings.RUN_PSYCHOMETRIC_TESTS:
+        return
+
+    pt_dir = settings.PSYCHOMETRIC_TESTS_DIR
+    lang = data_collection.language
+    country = data_collection.country
+    lab = str(data_collection.lab_number)
+    test_names = set(settings.PSYCHOMETRIC_TEST_MAPPING.values())
+
+    if not pt_dir.exists():
+        pt_warnings.append(
+            f"No 'psychometric-tests-sessions' folder found at {pt_dir}. "
+            "Psychometric tests stage will be skipped."
+        )
+        return
+
+    if _detect_session_first(pt_dir, test_names):
+        _validate_session_first(pt_dir, test_names, pt_warnings)
+        return
+
+    for base in [pt_dir, pt_dir / "core_data"]:
+        config_path = base / f"participant_configs_{lang}_{country}_{lab}"
+        data_path = base / f"psychometric_test_{lang}_{country}_{lab}"
+
+        if config_path.exists() and data_path.exists():
+            logger.info(
+                f"Task-first psychometric test data found at {data_path}. "
+                f"Auto-restructuring to {pt_dir}..."
+            )
+            try:
+                from ..scripts.restructure_psycho_tests import (
+                    fix_psycho_tests_structure,
+                )
+
+                fix_psycho_tests_structure(config_path, data_path)
+                logger.info("Psychometric tests restructured to session-first format.")
+            except Exception as e:
+                pt_warnings.append(
+                    f"Auto-restructuring psychometric tests failed: {e}. "
+                    "You can run 'restructure_psychometric_tests' CLI manually."
+                )
+            return
+
+    archives = _find_archives(pt_dir)
+    if archives:
+        pt_warnings.append(
+            f"Archives found in {pt_dir}: {', '.join(archives)}. "
+            "Please unzip the psychometric test data and place it in the expected structure:\n"
+            f"  {pt_dir}/psychometric_test_{lang}_{country}_{lab}/\n"
+            f"    PLAB/{{sid}}/...\n"
+            f"    RAN/{{sid}}/...\n"
+            f"    Stroop_Flanker/{{sid}}/...\n"
+            f"    WMC/{{sid}}/...\n"
+            f"    WikiVocab/{{sid}}/...\n"
+            f"  {pt_dir}/participant_configs_{lang}_{country}_{lab}/\n"
+            f"    {{sid}}.yaml"
+        )
+        return
+
+    pt_warnings.append(
+        f"No recognizable psychometric test data found in {pt_dir}. "
+        "Psychometric tests stage will be skipped."
+    )
+
+
+def _detect_session_first(pt_dir: Path, test_names: set[str]) -> bool:
+    """Check if *pt_dir* contains session-first (restructured) data.
+
+    A folder counts as session-first if its name is SID-compliant and it
+    contains at least one test subfolder (PLAB, RAN, etc.).
+    """
+    from ..models.sid import Sid
+
+    for child in pt_dir.iterdir():
+        if not child.is_dir():
+            continue
+        try:
+            Sid(child.name)
+        except (ValueError, TypeError):
+            continue
+        try:
+            for sub in child.iterdir():
+                if sub.is_dir() and sub.name in test_names:
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _validate_session_first(
+    pt_dir: Path,
+    test_names: set[str],
+    pt_warnings: list[str],
+) -> None:
+    """Warn-only validation of session-first psychometric test data."""
+    for child in sorted(pt_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        has_test_subfolder = any((child / t).is_dir() for t in test_names)
+        if not has_test_subfolder:
+            continue
+
+        config_files = list(child.glob("*.yaml"))
+        if not config_files:
+            pt_warnings.append(
+                f"Session folder '{child.name}' has no YAML config file."
+            )
+
+        for test_name in sorted(test_names):
+            if not (child / test_name).is_dir():
+                pt_warnings.append(
+                    f"Session folder '{child.name}' is missing test folder: {test_name}"
+                )

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -101,6 +101,7 @@ def run_preflight_check(data_collection) -> None:
     _check_shared_files(data_collection, errors, warnings)
     _check_skipped_sessions(data_collection, errors)
     _check_sessions(data_collection, errors)
+    _check_stimulus_order_coverage(data_collection, errors)
 
     pt_warnings: list[str] = []
     _check_psychometric_tests(data_collection, pt_warnings)
@@ -406,6 +407,75 @@ def _check_parseable_csv(
         )
 
 
+def _check_stimulus_order_coverage(
+    data_collection,
+    groups: dict[str, list[str]],
+) -> None:
+    """Check that every session's participant ID is present in the stimulus order versions CSV.
+
+    Detects missing and duplicate participant IDs, which would cause
+    ``_load_session_stimulus_order`` to fail mid-pipeline.
+    """
+    from ..config import settings
+    from ..models.sid import Sid
+
+    # Resolve the *source* stimulus dir (same logic as _check_shared_files)
+    dcn_name = getattr(data_collection, "data_collection_name", None)
+    if dcn_name:
+        source_stim_dir = settings.DATASET_DIR / f"stimuli_{dcn_name}"
+    else:
+        source_stim_dir = data_collection.stimulus_dir
+    if not source_stim_dir.exists():
+        source_stim_dir = data_collection.stimulus_dir
+
+    csv_path = (
+        source_stim_dir
+        / "config"
+        / f"stimulus_order_versions_{data_collection.language}_{data_collection.country}_{data_collection.lab_number}.csv"
+    )
+    if not _ci_exists(csv_path):
+        return  # already reported by _check_shared_files
+
+    try:
+        df = pl.read_csv(_ci_resolve(csv_path), infer_schema_length=0)
+    except Exception:
+        return  # already reported by _check_shared_files
+
+    if "participant_id" not in df.columns:
+        return  # already reported by _check_shared_files
+
+    # Read non-null participant IDs from the CSV
+    csv_pids_raw = df.filter(pl.col("participant_id").is_not_null())[
+        "participant_id"
+    ].to_list()
+
+    # Check each session's PID
+    missing_pids: list[str] = []
+    duplicate_pids: list[str] = []
+    for session in data_collection.sessions.values():
+        try:
+            pid = Sid(session.session_identifier).pid
+        except (ValueError, TypeError):
+            continue
+
+        count = sum(1 for p in csv_pids_raw if str(int(float(p))).zfill(3) == pid)
+        if count == 0:
+            missing_pids.append(f"{session.session_identifier} (PID {pid})")
+        elif count > 1:
+            duplicate_pids.append(
+                f"{session.session_identifier} (PID {pid}, {count} entries)"
+            )
+
+    for entry in missing_pids:
+        groups.setdefault("Stimulus order versions coverage", []).append(
+            f"{entry} — not found in stimulus_order_versions CSV"
+        )
+    for entry in duplicate_pids:
+        groups.setdefault("Stimulus order versions coverage", []).append(
+            f"{entry} — duplicate entries in stimulus_order_versions CSV"
+        )
+
+
 def _format_message(groups: dict[str, list[str]]) -> str:
     """Transform the grouped error dict into a human-readable message."""
     n_total = sum(len(v) for v in groups.values())
@@ -448,6 +518,7 @@ def _format_message(groups: dict[str, list[str]]) -> str:
         "GENERAL_LOGFILE_*.txt",
         "completed_stimuli.csv",
         "question_order_versions.csv",
+        "Stimulus order versions coverage",
     ]:
         if label not in groups:
             continue
@@ -455,6 +526,26 @@ def _format_message(groups: dict[str, list[str]]) -> str:
         lines.append(f"\n  {label} \u2014 {len(entries)}:")
         for entry in entries:
             lines.append(f"      {entry}")
+
+    # --- Sessions concerned (summary) -------------------------------------
+    per_session_labels = [
+        "EDF data file",
+        "Logfiles folder",
+        "EXPERIMENT_*.txt",
+        "GENERAL_LOGFILE_*.txt",
+        "completed_stimuli.csv",
+        "question_order_versions.csv",
+        "Stimulus order versions coverage",
+    ]
+    sessions_concerned: set[str] = set()
+    for label in per_session_labels:
+        for entry in groups.get(label, []):
+            sid = entry.split(" (")[0]
+            sessions_concerned.add(sid)
+    if sessions_concerned:
+        lines.append(
+            f"\n  Sessions concerned: {', '.join(f"'{s}'" for s in sorted(sessions_concerned))}"
+        )
 
     return "\n".join(lines)
 

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -152,7 +152,7 @@ class Settings:
 
     @property
     def PSYCHOMETRIC_TESTS_DIR(self) -> Path:
-        """The directory for psychometric tests."""
+        """The directory for psychometric test sessions (input, session-first)."""
         if "PSYCHOMETRIC_TESTS_DIR" in self.__dict__:
             return self.__dict__["PSYCHOMETRIC_TESTS_DIR"]
         return self.DATASET_DIR / "psychometric-tests-sessions"
@@ -163,7 +163,7 @@ class Settings:
 
     @property
     def PSYM_CORE_DATA(self) -> Path:
-        """The directory for core psychometric data."""
+        """The directory for raw psychometric data (task-first, input)."""
         if "PSYM_CORE_DATA" in self.__dict__:
             return self.__dict__["PSYM_CORE_DATA"]
         return self.PSYCHOMETRIC_TESTS_DIR / "core_data"
@@ -408,6 +408,9 @@ class Settings:
         #: Subfolder name for comprehension question answers.
         self.ANSWERS_FOLDER = Path("comp_answers/")
 
+        #: Subfolder name for psychometric tests output (overview + detailed CSVs).
+        self.PSYCHOMETRIC_TESTS_FOLDER = Path("psychometric_tests/")
+
         #: Regex patterns for relevant ASC messages for comprehension questions.
         self.ANSWER_MSG_PATTERNS = [
             r"start_recording_.*_question_\d+",
@@ -427,6 +430,8 @@ class Settings:
         self.RUN_READING_MEASURES = True
         #: Whether to collect comprehension question answers.
         self.RUN_COMPREHENSION_ANSWERS = True
+        #: Whether to process psychometric tests.
+        self.RUN_PSYCHOMETRIC_TESTS = True
         #: Whether to create sanity check reports.
         self.RUN_SANITY_CHECKS = True
         #: Whether to run the preflight input file check before processing.

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -422,6 +422,8 @@ class Settings:
         ]
 
         # --- PIPELINE STAGES ---
+        #: Whether to run the preflight input file check before processing.
+        self.RUN_PREFLIGHT_CHECK = True
         #: Whether to perform fixation detection.
         self.RUN_FIXATION_DETECTION = True
         #: Whether to perform saccade detection.
@@ -430,12 +432,10 @@ class Settings:
         self.RUN_READING_MEASURES = True
         #: Whether to collect comprehension question answers.
         self.RUN_COMPREHENSION_ANSWERS = True
-        #: Whether to process psychometric tests.
-        self.RUN_PSYCHOMETRIC_TESTS = True
         #: Whether to create sanity check reports.
         self.RUN_SANITY_CHECKS = True
-        #: Whether to run the preflight input file check before processing.
-        self.RUN_PREFLIGHT_CHECK = True
+        #: Whether to process psychometric tests.
+        self.RUN_PSYCHOMETRIC_TESTS = True
 
         #: Column name for the trial identifier.
         self.TRIAL_COL = "trial"

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -1375,7 +1375,7 @@ class MultipleyeDataCollection:
             et_sid = None
 
         if self.psychometric_tests:
-            pt_dir = self.data_root.parent / "psychometric-tests-sessions"
+            pt_dir = settings.PSYCHOMETRIC_TESTS_DIR
             found_path = None
 
             if pt_dir.exists() and et_sid:

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -280,7 +280,7 @@ class MultipleyeDataCollection:
                     else:
                         if item.name not in settings.IGNORED_SESSION_FOLDERS:
                             self.logger.warning(
-                                f"Folder in eye-tracking-sessions {item.name} does not match the eye-tracking session regex pattern "
+                                f"Folder in eye-tracking-sessions '{item.name}' does not match the eye-tracking session regex pattern "
                                 f"{session_folder_regex}. Not considered an eye-tracking session."
                             )
 

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -154,6 +154,12 @@ class Sid:
 
         return _settings.OUTPUT_DIR / _settings.ANSWERS_FOLDER / str(self)
 
+    @property
+    def psychometric_tests_dir(self) -> Path:
+        from ..config import settings as _settings
+
+        return _settings.OUTPUT_DIR / _settings.PSYCHOMETRIC_TESTS_FOLDER / str(self)
+
     def __str__(self) -> str:
         base = self.id_no_postfix
         if self.postfix:

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -38,25 +38,26 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
     3. Extracts session information (PID, session part, postfix).
     4. Preprocesses each individual test (LWMC, RAN, Stroop, Flanker, WikiVocab, PLAB).
     5. Aggregates results into an overview row per session.
-    6. Writes a detailed CSV for each session within its folder.
-    7. Writes a comprehensive overview CSV for all sessions.
+    6. Writes a detailed CSV for each session to the output directory.
+    7. Writes a comprehensive overview CSV for all sessions to the output directory.
 
     Two types of outputs are generated:
 
-    1. **Overview CSV** (one row per session) saved directly under the
-       psychometric-tests-sessions folder. The filename is descriptive and
-       includes the study/session tag (e.g. "SQ_CH_1_PT2"). The overview
-       contains only the requested summary metrics:
+    1. **Overview CSV** (one row per session) saved to
+       ``OUTPUT_DIR / PSYCHOMETRIC_TESTS_FOLDER``.
+       The filename includes the data collection name.
+       The overview contains only the requested summary metrics:
        - LWMC: scores only (no times)
        - Stroop & Flanker: AccuracyEffect and TREffect only
        - WikiVocab: rt_mean, accuracy, incorrect_correct_score
        - RAN: Reaction time for two trials
        - PLAB: RT mean and accuracy
 
-    2. **Per-session detailed CSV** placed in each session folder with all
-       available detailed metrics in a readable, wide format (namespaced
-       columns). For example, grouped RT/accuracy for Stroop/Flanker are stored
-       as columns like ``Stroop_congruent_rt_mean``.
+    2. **Per-session detailed CSV** saved to
+       ``OUTPUT_DIR / PSYCHOMETRIC_TESTS_FOLDER / {session_name}``
+       with all available detailed metrics in a readable, wide format
+       (namespaced columns). For example, grouped RT/accuracy for
+       Stroop/Flanker are stored as columns like ``Stroop_congruent_rt_mean``.
 
     Parameters
     ----------
@@ -76,6 +77,9 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
     """
     if test_session_folder is None:
         test_session_folder = settings.PSYCHOMETRIC_TESTS_DIR
+
+    output_dir = settings.OUTPUT_DIR / settings.PSYCHOMETRIC_TESTS_FOLDER
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Run sanity check before processing
     validate_psychometric_data(
@@ -265,23 +269,22 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                     category=UserWarning,
                 )
 
-        # Write per-session detailed CSV inside the session folder
+        # Write per-session detailed CSV to the output directory
         try:
-            detailed_path = session / f"psychometric_details_{session.stem}.csv"
+            detailed_out = output_dir / session.name
+            detailed_out.mkdir(parents=True, exist_ok=True)
+            detailed_path = detailed_out / f"psychometric_details_{session.name}.csv"
             pd.DataFrame([detailed_row]).to_csv(detailed_path, index=False)
         except Exception as exc:
             warnings.warn(
-                f"Failed to write detailed CSV for {session.stem}: {exc}",
+                f"Failed to write detailed CSV for {session.name}: {exc}",
                 category=UserWarning,
             )
 
         overview_rows.append(overview_row)
 
-    # Write overview CSV (wide format) directly into psychometric-tests-sessions folder
-    out_path = (
-        test_session_folder
-        / f"psychometric_overview_{test_session_folder.parent.stem}.csv"
-    )
+    # Write overview CSV (wide format) to the output directory
+    out_path = output_dir / f"psychometric_overview_{settings.DATA_COLLECTION_NAME}.csv"
     df = pd.DataFrame(overview_rows)
     # Ensure columns order: session_id, participant_id, then flags, then notes, then the rest
     session_cols = ["session_id"]

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -79,6 +79,17 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
         test_session_folder = settings.PSYCHOMETRIC_TESTS_DIR
 
     output_dir = settings.OUTPUT_DIR / settings.PSYCHOMETRIC_TESTS_FOLDER
+
+    if not test_session_folder.exists() or not any(
+        _is_valid_folder(p) for p in test_session_folder.iterdir()
+    ):
+        from ..utils.logging import get_logger
+
+        get_logger(__name__).info(
+            "No psychometric test session folders found. Skipping."
+        )
+        return output_dir
+
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Run sanity check before processing

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -86,7 +86,7 @@ def prepare_language_folder(data_collection_name: str | None = None):
                 tar.extractall(path=data_folder_path)
             logger.info(f"Extracted 'psychometric-tests' from '{tar_path}'")
         else:
-            msg = (
+            logger.warning(
                 f"The 'psychometric-tests-sessions' folder does not exist in '{data_folder_path}'. "
                 "If this data collection includes psychometric tests, please create the folder "
                 f"'{psychometric_tests_path}' and unzip the psychometric test data there.\n"
@@ -100,23 +100,25 @@ def prepare_language_folder(data_collection_name: str | None = None):
                 "      WikiVocab/{sid}/...\n"
                 f"    participant_configs_{dcn.lang}_{dcn.country}_{dcn.lab}/\n"
                 "      {sid}.yaml\n"
+                "Skipping psychometric tests preparation."
             )
-            raise FileNotFoundError(msg)
+            psychometric_tests_path = None
 
-    # che if ps tests need to be prepared because they use the old structure
-    config_path = (
-        psychometric_tests_path
-        / f"participant_configs_{dcn.lang}_{dcn.country}_{dcn.lab}"
-    )
-    data_path = (
-        psychometric_tests_path
-        / f"psychometric_test_{dcn.lang}_{dcn.country}_{dcn.lab}"
-    )
-    if config_path.exists() and data_path.exists():
-        logger.info(
-            f"Preparing psychometric tests structure for {data_collection_name}..."
+    # check if ps tests need to be prepared because they use the old structure
+    if psychometric_tests_path is not None:
+        config_path = (
+            psychometric_tests_path
+            / f"participant_configs_{dcn.lang}_{dcn.country}_{dcn.lab}"
         )
-        fix_psycho_tests_structure(config_path, data_path)
+        data_path = (
+            psychometric_tests_path
+            / f"psychometric_test_{dcn.lang}_{dcn.country}_{dcn.lab}"
+        )
+        if config_path.exists() and data_path.exists():
+            logger.info(
+                f"Preparing psychometric tests structure for {data_collection_name}..."
+            )
+            fix_psycho_tests_structure(config_path, data_path)
 
     # check if the participant folders are zipped and if yes, unzip them
     for participant_folder in eye_tracking_sessions_path.glob("*"):

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -86,10 +86,22 @@ def prepare_language_folder(data_collection_name: str | None = None):
                 tar.extractall(path=data_folder_path)
             logger.info(f"Extracted 'psychometric-tests' from '{tar_path}'")
         else:
-            raise FileNotFoundError(
+            msg = (
                 f"The 'psychometric-tests-sessions' folder does not exist in '{data_folder_path}'. "
-                "Please ensure the data collection is correctly structured."
+                "If this data collection includes psychometric tests, please create the folder "
+                f"'{psychometric_tests_path}' and unzip the psychometric test data there.\n"
+                "Expected structure after unzipping (task-first):\n"
+                f"  psychometric-tests-sessions/\n"
+                f"    psychometric_test_{dcn.lang}_{dcn.country}_{dcn.lab}/\n"
+                "      PLAB/{sid}/...\n"
+                "      RAN/{sid}/...\n"
+                "      Stroop_Flanker/{sid}/...\n"
+                "      WMC/{sid}/...\n"
+                "      WikiVocab/{sid}/...\n"
+                f"    participant_configs_{dcn.lang}_{dcn.country}_{dcn.lab}/\n"
+                "      {sid}.yaml\n"
             )
+            raise FileNotFoundError(msg)
 
     # che if ps tests need to be prepared because they use the old structure
     config_path = (

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -378,6 +378,14 @@ def run_preprocessing(config_path: str | None = None):
     data_collection.create_dataset_overview(path=settings.OUTPUT_DIR)
     data_collection.parse_participant_data(settings.OUTPUT_DIR / "participant_data.csv")
 
+    if settings.RUN_PSYCHOMETRIC_TESTS:
+        logger.info("Processing psychometric tests...")
+        from ..psychometric_tests.preprocess_psychometric_tests import (
+            preprocess_all_sessions,
+        )
+
+        preprocess_all_sessions(settings.PSYCHOMETRIC_TESTS_DIR)
+
 
 def main():
     """Run MultiplEYE preprocessing with the config file as argument."""

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -74,6 +74,8 @@ acceptable_num_trials: 10
 tracked_eye: ["L", "R", "RIGHT", "LEFT"]
 
 # --- PIPELINE STAGES ---
+# Whether to run the preflight input file check before processing.
+RUN_PREFLIGHT_CHECK: true
 # Whether to perform fixation detection.
 RUN_FIXATION_DETECTION: true
 # Whether to perform saccade detection.
@@ -82,12 +84,10 @@ RUN_SACCADE_DETECTION: true
 RUN_READING_MEASURES: true
 # Whether to collect comprehension question answers.
 RUN_COMPREHENSION_ANSWERS: true
-# Whether to process psychometric tests.
-RUN_PSYCHOMETRIC_TESTS: true
 # Whether to create sanity check reports.
 RUN_SANITY_CHECKS: true
-# Whether to run the preflight input file check before processing.
-RUN_PREFLIGHT_CHECK: true
+# Whether to process psychometric tests.
+RUN_PSYCHOMETRIC_TESTS: true
 
 # --- INTERNAL (do not change) ---
 # Whether to force reconversion of EDF files to ASC even if output exists.

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -82,6 +82,8 @@ RUN_SACCADE_DETECTION: true
 RUN_READING_MEASURES: true
 # Whether to collect comprehension question answers.
 RUN_COMPREHENSION_ANSWERS: true
+# Whether to process psychometric tests.
+RUN_PSYCHOMETRIC_TESTS: true
 # Whether to create sanity check reports.
 RUN_SANITY_CHECKS: true
 # Whether to run the preflight input file check before processing.
@@ -98,6 +100,7 @@ reading_measures_folder: "reading_measures/"
 sanity_checks_folder: "sanity_checks/"
 metadata_folder: "metadata/"
 answers_folder: "comp_answers/"
+psychometric_tests_folder: "psychometric_tests/"
 trial_cols: ["trial", "stimulus", "page"]
 trial_col: "trial"
 page_col: "page"

--- a/tests/unit/data_collection/test_ignored_folders.py
+++ b/tests/unit/data_collection/test_ignored_folders.py
@@ -73,7 +73,7 @@ def test_add_recorded_sessions_logging(
     ):
         instance.add_recorded_sessions(data_root, regex)
 
-        warning_msg = f"Folder in eye-tracking-sessions {folder_name} does not match the eye-tracking session regex pattern {regex}. Not considered an eye-tracking session."
+        warning_msg = f"Folder in eye-tracking-sessions '{folder_name}' does not match the eye-tracking session regex pattern {regex}. Not considered an eye-tracking session."
 
         if should_warn:
             instance.logger.warning.assert_called_with(warning_msg)

--- a/tests/unit/preprocessing/checks/test_preflight.py
+++ b/tests/unit/preprocessing/checks/test_preflight.py
@@ -6,11 +6,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
+import yaml
 
 from preprocessing.checks.preflight import (
     PreflightError,
     run_preflight_check,
+    _check_psychometric_tests,
 )
+from preprocessing.config import settings
 
 
 @dataclass
@@ -607,3 +610,309 @@ def _make_empty(path: Path) -> None:
             shutil.rmtree(child)
         else:
             child.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Psychometric tests preflight checks
+# ---------------------------------------------------------------------------
+
+ALL_TESTS = ["PLAB", "RAN", "Stroop_Flanker", "WMC", "WikiVocab"]
+
+
+@pytest.fixture
+def pt_env(tmp_path: Path, monkeypatch):
+    """Set up a basic environment with PT dir and a FakeDataCollection."""
+    pt_dir = tmp_path / "data" / "dcn" / "psychometric-tests-sessions"
+    pt_dir.mkdir(parents=True)
+    monkeypatch.setattr(type(settings), "PSYCHOMETRIC_TESTS_DIR", pt_dir)
+    monkeypatch.setattr(settings, "RUN_PSYCHOMETRIC_TESTS", True)
+
+    dc = FakeDataCollection(
+        stimulus_dir=tmp_path / "stimuli",
+        language="EN",
+        country="UK",
+        lab_number=1,
+        sessions={},
+    )
+    return dc, pt_dir
+
+
+def _make_session_first(
+    pt_dir: Path,
+    sid: str = "001_EN_UK_1_PT1",
+    tests: list[str] | None = None,
+    with_yaml: bool = True,
+):
+    """Create a session-first folder with given test subfolders."""
+    tests = tests if tests is not None else ALL_TESTS
+    session = pt_dir / sid
+    session.mkdir(parents=True, exist_ok=True)
+    if with_yaml:
+        (session / f"{sid}.yaml").touch()
+    for t in tests:
+        (session / t).mkdir()
+    return session
+
+
+def _make_task_first(
+    base: Path,
+    lang: str = "EN",
+    country: str = "UK",
+    lab: str = "1",
+    tests: list[str] | None = None,
+):
+    """Create a task-first structure under *base* (either pt_dir or core_data)."""
+    tests = tests if tests is not None else ["PLAB", "RAN"]
+    config_dir = base / f"participant_configs_{lang}_{country}_{lab}"
+    config_dir.mkdir(parents=True)
+    yaml.safe_dump({"dummy": True}, open(config_dir / "001_EN_UK_1_S1.yaml", "w"))
+
+    data_dir = base / f"psychometric_test_{lang}_{country}_{lab}"
+    for t in tests:
+        s = data_dir / t / "001_EN_UK_1_PT1"
+        s.mkdir(parents=True)
+        (s / "data.csv").write_text("dummy", encoding="utf-8")
+    return config_dir, data_dir
+
+
+@pytest.mark.parametrize(
+    "scenario, setup_fn, expect_warnings",
+    [
+        (
+            "session_first_missing_tests",
+            lambda pt_dir: _make_session_first(pt_dir, tests=["PLAB"]),
+            ["missing test folder: RAN", "missing test folder: WMC"],
+        ),
+        (
+            "session_first_missing_yaml",
+            lambda pt_dir: _make_session_first(pt_dir, with_yaml=False),
+            ["no YAML config"],
+        ),
+    ],
+    ids=["session_first_missing_tests", "session_first_missing_yaml"],
+)
+def test_pt_check_session_first_warnings(pt_env, scenario, setup_fn, expect_warnings):
+    """Session-first data with issues produces the expected warnings."""
+    dc, pt_dir = pt_env
+    setup_fn(pt_dir)
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+    for substr in expect_warnings:
+        assert any(substr in w for w in pt_warnings), (
+            f"Expected '{substr}' in warnings: {pt_warnings}"
+        )
+
+
+def test_pt_check_session_first_valid(pt_env):
+    """Well-formed session-first data produces no warnings."""
+    dc, pt_dir = pt_env
+    _make_session_first(pt_dir)
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+    assert pt_warnings == []
+
+
+def test_pt_check_task_first_auto_restructure_flat(pt_env):
+    """Auto-restructures flat task-first data to session-first."""
+    dc, pt_dir = pt_env
+    _make_task_first(pt_dir)
+
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+
+    assert not any("No recognizable" in w for w in pt_warnings)
+    assert not any("Archives found" in w for w in pt_warnings)
+
+    restructured = pt_dir / "001_EN_UK_1_PT1"
+    assert restructured.exists()
+    assert (restructured / "PLAB").is_dir()
+    assert (restructured / "001_EN_UK_1_S1.yaml").exists()
+
+
+def test_pt_check_task_first_auto_restructure_core_data(pt_env):
+    """Auto-restructures task-first data under core_data/ wrapper."""
+    dc, pt_dir = pt_env
+    core_data = pt_dir / "core_data"
+    core_data.mkdir()
+    _make_task_first(core_data)
+
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+
+    restructured = pt_dir / "001_EN_UK_1_PT1"
+    assert restructured.exists()
+    assert (restructured / "PLAB").is_dir()
+
+
+def test_pt_check_no_folder(tmp_path: Path, monkeypatch):
+    """Warns when psychometric-tests-sessions folder doesn't exist."""
+    monkeypatch.setattr(
+        type(settings), "PSYCHOMETRIC_TESTS_DIR", tmp_path / "nonexistent"
+    )
+    monkeypatch.setattr(settings, "RUN_PSYCHOMETRIC_TESTS", True)
+
+    dc = FakeDataCollection(
+        stimulus_dir=tmp_path / "stimuli",
+        language="EN",
+        country="UK",
+        lab_number=1,
+        sessions={},
+    )
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+    assert len(pt_warnings) == 1
+    assert "No 'psychometric-tests-sessions' folder" in pt_warnings[0]
+
+
+@pytest.mark.parametrize(
+    "setup_fn, expected_substrings",
+    [
+        (
+            lambda pt_dir: (pt_dir / "psychometric_data.zip").write_text(
+                "fake", encoding="utf-8"
+            ),
+            ["Archives found", "psychometric_data.zip", "psychometric_test_EN_UK_1"],
+        ),
+        (
+            lambda pt_dir: (
+                (pt_dir / "random_folder").mkdir()
+                or (pt_dir / "random_folder" / "stuff.txt").write_text(
+                    "x", encoding="utf-8"
+                )
+            ),
+            ["No recognizable"],
+        ),
+    ],
+    ids=["archives_found", "unrecognized_data"],
+)
+def test_pt_check_data_issues(
+    tmp_path: Path, monkeypatch, setup_fn, expected_substrings
+):
+    """Warns about archives or unrecognized data in the PT folder."""
+    pt_dir = tmp_path / "pt"
+    pt_dir.mkdir()
+    monkeypatch.setattr(type(settings), "PSYCHOMETRIC_TESTS_DIR", pt_dir)
+    monkeypatch.setattr(settings, "RUN_PSYCHOMETRIC_TESTS", True)
+    setup_fn(pt_dir)
+
+    dc = FakeDataCollection(
+        stimulus_dir=tmp_path / "stimuli",
+        language="EN",
+        country="UK",
+        lab_number=1,
+        sessions={},
+    )
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+    assert len(pt_warnings) == 1
+    for substr in expected_substrings:
+        assert substr in pt_warnings[0]
+
+
+def test_pt_check_flag_disabled(pt_env, monkeypatch):
+    """No warnings when RUN_PSYCHOMETRIC_TESTS is False."""
+    dc, pt_dir = pt_env
+    monkeypatch.setattr(settings, "RUN_PSYCHOMETRIC_TESTS", False)
+    pt_warnings: list[str] = []
+    _check_psychometric_tests(dc, pt_warnings)
+    assert pt_warnings == []
+
+
+def test_pt_does_not_inflate_error_count(tmp_path: Path, monkeypatch):
+    """PT warnings must not inflate PreflightError.num_errors."""
+    monkeypatch.setattr(
+        type(settings), "PSYCHOMETRIC_TESTS_DIR", tmp_path / "nonexistent_pt"
+    )
+    monkeypatch.setattr(settings, "RUN_PSYCHOMETRIC_TESTS", True)
+
+    stim_dir = tmp_path / "stimuli"
+    stim_dir.mkdir()
+    lang = "EN"
+    lang_lower = lang.lower()
+    country = "UK"
+    country_lower = country.lower()
+    labnum = 1
+    city = "city"
+    year = 2024
+
+    (stim_dir / f"multipleye_stimuli_experiment_{lang}.xlsx").write_text("x")
+    (stim_dir / f"multipleye_comprehension_questions_{lang}.xlsx").write_text("x")
+    (
+        stim_dir
+        / f"multipleye_participant_instructions_{lang_lower}_with_img_paths.csv"
+    ).write_text("x")
+
+    config_dir = stim_dir / "config"
+    config_dir.mkdir()
+    (
+        config_dir / f"config_{lang_lower}_{country_lower}_{city}_{labnum}_{year}.py"
+    ).write_text("x")
+    (
+        config_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_lab_configuration.json"
+    ).write_text("{}")
+    (config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv").write_text(
+        "participant_id,version_number\n001,1\n"
+    )
+
+    for folder_name in [
+        f"stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_images_{lang_lower}_{country_lower}_{labnum}",
+        f"question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"participant_instructions_images_{lang_lower}_{country_lower}_{labnum}",
+    ]:
+        (stim_dir / folder_name).mkdir()
+
+    doc_dir = stim_dir.parent / "documentation"
+    doc_dir.mkdir()
+    (
+        doc_dir
+        / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_metadata_form.json"
+    ).write_text("{}")
+
+    sid = "001_EN_UK_1_ET1"
+    sess_folder = tmp_path / "sessions" / sid
+    sess_folder.mkdir(parents=True)
+    logfiles = sess_folder / "logfiles"
+    logfiles.mkdir()
+    (logfiles / "EXPERIMENT_LOGFILE_001.txt").write_text("x")
+    (logfiles / "GENERAL_LOGFILE_001.txt").write_text("x")
+    _write_csv(
+        logfiles / "completed_stimuli.csv",
+        ["stimulus_id", "stimulus_name", "trial_id", "completed"],
+        [["1", "Arg_PISACowsMilk", "1", "1"]],
+    )
+    _write_csv(
+        logfiles / "question_order_versions.csv",
+        [
+            "question_order_version",
+            "local_question_1",
+            "local_question_2",
+            "bridging_question_1",
+            "bridging_question_2",
+            "global_question_1",
+            "global_question_2",
+        ],
+        [["1", "101", "102", "201", "202", "301", "302"]],
+    )
+
+    session = FakeSession(
+        session_identifier=sid,
+        session_file_path=sess_folder / "data.edf",
+        session_folder_path=sess_folder,
+    )
+    dc = FakeDataCollection(
+        stimulus_dir=stim_dir,
+        language="EN",
+        country="UK",
+        lab_number=1,
+        city=city,
+        year=year,
+        sessions={sid: session},
+    )
+
+    with pytest.raises(PreflightError) as exc_info:
+        run_preflight_check(dc)
+    assert exc_info.value.num_errors == 1

--- a/tests/unit/preprocessing/checks/test_preflight.py
+++ b/tests/unit/preprocessing/checks/test_preflight.py
@@ -408,7 +408,7 @@ def test_preflight_multiple_sessions(tmp_path: Path):
         / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_lab_configuration.json"
     ).write_text("{}", encoding="utf-8")
     (config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv").write_text(
-        "participant_id,version_number\n001,1\n", encoding="utf-8"
+        "participant_id,version_number\n000,1\n001,1\n002,1\n", encoding="utf-8"
     )
 
     for folder_name in [

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -228,6 +228,7 @@ FOLDER_PROPERTIES = [
     ("reading_measures_dir", settings.READING_MEASURES_FOLDER),
     ("metadata_dir", settings.METADATA_FOLDER),
     ("answers_dir", settings.ANSWERS_FOLDER),
+    ("psychometric_tests_dir", settings.PSYCHOMETRIC_TESTS_FOLDER),
 ]
 
 

--- a/tests/unit/preprocessing/psychometric_tests/test_non_compliant_sid.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_non_compliant_sid.py
@@ -6,7 +6,7 @@ from preprocessing.psychometric_tests.preprocess_psychometric_tests import (
 from preprocessing.config import settings
 
 
-def test_non_compliant_sid_in_preprocess(tmp_path):
+def test_non_compliant_sid_in_preprocess(tmp_path, monkeypatch):
     # Setup: Create a non-compliant session folder
     # Based on issue: 010_DE_Lueneburg_1_PT1.yaml (not SID compliant)
     # A compliant SID is like 001_en_UK_1_PT1 (3 digits, 2 chars lang, 2 chars country, lab, session)
@@ -21,23 +21,28 @@ def test_non_compliant_sid_in_preprocess(tmp_path):
     # Create a dummy yaml file inside
     (non_compliant_folder / "010_DE_Lueneburg_1_PT1.yaml").touch()
 
-    # Mock settings.PSYCHOMETRIC_TESTS_DIR
-    original_dir = settings.PSYCHOMETRIC_TESTS_DIR
-    settings.PSYCHOMETRIC_TESTS_DIR = sessions_dir
+    output_dir = tmp_path / "output" / "dcn" / "psychometric_tests"
+    monkeypatch.setattr(settings, "PSYCHOMETRIC_TESTS_DIR", sessions_dir)
+    monkeypatch.setattr(settings, "OUTPUT_DIR", tmp_path / "output" / "dcn")
+    settings.__dict__["DATA_COLLECTION_NAME"] = "dcn"
 
-    try:
-        overview_path = preprocess_all_sessions(sessions_dir)
-        df = pd.read_csv(overview_path)
+    overview_path = preprocess_all_sessions(sessions_dir)
+    df = pd.read_csv(overview_path)
 
-        # Check session_id for non-compliant folder
-        # The participant_id might also be extracted incorrectly if not compliant
-        # 010_DE_Lueneburg_1_PT1 fallback pid was session.name[:3]
-        row = df[df["participant_id"].astype(str).isin(["10", "010"])].iloc[0]
+    assert overview_path == output_dir / "psychometric_overview_dcn.csv"
 
-        assert row["session_id"] == "010_DE_Lueneburg_1_PT1"
+    # Check session_id for non-compliant folder
+    # The participant_id might also be extracted incorrectly if not compliant
+    # 010_DE_Lueneburg_1_PT1 fallback pid was session.name[:3]
+    row = df[df["participant_id"].astype(str).isin(["10", "010"])].iloc[0]
+    assert row["session_id"] == "010_DE_Lueneburg_1_PT1"
 
-    finally:
-        settings.PSYCHOMETRIC_TESTS_DIR = original_dir
+    detailed_path = (
+        output_dir
+        / "010_DE_Lueneburg_1_PT1"
+        / "psychometric_details_010_DE_Lueneburg_1_PT1.csv"
+    )
+    assert detailed_path.exists()
 
 
 def test_non_compliant_sid_in_merged_overview(tmp_path):

--- a/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
+++ b/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
@@ -246,3 +246,24 @@ def test_prepare_language_folder_optional_aoi_images(
     assert (
         preprocessed_stim_dir / f"aoi_stimuli_images_{suffix}" / "overlay.png"
     ).exists()
+
+
+@pytest.mark.parametrize("data_collection_name", ["MultiplEYE_DA_DK_Aalborg_1_2026"])
+def test_prepare_language_folder_no_pt_data(
+    mock_data_collection_factory, data_collection_name
+):
+    """Pipeline should warn, not raise, when psychometric-tests-sessions is missing."""
+    tmp_path, data_collection_name, aoi_dir = mock_data_collection_factory(
+        data_collection_name
+    )
+    setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
+
+    # Remove the psychometric-tests-sessions folder
+    import shutil
+
+    shutil.rmtree(
+        tmp_path / "data" / data_collection_name / "psychometric-tests-sessions"
+    )
+
+    # Should not raise
+    prepare_language_folder(data_collection_name)


### PR DESCRIPTION
Integrate psychometric test preprocessing into the MultiplEYE pipeline, improve preflight validation with deeper cross-checks, and fix several pipeline-edge-case bugs.

### Psychometric tests integration
- Config: Add PSYCHOMETRIC_TESTS_FOLDER output path and RUN_PSYCHOMETRIC_TESTS pipeline flag (default: true)
- Sid model: Add psychometric_tests_dir property pointing to output_dir/psychometric_tests/{sid}
- Preflight: New _check_psychometric_tests() — detects task-first vs session-first format, auto-restructures, warns about archives, validates session-first data. Warnings are isolated from the error count (PT is optional)
- Pipeline: preprocess_all_sessions() runs after the session loop if data exists and RUN_PSYCHOMETRIC_TESTS is enabled. Skips gracefully with a single info message when no session folders are found
- API: Expose preprocess_all_sessions through api.py

### Preflight improvements
- Source stimulus validation: Preflight now validates the source stimulus folder (data/<DCN>/stimuli_<DCN>/) instead of the OUTPUT_DIR copy, preventing false negatives when prepare_language_folder has already copied assets
- Stimulus order coverage check: Validates that every session's participant ID exists in stimulus_order_versions_*.csv: catches missing/duplicate PIDs that would crash the pipeline mid-processing
- Sessions concerned summary: Adds a Sessions concerned: '...', '...' line at the end of the error message, listing all unique session IDs with issues

### Pipeline fixes
- Event loading: Remove stale settings.OUTPUT_DIR argument from "load existing event data" calls (regression from Sid refactor)
- Prepare_language_folder: Downgrade missing stimulus config folder from FileNotFoundError to logger.warning so preflight can report all issues in one run
- PT early skip: Bail out at the top of preprocess_all_sessions when no session folders exist, avoiding empty CSV writes and noisy validation warnings
- Merged CSV lead-zero fix: Read participant_id as string in create_merged_psychometric_overview to preserve leading zeros