### PR TITLE
fix: Case insensitive filematching

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinx_design",
     "sphinx_copybutton",
+    "sphinxcontrib.mermaid",
 ]
 
 templates_path = ["_templates"]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -157,7 +157,3 @@ You can always check the available options for each script by using the `--help`
 ```bash
 run_preprocessing --help
 ```
-
-Processing the {ref}`psychometric_tests` is not part of the preprocessing pipeline.
-This is done separately, find the
-{ref}`instructions on the corresponding page <running_calculations_psychometric>`.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,6 +19,7 @@ the psychometric tests. This step is rather fast.
 configuration
 preprocessing
 technical_architecture
+pipeline_stages
 reading_measures
 psychometric_tests
 

--- a/docs/guide/pipeline_stages.md
+++ b/docs/guide/pipeline_stages.md
@@ -1,0 +1,266 @@
+(pipeline_stages)=
+
+# Pipeline Stages
+
+This page documents each preprocessing stage in detail — what goes in, what comes out,
+and what happens along the way. For the broader picture (data layout, output structure),
+see {ref}`technical_architecture`.
+
+```{mermaid}
+graph TB
+    subgraph Setup[Setup]
+        direction LR
+        A1[Prepare Data] --> A2[Preflight] --> A3[EDF → ASC]
+    end
+    subgraph Load[Session Loading]
+        direction LR
+        B1[Session Info] --> B2[Load Gaze] --> B3[Preprocess]
+    end
+    subgraph Events[Event Detection]
+        direction LR
+        C1[Fixation Detection]
+        C2[Saccade Detection]
+    end
+    subgraph Analysis[Analysis]
+        direction LR
+        D1[AOI Mapping] --> D2[Reading Measures]
+        D1 --> D3[Parse Answers]
+    end
+    subgraph Report[Quality & Summary]
+        direction LR
+        E1[Sanity Checks] --> E2[Participant CSV]
+    end
+    A3 --> B1
+    B3 --> C1 & C2
+    C1 & C2 --> D1
+    C1 --> E1
+    D3 --> E1
+    A1 -.-> F[Psychometric Tests]
+```
+
+Stages 0–2 are preparation for all sessions. Stages 3–12 run per session in a loop.
+Stage 13 is independent and runs once at the end, after all sessions are done.
+
+(preprocessing_step_0)=
+
+## Stage 0: Data Preparation
+
+**Prepare the raw folder: extract archives, copy stimulus files, fix AOIs, and get
+psychometric test data into shape.** This runs once before anything else. It handles the
+messy reality of real data collections: tar archives that need unpacking, zip files per
+participant, AOI CSV files that need splitting into text and question variants, and
+old-format psychometric test data that needs restructuring from task-first to session-first.
+
+The function is `prepare_language_folder()` in `scripts.prepare_language_folder`. It also
+copies stimulus images, question images, and configuration files into the output folder so
+the pipeline has everything it needs in one place.
+
+(preprocessing_step_1)=
+
+## Stage 1: Preflight Check
+
+**Validate every input file before the pipeline touches any data.** This catches missing
+files early rather than failing midway. It checks that the stimulus XLSX files exist, every
+session has its EDF and logfiles, all participant IDs appear in the stimulus order table,
+and psychometric test folders are present if expected.
+
+The check lives in `checks.preflight.run_preflight_check()`. It does not fail on the first
+problem — it collects everything wrong and reports it all at once, so you can fix multiple
+issues in one go. File matching is case-insensitive because operating systems differ.
+
+(preprocessing_step_2)=
+
+## Stage 2: EDF to ASC
+
+**Convert EyeLink binary files to readable ASCII.** EyeTrackers record in `.edf` format,
+which is proprietary. The pipeline calls the `edf2asc` binary from the EyeLink SDK to
+produce `.asc` files that contain both the gaze samples and the timestamped messages that
+encode trial structure.
+
+The method is `MultipleyeDataCollection.convert_edf_to_asc()`. It runs the binary with
+flags `-input -ftime -p <output_dir> -y` and copies the result to `asc/<sid>/<sid>.asc`.
+If the ASC already exists and `FORCE_RECONVERT_ASC` is off, it skips. The `edf2asc` binary
+cannot be distributed with this pipeline due to licensing.
+
+(preprocessing_step_3)=
+
+## Stage 3: Session-Level Information
+
+**Load everything about a session: what stimuli were read, what the logfiles say, and
+which randomisation version was used.** This is where the raw session folder gets turned
+into a rich `Session` object with all its metadata. The pipeline reads `completed_stimuli.csv`
+to know which trials count, parses the ASC messages to get timestamps and reading times,
+loads the experiment logfile for trial details, extracts the stimulus order version from
+the general logfile, and builds a full list of `Stimulus` objects with their AOIs and
+questions.
+
+This is all done by `prepare_session_level_information()` in
+`data_collection.multipleye_data_collection`. It also handles crashed sessions where a
+participant had to restart — it detects the restart flag and adjusts the stimulus order
+accordingly.
+
+(preprocessing_step_4)=
+
+## Stage 4: Gaze Data Loading
+
+**Turn the ASC file into a structured gaze object with trials, pages, and activities.**
+The pipeline uses `pymovements.gaze.from_asc()` with a set of regex patterns that decode
+the experiment's message format. Each `start_recording_...` message marks a new recording
+segment: reading a page, answering a question, or rating a stimulus. The patterns pull out
+the trial number, stimulus name, page number, and activity type.
+
+Two code paths exist. On first run, the ASC is parsed fresh and the per-trial raw CSVs are
+saved. On subsequent runs, the cached CSVs are loaded back and stitched into a `Gaze`
+object — this is faster and avoids re-parsing. Only data for completed stimuli (from
+`completed_stimuli.csv`) is kept; aborted trials are discarded.
+
+The entry points are `load_gaze_data()` and `load_trial_level_raw_data()` in `io.load`.
+
+(preprocessing_step_5)=
+
+## Stage 5: Signal Preprocessing
+
+**Convert raw pixels to visual degrees and compute gaze velocity.** Raw eye-tracker
+coordinates are in pixels, which means nothing without knowing the screen size and viewing
+distance. The pipeline converts them to degrees of visual angle using the lab's hardware
+settings (`LabConfig`). Then it computes velocity with a Savitzky-Golay filter — two passes,
+50 ms window, polynomial degree 2. This cleaned signal is what the event detectors need.
+
+All of this happens in `signals.preprocess.preprocess_gaze()`.
+
+(preprocessing_step_6)=
+
+## Stage 6: Fixation Detection
+
+**Find fixations using a velocity threshold.** The I-VT algorithm marks samples below
+20 deg/s as fixation and groups consecutive ones. The minimum fixation duration is 100 ms.
+For each fixation found, the pipeline computes its centroid location and spatial dispersion.
+
+The function is `events.detect.detect_fixations()`. Results are saved as per-trial CSVs
+in `fixations/<sid>/`.
+
+(preprocessing_step_7)=
+
+## Stage 7: Saccade Detection
+
+**Detect saccades with a noise-adaptive threshold.** Unlike fixations, saccades are fast
+eye movements. The algorithm adapts the velocity threshold to the noise level of each
+recording. Minimum duration is 6 samples (roughly 12 ms at 500 Hz). Properties computed
+include amplitude in degrees, peak velocity, and dispersion.
+
+The function is `events.detect.detect_saccades()`. Results go to `saccades/<sid>/`.
+
+(preprocessing_step_8)=
+
+## Stage 8: AOI Mapping and Scanpaths
+
+**Map every fixation to the word and character the participant was looking at.** Using
+the AOI files from the stimulus folder, each fixation gets annotated with a character
+index, word index, line number, and page. This turns a list of coordinates into a reading
+scanpath.
+
+The function `mapping.aoi.map_fixations_to_aois()` collects all AOIs from the stimulus
+definitions and calls `pymovements`'s built-in mapping. The annotated fixations are saved
+as scanpath CSVs in `scanpaths/<sid>/`.
+
+(preprocessing_step_9)=
+
+## Stage 9: Reading Measures
+
+**Calculate word-level eye-movement measures from the scanpath.** This is where the
+pipeline produces the numbers that most reading researchers care about: how long did
+someone look at a word, did they regress, did they refixate. The pipeline first annotates
+fixations with run IDs and pass flags (first-pass vs regression), then computes measures
+for each word.
+
+Measures include total fixation count (TFC), first-fixation duration (FFD), first-pass
+reading time (FPRT), regression-path duration (RPD), and about a dozen more. The full list
+is documented in the {ref}`reading_measures` section.
+
+The entry point is `metrics.calculate.calculate_reading_measures()`.
+
+(preprocessing_step_10)=
+
+## Stage 10: Comprehension Answers
+
+**Extract what answers participants gave to comprehension questions and whether they
+were correct.** The primary source is the ASC file itself — the experiment software logs
+`preliminary_answer`, `final_answer_given_is_...`, and `answer_given_is_correct:...`
+messages with millisecond timestamps. These give you both response times and accuracy.
+
+If ASC messages are unavailable (some data collections have this gap), the pipeline falls
+back to the EXPERIMENT logfile, which has the final answer and correctness but no response
+times. A warning is logged in that case.
+
+The parsed answers are then combined with the participant's question order version and the
+stimulus definitions to produce a full answer table with trial, stimulus, question ID,
+condition (local/bridging/global), response, correctness, and RTs. Saved to
+`comp_answers/<sid>/<sid>_answers.csv`.
+
+The relevant modules are in `answers/`: `msg_parser.py`, `experiment_log_parser.py`,
+`collect.py`.
+
+(preprocessing_step_11)=
+
+## Stage 11: Sanity Checks and Reports
+
+**Generate quality reports at the session and dataset level.** This stage produces text
+reports on calibration quality, validation scores, data loss, fixation statistics per page,
+and logfile consistency. It also creates plots (gaze-over-stimulus, main sequence) that
+help spot problematic sessions visually.
+
+Session overviews and a dataset overview YAML are written to the metadata folder. The
+checks live in `checks/et_quality_checks.py` and `checks/formal_experiment_checks.py`.
+
+(preprocessing_step_12)=
+
+## Stage 12: Participant Data
+
+**Aggregate questionnaire data into a single CSV.** Participant questionnaires are stored
+as individual JSON files. This step reads them all, fixes a known key-naming bug from
+earlier experiment versions, and writes a tidy `participant_data.csv`.
+
+(preprocessing_step_13)=
+
+## Stage 13: Psychometric Tests
+
+**Process psychometric test exports into summary metrics.** Six tests are supported:
+working memory (LWMC), rapid automatised naming (RAN), Stroop, Flanker, vocabulary
+(WikiVocab/LexTALE), and language aptitude (PLAB). Each has its own preprocessing function
+in `psychometric_tests.preprocess_psychometric_tests`.
+
+The output is an overview CSV with one row per session (key metrics only, like accuracy
+effects and mean RTs) and a detailed CSV per session with all computed values. An
+additional merged overview combines PT1 and PT2 sessions for the same participant when
+their tests don't overlap.
+
+## Configuration
+
+**Everything is controlled by a single YAML file and a global `Settings` object.**
+The config sets the data collection name, which stages to run, quality thresholds, and
+logging verbosity. The pipeline looks for it in this order:
+
+1. `--config_path` argument
+2. `MULTIPLEYE_CONFIG` environment variable
+3. `multipleye_settings_preprocessing.yaml` in the current directory
+4. Auto-detected from the folder name (creates a template)
+
+See the {ref}`configuration_guide` for all available settings.
+
+## Package Architecture
+
+**The `preprocessing` package is organised by function, with a flat public API.**
+Internal modules live in subpackages (`io/`, `events/`, `signals/`, `mapping/`,
+`metrics/`, `answers/`, `checks/`, `psychometric_tests/`, `data_collection/`, `models/`,
+`utils/`, `scripts/`). The `api.py` facade re-exports all key functions so users can
+call `preprocessing.load_gaze_data(...)` instead of digging into submodules.
+
+The main data classes form a hierarchy: `MultipleyeDataCollection` owns a dict of
+`Session` objects, each of which owns lists of `Stimulus` and `Trial` objects. For
+two-session experiments, `MeridDataCollection` extends the base class and overrides only
+the stimulus order logic.
+
+**The pipeline caches aggressively.** Every stage checks whether its output already
+exists on disk. If it does and `overwrite` is false, the stage loads the cached result
+instead of recomputing. The number of cached files is validated against the list of
+completed stimuli to catch partial or corrupted runs.

--- a/docs/guide/pipeline_stages.md
+++ b/docs/guide/pipeline_stages.md
@@ -81,6 +81,7 @@ The method is `MultipleyeDataCollection.convert_edf_to_asc()`. It runs the binar
 flags `-input -ftime -p <output_dir> -y` and copies the result to `asc/<sid>/<sid>.asc`.
 If the ASC already exists and `FORCE_RECONVERT_ASC` is off, it skips. The `edf2asc` binary
 cannot be distributed with this pipeline due to licensing.
+See the {ref}`installation instructions <eyelink_dev_kit>` for how to obtain it from SR Research.
 
 (preprocessing_step_3)=
 

--- a/docs/guide/preprocessing.md
+++ b/docs/guide/preprocessing.md
@@ -24,6 +24,8 @@ proprietary EyeLink format to analysis-ready data.
 
 The pipeline processes data on a session level and consists of several key steps including EDF to
 ASC conversion, data parsing, gaze event detection, AOI mapping, and reading measures calculation.
+After all sessions are processed, psychometric tests are calculated (if enabled and data is
+available).
 For more information about the available reading measures, see {ref}`reading_measures`.
 For detailed technical specifications of each step, including file formats and quality control
 procedures, please refer to the {ref}`technical_architecture` section.

--- a/docs/guide/psychometric_tests.md
+++ b/docs/guide/psychometric_tests.md
@@ -325,13 +325,6 @@ data/MultiplEYE_SQ_CH_Zurich_1_2025/psychometric-tests-sessions/
 │   └── psychometric_details_008_SQ_CH_1_PT2.csv
 ```
 
-The `psychometric_details_008_SQ_CH_1_PT2.csv` is written inside the session folder as an output,
-with all detailed measures for the session.
-Furthermore, an overview of all sessions will be written to
-`preprocessed_data/{data_collection_id}/psychometric_tests/psychometric_overview_{data_collection_id}.csv`,
-and a merged overview (one row per participant, combining PT sessions) to
-`psychometric_overview_{data_collection_id}_merged.csv`.
-
 If it happens that the data is structured first by the test folder and then by session folder,
 `prepare_language_folder` and the preflight check will detect this and restructure the data
 automatically.

--- a/docs/guide/psychometric_tests.md
+++ b/docs/guide/psychometric_tests.md
@@ -322,17 +322,20 @@ data/MultiplEYE_SQ_CH_Zurich_1_2025/psychometric-tests-sessions/
 │   ├── WikiVocab
 │   │   ├── SQCH1_008_PT2_2025-09-13_15-26-53.csv
 │   │   └── images
-│   └── psychometric_details_008_SQ_CH_1_PT2.csv (detail output for session)
+│   └── psychometric_details_008_SQ_CH_1_PT2.csv
 ```
 
-The `psychometric_details_008_SQ_CH_1_PT2.csv` is written as an output of the psychometric tests
-with all detailled measures for the session.
+The `psychometric_details_008_SQ_CH_1_PT2.csv` is written inside the session folder as an output,
+with all detailed measures for the session.
 Furthermore, an overview of all sessions will be written to
-`data/{data_collection_id}/{data_collection_id}_overview.yaml`
+`preprocessed_data/{data_collection_id}/psychometric_tests/psychometric_overview_{data_collection_id}.csv`,
+and a merged overview (one row per participant, combining PT sessions) to
+`psychometric_overview_{data_collection_id}_merged.csv`.
 
 If it happens that the data is structured first by the test folder and then by session folder,
-the data can be restructured using the `preprocessing.scripts.restructure_psycho_tests:main`
-script.
+`prepare_language_folder` and the preflight check will detect this and restructure the data
+automatically.
+The `restructure_psycho_tests` CLI tool can still be used as a fallback.
 This can be invoked like this:
 
 ```bash
@@ -383,21 +386,36 @@ only calculating the results of tests with existing data.
 
 ### Running the Calculations
 
-The psychometric test calculations are performed by the `preprocess_psychometric_tests()` function,
-which processes each test separately and combines the results into overview and detailed output
-files.
+The psychometric test calculations are performed as part of the main preprocessing pipeline
+(via `run_preprocessing`, gated by `RUN_PSYCHOMETRIC_TESTS`), or standalone via the
+`preprocess_psychometric_tests()` function.
+Both process each test separately and combine the results into overview and detailed output files.
+
+#### Output Location
+
+All psychometric test results are written to
+`preprocessed_data/{data_collection_id}/psychometric_tests/`.
 
 #### Overview vs. Detailed Output
 
-The pipeline generates two types of output for each participant:
+The pipeline generates two types of output:
 
-- **Overview file** (`{data_collection_id}_overview.yaml`): Contains primary metrics as per
-  the original paper outputs.
-- **Detailed file** (`psychometric_details_{session_id}.csv`): Contains more detailed values.
+- **Overview file** (`psychometric_overview_{data_collection_id}.csv`): Contains one row per
+  session with primary metrics as per the original paper outputs.
+- **Merged overview file** (`psychometric_overview_{data_collection_id}_merged.csv`): Contains one
+  row per participant, merging disjoint PT sessions (e.g. PT1 with PT2).
+- **Detailed file** (`psychometric_details_{session_id}.csv`): Per-session CSV with all detailed
+  values, written to a subfolder named after the session.
 
 #### Command Line Usage
 
-The tests can be calculated with the following command:
+The tests can be calculated as part of the full pipeline:
+
+```bash
+run_preprocessing --config_path path/to/your_config.yaml
+```
+
+Or standalone:
 
 ```bash
 preprocess_psychometric_tests

--- a/docs/guide/reading_measures.md
+++ b/docs/guide/reading_measures.md
@@ -2,23 +2,70 @@
 
 # Reading Measures
 
-```{warning}
-This page is work in progress. Content will be added from a future PR.
-See https://github.com/MultiplEYE-COST/multipleye-preprocessing/pull/69/.
-```
+**Reading measures are word-level eye-movement metrics calculated from AOI-mapped
+fixations.** The pipeline computes them per trial by first annotating fixations with run
+and pass information, then deriving a set of standard measures for each word. The
+implementation lives in `metrics.reading.reading_measures`.
 
-## Overview
+## Fixation Annotation
 
-This section will document the reading measures calculated from preprocessed eye-tracking data.
+**Every fixation gets tagged with a run ID, first-pass status, regression flags, and
+neighbouring word indices.** This annotation is the foundation for all measures. The
+pipeline groups fixations by trial, stimulus, and page, then computes:
 
-## Available Measures
+- `run_id` — contiguous fixations on the same word form a run. Each time the reader moves
+  to a different word and comes back, a new run starts.
+- `is_first_pass` — a run is first-pass if the word is entered from the left, no higher
+  word index has been fixated before, and the word has not been entered before. All
+  later revisits (regressions-in) are marked as non-first-pass.
+- `is_reg_in` / `is_reg_out` — a regression occurs when the next fixation lands on a
+  lower (regression-out) or the previous fixation came from a higher (regression-in) word
+  index.
+- `is_first_fix` — the very first fixation on the word in the entire trial.
+- `prev_word_idx` / `next_word_idx` — word indices of the preceding and following
+  fixation, used for saccade length calculation.
 
-(TBD - to be added)
+## Fixation-based Measures
 
-## Calculation
+| Abbreviation | Description |
+|---|---|
+| **FFD** | Duration of the first fixation on a word during first-pass reading, 0 if skipped in first-pass |
+| **FD** | Duration of the first fixation on the word, regardless of pass |
+| **FPF** | 1 if the word was fixated in first-pass, 0 otherwise |
+| **FPFC** | Number of first-pass fixations on the word |
+| **FPRT** | Sum of all first-pass fixation durations (0 if skipped) |
+| **FRT** | Sum of fixations from first entering the word until first leaving it (same as FPRT when the first run was first-pass) |
+| **TFC** | Total number of fixations on the word |
+| **TFT** | Sum of all fixations (FPRT + RRT) |
+| **RR** | 1 if the word had re-reading after first-pass, 0 otherwise |
+| **RRT** | Sum of fixations that are not part of first-pass (TFT - FPRT) |
+| **SFD** | Duration of the only first-pass fixation; 0 if skipped or multiple first-pass fixations |
 
-(TBD - to be added)
+## Transition-based Measures
+
+| Abbreviation | Description |
+|---|---|
+| **LP** | Character index of the first fixation on the word (landing position) |
+| **RBRT** | Sum of fixation durations on the word until a word to its right is fixated (RPD_inc - RPD_exc) |
+| **RPD_exc** | Sum of regressive fixation durations after a first-pass regression until fixating a word to the right, excluding fixations on the word itself |
+| **RPD_inc** | Sum of all fixations from first first-pass fixation on the word until fixating a word to its right (includes regressive fixations); 0 if not fixated in first-pass |
+| **SL_in** | Saccade length leading to the first fixation on the word (in words); positive = progressive, negative = regressive |
+| **SL_out** | Saccade length of the first saccade leaving the word (in words) |
+| **TRC_in** | Number of regressive saccades landing on this word |
+| **TRC_out** | Number of regressive saccades initiated from this word |
 
 ## Output Format
 
-(TBD - to be added)
+**Reading measures are saved as one CSV per trial in `reading_measures/<sid>/`.**
+The filename follows the pattern `{sid}_{trial}_{stimulus}_reading_measures.csv`.
+Each row is a word, with columns for the trial identifier, page number, word index, word
+text, and all measures above. Words that were never fixated have zeros in all measure
+columns and are marked as `skipped = 1`.
+
+## AOI Enlargement
+
+**AOIs are enlarged vertically before mapping to cover the space between lines.**
+The original AOIs from the stimulus files only cover the exact character bounding box.
+A fixation slightly above or below the line would miss the word. The `enlarge_aois()`
+function in `mapping.aoi` extends each AOI upward and downward by half the inter-line
+spacing, so fixations between lines still map to the correct character.

--- a/docs/guide/technical_architecture.md
+++ b/docs/guide/technical_architecture.md
@@ -2,323 +2,115 @@
 
 # Technical Architecture
 
-This section provides detailed technical specifications of the MultiplEYE preprocessing pipeline.
-For user-facing instructions on how to run the preprocessing, please refer to the {ref}`preprocessing_guide`.
+This page covers the data layout, pipeline philosophy, and output structure.
+For a detailed stage-by-stage breakdown, see {ref}`pipeline_stages`.
 
 (multiplEYE_data_structure)=
 
-## The MultiplEYE Data Structure
+## Data Structure
 
-Each MultiplEYE dataset contains the data for one language. The eye-tracking data is organised by
-session. The stimulus information is available in a separate folder containing the aoi files for
-each stimulus.
+**A MultiplEYE dataset lives in one folder named by language, country, lab, and year.**
+Inside you find the raw eye-tracking sessions, stimulus materials, psychometric test exports,
+and participant questionnaires. The naming follows the pattern
+`MultiplEYE_{LANG}_{COUNTRY}_{CITY}_{LAB}_{YEAR}` (e.g. `MultiplEYE_HR_HR_Zagreb_1_2025`).
 
-```text
-MultiplEYE__languageISOcode]__countryISOcode]__city]__identifier]__yearDataCollectionEnd]
-├── eye-tracking-sessions
-│   ├── 001_…_…_…_ET1
-│   │   ├── ….edf
-│   │   └── ….asc
-│   ├── 002_…_…_…_ET1
-│   ├── 005_…_…_…_ET1
-│   ├── pilot_sessions
-│   │   └── …
-│   └── test_sessions
-│       └── …
-└── stimuli_MultiplEYE__languageISOcode]__countryISOcode]__city]__identifier]__yearDataCollectionEnd]
-    └── aoi__languageISOcode]__countryISOcode]__identifier]
-        ├── _stimulus-name-id]_aoi.csv
-        ├── _stimulus-name-id]_aoi_questions.csv
-        └── …
-```
-
-### A Session Folder
-
-Each session folder contains the raw files in .edf and .asc format in addition to some other files
-that are not relevant for the preprocessing pipeline.
+The top-level folder looks like this:
 
 ```text
-001_…_…_…_ET1
-├── _3-digit-P-ID]_languageISOcode]_countryISOcode]_identifier].asc
-├── _3-digit-P-ID]_languageISOcode]_countryISOcode]_identifier].edf
-├── …
+MultiplEYE_HR_HR_Zagreb_1_2025/
+├── eye-tracking-sessions/          # one subfolder per participant
+│   ├── 015_HR_hr_Zagreb_1_S1/     # session = participant + recording
+│   │   ├── 015_HR_hr_Zagreb_1.edf
+│   │   ├── 015_HR_hr_Zagreb_1.asc
+│   │   └── logfiles/              # PsychoPy output
+│   ├── 016_HR_hr_Zagreb_1_S1/
+│   ├── pilot_sessions/            # optional
+│   └── test_sessions/             # optional
+├── psychometric-tests-sessions/   # raw PT exports per session
+│   ├── 015_HR_hr_Zagreb_1_PT1/
+│   │   ├── WMC/
+│   │   ├── RAN/
+│   │   ├── Stroop_Flanker/
+│   │   ├── WikiVocab/
+│   │   └── PLAB/
+│   └── participant_configs_HR_hr_1/
+├── stimuli_MultiplEYE_HR_HR_Zagreb_1_2025/
+│   ├── aoi_HR_hr_1/
+│   ├── stimuli_images_HR_hr_1/
+│   ├── question_images_HR_hr_1/
+│   ├── config/                    # lab config, stimulus order, metadata
+│   ├── multipleye_stimuli_experiment_HR.xlsx
+│   └── multipleye_comprehension_questions_HR.xlsx
+├── participant_questionnaire_HR_hr_1_2025/
+└── documentation/
 ```
 
-### Preprocessing Pipeline Philosophy
-
-The MultiplEYE preprocessing pipeline (and most pipelines) is applied on a **session-level.**
-Settings can change between sessions. Each session should be summarised on session- and trial-level.
-Information at the dataset-level is not relevant at this stage. This will only become relevant once
-the data is published and all sessions have been preprocessed.
-
-The initial input is the original gaze file, including some metadata on the session (experiment
-details). The output from the previous step is always the input to the next step. However, each step
-requires the specification of further input (i.e. parameters etc.) that has to be chosen by the
-user on a session level!
-
-Note that the **participant ID** is a three-digit number and the **session identifier** contains the
-participant id including a language code, country code, and lab identifier. P-IDs are unique only
-within a given dataset while session identifiers are unique across all MultiplEYE datasets. This
-means that all MultipEYE sessions can be preprocessed in one go. In a MultiplEYE context these two
-terms are occasionally used interchangeably in a less formal context.
-
-(preprocessing_steps)=
-
-## Preprocessing Pipeline Steps
-
-(preprocessing_step_1)=
-
-### Step 1: Parse .asc File into Sample .csv and Metadata
-
-Input: .asc (eyelink specific, different for other devices) file containing samples and metadata
-about the session (i.e. sampling frequency, eye-to-screen distance).
-Output: .csv sample files and metadata .json files (content specified below) **split by trial (all
-pages) and session**.
-
-The (unstructured) .asc file should be parsed into a cleaned .csv file containing the gaze samples
-and several metadata .json documents that contain all information found in the .asc file in addition
-to the metadata provided as input.
-
-#### Input Metadata at the Session Level
-
-- Lab configuration
-    - sampling frequency
-    - eye-to-screen distance
-    - resolution in px
-    - screen size in mm
-    - eye-tracker
-    - *… tbd*
-
-(step_1_file_formats)=
-
-#### File Formats
-
-(step_1_samples)=
-
-##### Samples
-
-Filename: p-id_stimulus-id_*samples*.csv
-
-The samples file contains timestamp, pixel x, pixel y, pupil area/diameter, and page
-number/identifier.
-
-(step_1_metadata)=
-
-##### Metadata
-
-The metadata should be extracted on trial- and session-level.
-
-Trial-level (one file contains all trials):
-
-- stimulus item
-- reading time
-- answers to all 6 comprehension questions
-- answers to all 3 rating questions
-- last validation before stimulus + scores
-- blinks
-
-Session-level
-Filename: session-id_metadata.json
-
-- trial-id to stimulus-id mapping inferred from .asc
-- calibrations
-    - total number
-    - timestamps
-- validations
-    - scores for each
-    - timestamps
-    - total number
-- number of (completed) trials
-- number of pages read
-- initial calibration (yes or no), i.e. before the first trial
-- final validation, i.e. after the last trial
-- lab config (can be different for a session within one dataset)
-    - sampling frequency
-    - tracked eye
-    - eye-to-screen distance
-    - device
-    - …
-- reading time
-- time spent in breaks / non-reading
-- stimuli (=> aoi files + stimulus metadata)
-    - e.g. whether annotations are available, which
-    -
-
-(step_1_sanity_checks)=
-
-#### Sanity Checks to be Performed
-
-Input sampling frequency should match the found sampling frequency.
-In general, lab settings provided should match what is found in the data files.
-
-(step_1_data_quality_reports)=
-
-#### Data Quality Reports
-
-Data quality reports should be generated to validate the parsing process. ...
-
-(preprocessing_step_2)=
-
-### Step 2: Detect Gaze Events (Fixations and Saccades)
-
-Input: sample .csv for each session and trial (not eyelink specific any more).
-Output: gaze events .csv (this is ideal for reading) → both fixations and saccades in one file.
-
-Detection of gaze events (fixation and saccades). The fixations and saccades should be in one file
-containing features for both. The saccade features are mapped to the fixation before and after the
-saccades. This will lead to some redundancies, but from a user perspective this is the ideal format.
-
-It should be possible to adjust parameters for each individual session. That is, one function call
-for each session. Which fixation and saccade features are calculated can be selected by user.
-
-(step_2_file_formats)=
-
-#### File Formats
-
-Fixations and saccades are in ONE file, saccades are basically a feature of fixations, one line is
-one fixation. Filename: p-id_stimulus-id_*events*.csv.
-
-- fixation duration
-- location x
-- location y
-- location std/stability
-- incoming saccade duration
-- outgoing saccade duration
-- saccade length in px (for incoming and outgoing, also features below)
-- saccade peak velocity (inc. & out.)
-- saccade mean velocity (inc. & out.)
-- s. peak acceleration (inc. & out.)
-- s. mean acceleration (inc. & out.)
-- blink before
-- blink after
-
-(step_2_sanity_checks)=
-
-#### Sanity Checks to be Performed
-
-Sanity checks should be performed to validate the event detection process. ...
-
-(step_2_data_quality_reports)=
-
-#### Data Quality Reports
-
-Data quality reports should report data loss, everything that occurs during the detection of the
-fixations that are not normal, RMS-S2 (for fixations) or median RMS-S2 (including saccades), and
-check fixations on the bottom right dot (precision).
-
-(preprocessing_step_3a)=
-
-### Step 3a: AOI Mapping
-
-Input: gaze event .csv + aoi files from the stimulus folder.
-Output: fix indices mapped to word and char index.
-
-Fixations are mapped to words and characters. Can be index based at this point and later be merged
-with the actual characters and words.
-
-(step_3a_file_formats)=
-
-#### File Formats
-
-Filename: p-id_stimulus-id_*aoi-mapping*.csv.
-
-- fixation index
-- char index
-- word index
-- line index
-- incoming saccade landing position in character index in word == outgoing!
-- incoming length in characters
-- outgoing saccade length in characters
-
-(step_3a_data_quality_reports)=
-
-#### Data Quality Reports
-
-Data quality reports should include aoi dwell time and proportion time on aoi/time on a background.
-
-(step_3a_sanity_checks)=
-
-#### Sanity Checks to be Performed
-
-Sanity checks should be performed to validate the AOI mapping process.
-
-(preprocessing_step_3b)=
-
-### Step 3b: Scanpaths
-
-Input: gaze events .csv and aoi mapping.
-Output: gaze events + aois + other features (optional).
-
-The goal is to have the fixations + the words and the character, line index, etc. in ONE file.
-In addition, there should be some other features about the user, the experiment, the text, etc.
-It should be possible to generate more minimalistic versions and more extensive versions of this.
-
-(step_3b_file_formats)=
-
-#### File Formats
-
-Filename: p-id_stimulus-id_*events*.csv.
-
-The file contains columns from aoi mapping + columns from fixations.
-
-(step_3b_sanity_checks)=
-
-#### Sanity Checks to be Performed
-
-Sanity checks should be performed to validate the scanpath generation.
-
-(step_3b_data_quality_reports)=
-
-#### Data Quality Reports
-
-Data quality reports should be generated to validate the scanpath process.
-
-(preprocessing_step_4)=
-
-### Step 4: Calculate Reading Measures / AOI-based Measures
-
-Input: scanpath files (see above) + aoi files.
-Output: .csv file for each session and trial containing reading measures and minimal information on
-participant.
-
-Reading measures (also called aoi-base measures, which is more general) are calculated on a word (or
-general aoi-based) basis. In the case of reading, this means that for each word in the stimulus
-texts, a set of measures is calculated. A list of common reading measures and their definition can
-be found
-here: [https://link.springer.com/article/10.3758/s13428-024-02536-8/tables/12](https://link.springer.com/article/10.3758/s13428-024-02536-8/tables/12)
-
-(step_4_file_formats)=
-
-#### File Formats
-
-Filename: p-id_stimulus-id_*aoi-measures*.csv.
-
-- word index
-- _word] → this is not always necessary and heavily depends on copyright etc., but in any case it
-  can be merged with the aois
-- word-level annotation (i.e. word index in sentence, pos-tag, … line num.. )
-- all reading measures from the table linked above
-
-(step_4_sanity_checks)=
-
-#### Sanity Checks to be Performed
-
-Sanity checks should verify that total fixations durations are within an expected range and check
-for outliers.
-
-(step_4_data_quality_reports)=
-
-#### Data Quality Reports
-
-Data quality reports should include calculated word length effects, surprisal effects, and other
-relevant metrics.
+**A session identifier carries the participant ID, language, country, lab, and session type.**
+The format is `{PID}_{LANG}_{country}_{lab}_{session}`. For example `015_HR_hr_Zagreb_1_S1`
+means participant 015, Croatian, lab Zagreb 1, eye-tracking session 1.
+Session types are `S` / `ET` for eye-tracking and `PT` for psychometric tests.
+The participant ID is always three digits and unique only within a dataset.
+
+**The pipeline works session-by-session and assumes a fixed set of logfiles per session.**
+Each session folder must contain an EDF (or ASC) file and a `logfiles/` subfolder with:
+
+- `completed_stimuli.csv` — which stimuli the participant actually read
+- `question_order_versions.csv` — which randomisation version was used
+- `EXPERIMENT_{...}.txt` — trial-level log from PsychoPy
+- `GENERAL_LOGFILE_{...}.txt` — contains the stimulus order version number
+
+**Stimulus definitions live in the stimulus folder, shared across all sessions.**
+The AOI files (`{stimulus}_aoi.csv` and `{stimulus}_aoi_questions.csv`) define word- and
+character-level interest areas per stimulus. The config folder contains the lab hardware
+settings, the stimulus order randomisation table, and the experiment metadata form.
+
+## Pipeline Philosophy
+
+**Every stage reads the output of the previous stage and can be toggled on or off.**
+The configuration YAML controls which stages run. Output files are cached on disk; when
+`overwrite: false` the pipeline skips recomputation and validates file counts against the
+expected number of completed stimuli.
+
+**Two experiment types are supported through the same interface.** `MultiplEYE` uses one
+session per participant. `MeRID` splits the stimulus order across two sessions — the
+`MeridDataCollection` overrides the stimulus loading logic while keeping everything else
+identical.
+
+**The pipeline is batch-oriented.** It discovers all sessions in a data collection, runs a
+preflight check on all of them, converts EDFs to ASC, loads session-level metadata, and
+then loops over each session for the heavy computation (gaze processing, event detection,
+reading measures, answers, sanity checks). Psychometric tests run once at the end over all
+sessions.
+
+**For a full stage-by-stage description, head over to {ref}`pipeline_stages`.**
 
 (output_folder_structure)=
 
-## Output Folder Structure
+## Output Structure
 
-By default, files should be written to the session folder the .asc file was taken from. But it
-should be possible to change the path so that the files can be written to a folder containing only
-the output data from the specific preprocessing step (i.e. fixations).
+**Everything lands in `preprocessed_data/{data_collection_name}/`, organised by stage.**
+Each stage has its own folder with subfolders per session. This keeps the data tidy and
+makes it easy to see what's been processed.
 
-(the default now is another folder)
+```text
+preprocessed_data/{dcn}/
+├── asc/                    # converted ASC files
+├── raw_data/               # per-trial gaze samples
+├── metadata/               # session metadata, calibrations, validations
+├── fixations/              # detected fixations
+├── saccades/               # detected saccades
+├── scanpaths/              # AOI-mapped fixations
+├── reading_measures/       # word-level reading measures
+├── comp_answers/           # comprehension question answers
+├── sanity_checks/          # quality reports and plots
+├── psychometric_tests/     # PT overview + per-session details
+├── participant_data.csv
+├── {dcn}_overview.yaml
+└── stimuli_{dcn}/          # copy of stimulus assets used
+```
+
+**Filenames follow a consistent pattern.** Per-trial files are named
+`{sid}_{trial}_{stimulus}_{stage}.csv`. Psychometric test outputs use
+`psychometric_overview_{dcn}.csv` (one row per session) and
+`psychometric_overview_{dcn}_merged.csv` (sessions merged per participant when tests are
+disjoint). The merged overview combines PT1 and PT2 data for the same subject.

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -7,13 +7,13 @@ consolidated error instead of triggering mid-loop failures one at a time.
 
 from __future__ import annotations
 
-import fnmatch
 import os
 import sys
 from pathlib import Path
 
 import polars as pl
 
+from ..utils.data_path_utils import _ci_exists, _ci_glob, _ci_resolve
 from ..utils.logging import get_logger
 
 logger = get_logger()
@@ -142,55 +142,6 @@ def _require_glob(
         groups.setdefault(label, []).append(str(directory / pattern))
 
 
-def _ci_exists(path: Path) -> bool:
-    """Check if a path exists, falling back to case-insensitive comparison."""
-    if path.exists():
-        return True
-    parent = path.parent
-    if not parent.exists():
-        return False
-    try:
-        entries = os.listdir(parent)
-    except OSError:
-        return False
-    target = path.name.casefold()
-    return any(entry.casefold() == target for entry in entries)
-
-
-def _ci_resolve(path: Path) -> Path:
-    """Resolve a path to its actual on-disk spelling (case correction)."""
-    if path.exists():
-        return path
-    parent = path.parent
-    if not parent.exists():
-        return path
-    try:
-        entries = os.listdir(parent)
-    except OSError:
-        return path
-    target = path.name.casefold()
-    for entry in entries:
-        if entry.casefold() == target:
-            return parent / entry
-    return path
-
-
-def _ci_glob(directory: Path, pattern: str) -> list[Path]:
-    """Case-insensitive glob, returning actual on-disk paths."""
-    if not directory.exists():
-        return []
-    try:
-        entries = os.listdir(directory)
-    except OSError:
-        return []
-    pattern_cf = pattern.casefold()
-    return [
-        directory / entry
-        for entry in entries
-        if fnmatch.fnmatch(entry.casefold(), pattern_cf)
-    ]
-
-
 def _find_archives(directory: Path) -> list[str]:
     """Find common archive files in the given directory."""
     patterns = ["*.zip", "*.tar.gz", "*.tar", "*.tgz", "*.7z", "*.rar"]
@@ -255,27 +206,23 @@ def _check_shared_files(
     city = data_collection.city
     year = data_collection.year
 
-    lang_lower = lang.lower()
-    country_lower = country.lower()
-
     # --- Stimulus directory empty check -----------------------------------
     if not _stim_dir_empty_check(stim_dir, errors):
         return
 
     # --- Stimulus definition files (errors) -------------------------------
     _require_file(
-        stim_dir / f"multipleye_stimuli_experiment_{lang_lower}.xlsx",
+        stim_dir / f"multipleye_stimuli_experiment_{lang}.xlsx",
         "Stimulus definition xlsx",
         errors,
     )
     _require_file(
-        stim_dir / f"multipleye_comprehension_questions_{lang_lower}.xlsx",
+        stim_dir / f"multipleye_comprehension_questions_{lang}.xlsx",
         "Comprehension questions xlsx",
         errors,
     )
     _require_file(
-        stim_dir
-        / f"multipleye_participant_instructions_{lang_lower}_with_img_paths.csv",
+        stim_dir / f"multipleye_participant_instructions_{lang}_with_img_paths.csv",
         "Participant instructions CSV",
         errors,
     )
@@ -284,7 +231,7 @@ def _check_shared_files(
     config_dir = stim_dir / "config"
     _require_glob(
         config_dir,
-        f"config_{lang_lower}_{country_lower}_*_{labnum}_*.py",
+        f"config_{lang}_{country}_*_{labnum}_*.py",
         "Config python file",
         errors,
     )
@@ -295,26 +242,25 @@ def _check_shared_files(
         errors,
     )
     _require_file(
-        config_dir
-        / f"stimulus_order_versions_{lang_lower}_{country_lower}_{labnum}.csv",
+        config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv",
         "Stimulus order versions CSV",
         errors,
     )
 
     # --- Image/AOI folders (errors) ---------------------------------------
     for folder_name in [
-        f"stimuli_images_{lang_lower}_{country_lower}_{labnum}",
-        f"aoi_stimuli_{lang_lower}_{country_lower}_{labnum}",
-        f"question_images_{lang_lower}_{country_lower}_{labnum}",
-        f"participant_instructions_images_{lang_lower}_{country_lower}_{labnum}",
+        f"stimuli_images_{lang}_{country}_{labnum}",
+        f"aoi_stimuli_{lang}_{country}_{labnum}",
+        f"question_images_{lang}_{country}_{labnum}",
+        f"participant_instructions_images_{lang}_{country}_{labnum}",
     ]:
         _require_file(stim_dir / folder_name, f"Image folder: {folder_name}", errors)
 
     # --- Image/AOI folders (warnings — flaky, code handles absence) -------
     _warnings = warnings or {}
     for folder_name in [
-        f"aoi_stimuli_images_{lang_lower}_{country_lower}_{labnum}",
-        f"aoi_question_images_{lang_lower}_{country_lower}_{labnum}",
+        f"aoi_stimuli_images_{lang}_{country}_{labnum}",
+        f"aoi_question_images_{lang}_{country}_{labnum}",
     ]:
         _require_file(stim_dir / folder_name, f"Image folder: {folder_name}", _warnings)
 
@@ -429,7 +375,7 @@ def _check_stimulus_order_coverage(
     csv_path = (
         source_stim_dir
         / "config"
-        / f"stimulus_order_versions_{data_collection.language.casefold()}_{data_collection.country.casefold()}_{data_collection.lab_number}.csv"
+        / f"stimulus_order_versions_{data_collection.language}_{data_collection.country}_{data_collection.lab_number}.csv"
     )
     if not _ci_exists(csv_path):
         return  # already reported by _check_shared_files

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -268,12 +268,12 @@ def _check_shared_files(
 
     # --- Stimulus definition files (errors) -------------------------------
     _require_file(
-        stim_dir / f"multipleye_stimuli_experiment_{lang}.xlsx",
+        stim_dir / f"multipleye_stimuli_experiment_{lang_lower}.xlsx",
         "Stimulus definition xlsx",
         errors,
     )
     _require_file(
-        stim_dir / f"multipleye_comprehension_questions_{lang}.xlsx",
+        stim_dir / f"multipleye_comprehension_questions_{lang_lower}.xlsx",
         "Comprehension questions xlsx",
         errors,
     )
@@ -299,7 +299,7 @@ def _check_shared_files(
         errors,
     )
     _require_file(
-        config_dir / f"stimulus_order_versions_{lang}_{country}_{labnum}.csv",
+        config_dir / f"stimulus_order_versions_{lang_lower}_{country_lower}_{labnum}.csv",
         "Stimulus order versions CSV",
         errors,
     )

--- a/preprocessing/checks/preflight.py
+++ b/preprocessing/checks/preflight.py
@@ -241,18 +241,14 @@ def _check_shared_files(
     """Check files that are shared across all sessions (data-collection level)."""
     from ..config import settings
 
-    # Always validate the source stimulus folder in data/, not the OUTPUT_DIR copy that
-    # prepare_language_folder may have created.
-    source_stim_dir = getattr(
-        data_collection,
-        "data_collection_name",
-        None,
-    )
-    if source_stim_dir:
-        source_stim_dir = settings.DATASET_DIR / f"stimuli_{source_stim_dir}"
-    if not source_stim_dir or not source_stim_dir.exists():
-        source_stim_dir = data_collection.stimulus_dir
-    stim_dir = source_stim_dir
+    # Preflight always validates the input data/ folder, never the
+    # preprocessed_data/ output copy.  Fall back to stimulus_dir only for
+    # test/demo contexts that lack a real data_collection_name.
+    dcn_name = getattr(data_collection, "data_collection_name", None)
+    if dcn_name:
+        stim_dir = settings.DATASET_DIR / f"stimuli_{dcn_name}"
+    else:
+        stim_dir = data_collection.stimulus_dir.resolve()
     lang = data_collection.language
     country = data_collection.country
     labnum = data_collection.lab_number
@@ -299,7 +295,8 @@ def _check_shared_files(
         errors,
     )
     _require_file(
-        config_dir / f"stimulus_order_versions_{lang_lower}_{country_lower}_{labnum}.csv",
+        config_dir
+        / f"stimulus_order_versions_{lang_lower}_{country_lower}_{labnum}.csv",
         "Stimulus order versions CSV",
         errors,
     )
@@ -420,18 +417,19 @@ def _check_stimulus_order_coverage(
     from ..models.sid import Sid
 
     # Resolve the *source* stimulus dir (same logic as _check_shared_files)
+    # Preflight always validates the input data/ folder, never the
+    # preprocessed_data/ output copy.  Fall back to stimulus_dir only for
+    # test/demo contexts that lack a real data_collection_name.
     dcn_name = getattr(data_collection, "data_collection_name", None)
     if dcn_name:
         source_stim_dir = settings.DATASET_DIR / f"stimuli_{dcn_name}"
     else:
-        source_stim_dir = data_collection.stimulus_dir
-    if not source_stim_dir.exists():
-        source_stim_dir = data_collection.stimulus_dir
+        source_stim_dir = data_collection.stimulus_dir.resolve()
 
     csv_path = (
         source_stim_dir
         / "config"
-        / f"stimulus_order_versions_{data_collection.language}_{data_collection.country}_{data_collection.lab_number}.csv"
+        / f"stimulus_order_versions_{data_collection.language.casefold()}_{data_collection.country.casefold()}_{data_collection.lab_number}.csv"
     )
     if not _ci_exists(csv_path):
         return  # already reported by _check_shared_files

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -157,7 +157,7 @@ class MultipleyeDataCollection:
         # each participant
         stim_order_versions = (
             self.stimulus_dir / "config" / f"stimulus_order_versions_"
-            f"{self.language}_{self.country}_{self.lab_number}.csv"
+            f"{self.language.casefold()}_{self.country.casefold()}_{self.lab_number}.csv"
         )
         stim_order_versions = pd.read_csv(stim_order_versions)
         self.stim_order_versions = stim_order_versions[

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 from ..models.sid import Sid
 from ..models.dcn import Dcn
 from ..config import settings
+from ..utils.data_path_utils import _ci_resolve
 from ..utils.conversion import convert_to_time_str
 from ..utils.logging import get_logger
 from ..checks.et_quality_checks import (
@@ -155,9 +156,9 @@ class MultipleyeDataCollection:
 
         # load stimulus order versions to know what stimulus randomization was used for
         # each participant
-        stim_order_versions = (
+        stim_order_versions = _ci_resolve(
             self.stimulus_dir / "config" / f"stimulus_order_versions_"
-            f"{self.language.casefold()}_{self.country.casefold()}_{self.lab_number}.csv"
+            f"{self.language}_{self.country}_{self.lab_number}.csv"
         )
         stim_order_versions = pd.read_csv(stim_order_versions)
         self.stim_order_versions = stim_order_versions[

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -446,9 +446,11 @@ class MultipleyeDataCollection:
             + r"_ET\d(?:_.*)?"
         )
 
-        stimulus_folder_path = settings.OUTPUT_DIR / f"stimuli_{data_folder_name}"
+        stimulus_folder_path = (
+            settings.OUTPUT_DIR / f"stimuli_{data_folder_name}"
+        ).resolve()
         if not stimulus_folder_path.exists():
-            stimulus_folder_path = data_dir / f"stimuli_{data_folder_name}"
+            stimulus_folder_path = (data_dir / f"stimuli_{data_folder_name}").resolve()
 
         config_file = (
             stimulus_folder_path

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -11,6 +11,7 @@ import pymovements as pm
 from pymovements.stimulus import TextStimulus
 
 from ..config import settings
+from ..utils.data_path_utils import _ci_resolve
 from ..mapping.aoi import enlarge_aois
 from ..utils.logging import get_logger
 
@@ -109,8 +110,8 @@ class Stimulus:
         trial: str,
     ) -> "Stimulus":
         # assert stimulus_name in NAMES, f"{stimulus_name!r} is not a valid stimulus name"
-        stimulus_df_path = (
-            stimulus_dir / f"multipleye_stimuli_experiment_{lang.casefold()}.xlsx"
+        stimulus_df_path = _ci_resolve(
+            stimulus_dir / f"multipleye_stimuli_experiment_{lang}.xlsx"
         )
         assert stimulus_df_path.exists(), f"File {stimulus_df_path} does not exist"
 

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -109,7 +109,7 @@ class Stimulus:
         trial: str,
     ) -> "Stimulus":
         # assert stimulus_name in NAMES, f"{stimulus_name!r} is not a valid stimulus name"
-        stimulus_df_path = stimulus_dir / f"multipleye_stimuli_experiment_{lang}.xlsx"
+        stimulus_df_path = stimulus_dir / f"multipleye_stimuli_experiment_{lang.casefold()}.xlsx"
         assert stimulus_df_path.exists(), f"File {stimulus_df_path} does not exist"
 
         stimulus_df = pl.read_excel(stimulus_df_path, engine="calamine")

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -109,7 +109,9 @@ class Stimulus:
         trial: str,
     ) -> "Stimulus":
         # assert stimulus_name in NAMES, f"{stimulus_name!r} is not a valid stimulus name"
-        stimulus_df_path = stimulus_dir / f"multipleye_stimuli_experiment_{lang.casefold()}.xlsx"
+        stimulus_df_path = (
+            stimulus_dir / f"multipleye_stimuli_experiment_{lang.casefold()}.xlsx"
+        )
         assert stimulus_df_path.exists(), f"File {stimulus_df_path} does not exist"
 
         stimulus_df = pl.read_excel(stimulus_df_path, engine="calamine")

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -170,6 +170,15 @@ def prepare_language_folder(data_collection_name: str | None = None):
         / f"aoi_stimuli_{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
     )
 
+    # Always copy stimulus assets (config, xlsx, images) before AOI checks
+    # so files stay in sync even when AOIs are already fixed.
+    _copy_stimulus_assets(
+        stimulus_folder_path,
+        preprocessed_stimulus_path,
+        eye_tracking_sessions_path,
+        dcn,
+    )
+
     if (  # check if it already contains 24 files and the fixed marker
         destination_aoi_path.exists()
         and len(list(destination_aoi_path.glob("[!.]*.csv"))) == 24
@@ -187,14 +196,6 @@ def prepare_language_folder(data_collection_name: str | None = None):
         else:
             logger.warning(f"Source AOI path {source_aoi_path} does not exist.")
             return
-
-    # Copy other stimulus files
-    _copy_stimulus_assets(
-        stimulus_folder_path,
-        preprocessed_stimulus_path,
-        eye_tracking_sessions_path,
-        dcn,
-    )
 
     # get all aoi files in the preprocessed folder
     aoi_files = list(destination_aoi_path.glob("[!.]*.csv"))

--- a/preprocessing/utils/data_path_utils.py
+++ b/preprocessing/utils/data_path_utils.py
@@ -1,9 +1,62 @@
 """Utilities for working with paths, session identifiers, and further data locations."""
 
-import yaml
+import fnmatch
+import os
 from pathlib import Path
+
+import yaml
+
 from ..models.sid import Sid
 from preprocessing.config import settings
+
+
+def _ci_exists(path: Path) -> bool:
+    """Check if a path exists, falling back to case-insensitive comparison."""
+    if path.exists():
+        return True
+    parent = path.parent
+    if not parent.exists():
+        return False
+    try:
+        entries = os.listdir(parent)
+    except OSError:
+        return False
+    target = path.name.casefold()
+    return any(entry.casefold() == target for entry in entries)
+
+
+def _ci_resolve(path: Path) -> Path:
+    """Resolve a path to its actual on-disk spelling (case correction)."""
+    if path.exists():
+        return path
+    parent = path.parent
+    if not parent.exists():
+        return path
+    try:
+        entries = os.listdir(parent)
+    except OSError:
+        return path
+    target = path.name.casefold()
+    for entry in entries:
+        if entry.casefold() == target:
+            return parent / entry
+    return path
+
+
+def _ci_glob(directory: Path, pattern: str) -> list[Path]:
+    """Case-insensitive glob, returning actual on-disk paths."""
+    if not directory.exists():
+        return []
+    try:
+        entries = os.listdir(directory)
+    except OSError:
+        return []
+    pattern_cf = pattern.casefold()
+    return [
+        directory / entry
+        for entry in entries
+        if fnmatch.fnmatch(entry.casefold(), pattern_cf)
+    ]
 
 
 def validate_psychometric_data(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "ipykernel>=7.1.0",
     "jupyterlab",
     "ipywidgets",
+    "sphinxcontrib-mermaid>=2.0.2",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
- In Preflight-Check: Changed "lang/country" to lowercase versions in three filenames that use lowercase letters
- In Multipleye_data_collection: changed lang and country to lowercase for stimulus order file
- In Stimulus: Changed lang to lowercase in stimuli experiment excel filename- Shared case-insensitive utilities: 

Due to Linux being case sensitive (while we worked with insensitive filesystems on Mac):
- Moved `_ci_exists`, `_ci_resolve`, `_ci_glob` from `preflight.py` to `preprocessing/utils/data_path_utils.py` so all modules can use case-insensitive file lookups consistently.
- Reverted `lang_lower`/`country_lower`. File matching is already case-insensitive via _ci_exists/_ci_glob.
- `MultipleyeDataCollection.__init__`: Replaced `.casefold()` + raw `pd.read_csv()` with `_ci_resolve` before loading the stimulus order CSV, so it finds the file regardless of case on case-sensitive filesystems.
- `Stimulus.load()`: Replaced `.casefold()` + assert `path.exists()` with `_ci_resolve` before loading the experiment `xlsx`, for the same reason.
- Path fix (`_check_shared_files`): Resolved potential relative-path bug by using `.resolve()` on the fallback `stimulus_dir`, preventing path resolution from CWD when `data_collection_name` is absent.
- `create_from_data_folder`: Resolved `stimulus_folder_path` to absolute at construction time.
- `prepare_language_folder`: Moved `_copy_stimulus_assets` before the AOI early-return so xlsx/csv/config files are always synced from source to output, even when AOIs are already fixed.


#### Depends on 
- [x] #128 