### PR TITLE
feat: Windows path fix

### DIFF
--- a/preprocessing.ipynb
+++ b/preprocessing.ipynb
@@ -162,7 +162,7 @@
    "id": "11",
    "metadata": {},
    "source": [
-    "Note that executing the cell below for the first time can take very long. ONce you did it one, it will run through quickly."
+    "Note that executing the cell below for the first time can take very long. However, it will run through quickly after this initial run."
    ]
   },
   {

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -557,6 +557,7 @@ class Settings:
                 "EyeLink 1000",
                 "EyeLink Portable Duo",
                 "EyeLink Portable Duo 2000Hz Remote",
+                "EyeLink Duo",
             ],
         }
 

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -557,6 +557,7 @@ class Settings:
                 "EyeLink 1000",
                 "EyeLink Portable Duo",
                 "EyeLink Portable Duo 2000Hz Remote",
+                "Eyelink Duo",
                 "EyeLink Duo",
             ],
         }

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from ..models.dcn import Dcn
 from ..utils.data_path_utils import check_data_collection_exists
+from ..utils.file_utils import _copytree, _to_win_long_path
 from ..utils.logging import get_logger
 from ..scripts.restructure_psycho_tests import fix_psycho_tests_structure
 from ..utils.fix_multipleye_aoi_files import (
@@ -17,20 +18,6 @@ from ..utils.fix_multipleye_aoi_files import (
 )
 
 logger = get_logger()
-
-
-def _to_win_long_path(p: Path) -> str:
-    """Return a Windows extended-length path string when running on Windows.
-
-    Use this when calling APIs that may hit the legacy MAX_PATH limit.
-    """
-    s = str(p)
-    if os.name == "nt":
-        abs_path = os.path.abspath(s)
-        if not abs_path.startswith("\\\\?\\"):
-            return "\\\\?\\" + abs_path
-        return abs_path
-    return s
 
 
 def prepare_language_folder(data_collection_name: str | None = None):
@@ -198,12 +185,7 @@ def prepare_language_folder(data_collection_name: str | None = None):
     if not destination_aoi_path.exists():
         if source_aoi_path.exists():
             logger.debug(f"Copying AOI files to {destination_aoi_path}...")
-            # Skip hidden files when copying AOI folder and use Windows long-path prefix if needed
-            shutil.copytree(
-                _to_win_long_path(source_aoi_path),
-                _to_win_long_path(destination_aoi_path),
-                ignore=shutil.ignore_patterns(".*", "._*"),
-            )
+            _copytree(source_aoi_path, destination_aoi_path)
         else:
             logger.warning(f"Source AOI path {source_aoi_path} does not exist.")
             return
@@ -277,11 +259,7 @@ def _copy_stimulus_assets(
     dest_img = dest_stimulus_dir / stimuli_images_folder
     if source_img.exists() and not dest_img.exists():
         logger.debug(f"Copying {stimuli_images_folder}...")
-        shutil.copytree(
-            _to_win_long_path(source_img),
-            _to_win_long_path(dest_img),
-            ignore=shutil.ignore_patterns(".*", "._*"),
-        )
+        _copytree(source_img, dest_img)
 
     # 2. Copy Participant Instruction Images (all)
     instr_images_folder = f"participant_instructions_images_{suffix}"
@@ -289,11 +267,7 @@ def _copy_stimulus_assets(
     dest_instr = dest_stimulus_dir / instr_images_folder
     if source_instr.exists() and not dest_instr.exists():
         logger.debug(f"Copying {instr_images_folder}...")
-        shutil.copytree(
-            _to_win_long_path(source_instr),
-            _to_win_long_path(dest_instr),
-            ignore=shutil.ignore_patterns(".*", "._*"),
-        )
+        _copytree(source_instr, dest_instr)
 
     logger.debug("Copying remaining stimulus assets...")
 
@@ -304,29 +278,24 @@ def _copy_stimulus_assets(
         dest_aoi_img = dest_stimulus_dir / aoi_img_folder
         if source_aoi_img.exists() and not dest_aoi_img.exists():
             logger.debug(f"Copying {aoi_img_folder}...")
-            shutil.copytree(
-                _to_win_long_path(source_aoi_img),
-                _to_win_long_path(dest_aoi_img),
-                ignore=shutil.ignore_patterns(".*", "._*"),
-            )
+            _copytree(source_aoi_img, dest_aoi_img)
 
     # 4. Copy Config folder (includes stimulus order versions)
     source_config = source_stimulus_dir / "config"
     dest_config = dest_stimulus_dir / "config"
     if source_config.exists() and not dest_config.exists():
         logger.debug("Copying config folder...")
-        shutil.copytree(
-            _to_win_long_path(source_config),
-            _to_win_long_path(dest_config),
-            ignore=shutil.ignore_patterns(".*", "._*"),
-        )
+        _copytree(source_config, dest_config)
 
     # 5. Copy Excel files needed for loading
     for pattern in ["[!.]*.xlsx", "[!.]*.xls", "[!.]*.csv"]:
         for file in source_stimulus_dir.glob(pattern):
             dest_file = dest_stimulus_dir / file.name
             if not dest_file.exists():
-                shutil.copy2(file, dest_file)
+                shutil.copy2(
+                    _to_win_long_path(file) if os.name == "nt" else file,
+                    _to_win_long_path(dest_file) if os.name == "nt" else dest_file,
+                )
 
     # 6. Copy used Question Images
     question_images_folder = f"question_images_{suffix}"
@@ -343,12 +312,7 @@ def _copy_stimulus_assets(
             dest_v = dest_q_base / v_folder
             if source_v.exists() and not dest_v.exists():
                 logger.debug(f"Copying {v_folder}...")
-                # Skip hidden files when copying question image versions and use long-path prefix
-                shutil.copytree(
-                    _to_win_long_path(source_v),
-                    _to_win_long_path(dest_v),
-                    ignore=shutil.ignore_patterns(".*", "._*"),
-                )
+                _copytree(source_v, dest_v)
 
 
 def _get_used_stimulus_versions(eye_tracking_sessions_dir: Path) -> set[int]:

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -1,6 +1,7 @@
 import argparse
 import re
 import shutil
+import os
 import tarfile
 from pathlib import Path
 
@@ -16,6 +17,20 @@ from ..utils.fix_multipleye_aoi_files import (
 )
 
 logger = get_logger()
+
+
+def _to_win_long_path(p: Path) -> str:
+    """Return a Windows extended-length path string when running on Windows.
+
+    Use this when calling APIs that may hit the legacy MAX_PATH limit.
+    """
+    s = str(p)
+    if os.name == "nt":
+        abs_path = os.path.abspath(s)
+        if not abs_path.startswith("\\\\?\\"):
+            return "\\\\?\\" + abs_path
+        return abs_path
+    return s
 
 
 def prepare_language_folder(data_collection_name: str | None = None):
@@ -183,7 +198,12 @@ def prepare_language_folder(data_collection_name: str | None = None):
     if not destination_aoi_path.exists():
         if source_aoi_path.exists():
             logger.debug(f"Copying AOI files to {destination_aoi_path}...")
-            shutil.copytree(source_aoi_path, destination_aoi_path)
+            # Skip hidden files when copying AOI folder and use Windows long-path prefix if needed
+            shutil.copytree(
+                _to_win_long_path(source_aoi_path),
+                _to_win_long_path(destination_aoi_path),
+                ignore=shutil.ignore_patterns(".*", "._*"),
+            )
         else:
             logger.warning(f"Source AOI path {source_aoi_path} does not exist.")
             return
@@ -257,7 +277,11 @@ def _copy_stimulus_assets(
     dest_img = dest_stimulus_dir / stimuli_images_folder
     if source_img.exists() and not dest_img.exists():
         logger.debug(f"Copying {stimuli_images_folder}...")
-        shutil.copytree(source_img, dest_img)
+        shutil.copytree(
+            _to_win_long_path(source_img),
+            _to_win_long_path(dest_img),
+            ignore=shutil.ignore_patterns(".*", "._*"),
+        )
 
     # 2. Copy Participant Instruction Images (all)
     instr_images_folder = f"participant_instructions_images_{suffix}"
@@ -265,7 +289,11 @@ def _copy_stimulus_assets(
     dest_instr = dest_stimulus_dir / instr_images_folder
     if source_instr.exists() and not dest_instr.exists():
         logger.debug(f"Copying {instr_images_folder}...")
-        shutil.copytree(source_instr, dest_instr)
+        shutil.copytree(
+            _to_win_long_path(source_instr),
+            _to_win_long_path(dest_instr),
+            ignore=shutil.ignore_patterns(".*", "._*"),
+        )
 
     logger.debug("Copying remaining stimulus assets...")
 
@@ -276,14 +304,22 @@ def _copy_stimulus_assets(
         dest_aoi_img = dest_stimulus_dir / aoi_img_folder
         if source_aoi_img.exists() and not dest_aoi_img.exists():
             logger.debug(f"Copying {aoi_img_folder}...")
-            shutil.copytree(source_aoi_img, dest_aoi_img)
+            shutil.copytree(
+                _to_win_long_path(source_aoi_img),
+                _to_win_long_path(dest_aoi_img),
+                ignore=shutil.ignore_patterns(".*", "._*"),
+            )
 
     # 4. Copy Config folder (includes stimulus order versions)
     source_config = source_stimulus_dir / "config"
     dest_config = dest_stimulus_dir / "config"
     if source_config.exists() and not dest_config.exists():
         logger.debug("Copying config folder...")
-        shutil.copytree(source_config, dest_config)
+        shutil.copytree(
+            _to_win_long_path(source_config),
+            _to_win_long_path(dest_config),
+            ignore=shutil.ignore_patterns(".*", "._*"),
+        )
 
     # 5. Copy Excel files needed for loading
     for pattern in ["[!.]*.xlsx", "[!.]*.xls", "[!.]*.csv"]:
@@ -307,7 +343,12 @@ def _copy_stimulus_assets(
             dest_v = dest_q_base / v_folder
             if source_v.exists() and not dest_v.exists():
                 logger.debug(f"Copying {v_folder}...")
-                shutil.copytree(source_v, dest_v)
+                # Skip hidden files when copying question image versions and use long-path prefix
+                shutil.copytree(
+                    _to_win_long_path(source_v),
+                    _to_win_long_path(dest_v),
+                    ignore=shutil.ignore_patterns(".*", "._*"),
+                )
 
 
 def _get_used_stimulus_versions(eye_tracking_sessions_dir: Path) -> set[int]:

--- a/preprocessing/scripts/restructure_psycho_tests.py
+++ b/preprocessing/scripts/restructure_psycho_tests.py
@@ -8,6 +8,7 @@ import yaml
 
 from preprocessing.models.sid import Sid
 from preprocessing.utils import get_logger, validate_psychometric_data
+from preprocessing.utils.file_utils import _copytree
 
 logger = get_logger()
 
@@ -155,7 +156,7 @@ def fix_psycho_tests_structure(
             if old_path.exists():
                 new_test_path = session_folder / folder_name
                 new_test_path.mkdir(parents=True, exist_ok=True)
-                shutil.copytree(old_path, new_test_path, dirs_exist_ok=True)
+                _copytree(old_path, new_test_path, dirs_exist_ok=True)
 
         # copy the config file to the new session folder
         new_config_path = session_folder / config_file.name

--- a/preprocessing/utils/__init__.py
+++ b/preprocessing/utils/__init__.py
@@ -5,12 +5,15 @@ from .data_path_utils import (
     validate_psychometric_data,
 )
 from .data_collection_utils import _report_to_file
+from .file_utils import _copytree, _to_win_long_path
 from .logging import get_logger, setup_logging
 
 __all__ = [
     "check_data_collection_exists",
     "validate_psychometric_data",
     "_report_to_file",
+    "_copytree",
+    "_to_win_long_path",
     "get_logger",
     "setup_logging",
 ]

--- a/preprocessing/utils/file_utils.py
+++ b/preprocessing/utils/file_utils.py
@@ -1,0 +1,29 @@
+"""File system utility functions for cross-platform path handling."""
+
+import os
+import shutil
+from pathlib import Path
+
+
+def _to_win_long_path(p: Path) -> str:
+    abs_path = str(os.path.abspath(p))
+    if os.name != "nt":
+        return abs_path
+    if not abs_path.startswith("\\\\?\\"):
+        return "\\\\?\\" + abs_path
+    return abs_path
+
+
+def _copytree(src: Path, dst: Path, **kwargs) -> None:
+    shutil.copytree(
+        src if os.name != "nt" else _to_win_long_path(src),
+        dst if os.name != "nt" else _to_win_long_path(dst),
+        ignore=shutil.ignore_patterns(".*", "._*"),
+        **kwargs,
+    )
+
+
+__all__ = [
+    "_to_win_long_path",
+    "_copytree",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,17 @@ dependencies = [
     "pandas>=2.2.2",
     "pillow==12.2.0",
     "polars>=1.28.1",
+    "pymovements",
     "tqdm>=4.66.4",
     "openpyxl>=3.0.0",
     "ipykernel>=7.1.0",
     "jupyterlab",
     "ipywidgets",
-    "pymovements==0.27.0",
+    "sphinxcontrib-mermaid>=2.0.2",
 ]
+
+[tool.uv.sources]
+pymovements = { git = "https://github.com/pymovements/pymovements.git", branch = "main" }
 
 [tool.setuptools.packages.find]
 include = ["preprocessing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,13 @@ dependencies = [
     "pandas>=2.2.2",
     "pillow==12.2.0",
     "polars>=1.28.1",
-    "pymovements",
     "tqdm>=4.66.4",
     "openpyxl>=3.0.0",
     "ipykernel>=7.1.0",
     "jupyterlab",
     "ipywidgets",
+    "pymovements==0.27.0",
 ]
-
-[tool.uv.sources]
-pymovements = { git = "https://github.com/pymovements/pymovements.git", branch = "main" }
 
 [tool.setuptools.packages.find]
 include = ["preprocessing"]

--- a/tests/unit/preprocessing/utils/test_file_utils.py
+++ b/tests/unit/preprocessing/utils/test_file_utils.py
@@ -1,0 +1,149 @@
+"""Tests for the file_utils submodule."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from preprocessing.utils.file_utils import _copytree, _to_win_long_path
+
+
+@pytest.fixture
+def source_dir(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "file.txt").write_text("imasourcedirfile")
+    return src
+
+
+@pytest.fixture
+def source_dest(source_dir, tmp_path):
+    return source_dir, tmp_path / "dest"
+
+
+class TestToWinLongPath:
+    @pytest.mark.parametrize(
+        "path_str",
+        [
+            "/home/user/file.txt",
+            "/",
+            "/home/user/my documents/file.txt",
+        ],
+    )
+    def test_unix_returns_absolute_path_without_prefix(self, path_str):
+        result = _to_win_long_path(Path(path_str))
+        assert result == os.path.abspath(path_str)
+        assert not result.startswith("\\\\?\\")
+
+    @pytest.mark.parametrize(
+        "path_str",
+        [
+            "relative/path",
+            "another/./docs/../file.txt",
+        ],
+    )
+    def test_unix_resolves_relative_to_absolute(self, path_str):
+        result = _to_win_long_path(Path(path_str))
+        assert result == os.path.abspath(path_str)
+        assert os.path.isabs(result)
+
+    @pytest.mark.parametrize(
+        "path_str, expected_suffix",
+        [
+            ("C:\\Users\\test\\file.txt", "C:\\Users\\test\\file.txt"),
+            ("C:\\Program Files\\app\\file.txt", "Program Files"),
+        ],
+    )
+    @patch("os.name", "nt")
+    def test_windows_prefixes_absolute_path(self, path_str, expected_suffix):
+        result = _to_win_long_path(Path(path_str))
+        assert result.startswith("\\\\?\\")
+        assert expected_suffix in result
+
+    @patch("os.name", "nt")
+    def test_windows_does_not_double_prefix(self):
+        with patch("os.path.abspath", return_value="\\\\?\\C:\\Users\\test\\file.txt"):
+            result = _to_win_long_path(Path("C:\\Users\\test\\file.txt"))
+            assert result == "\\\\?\\C:\\Users\\test\\file.txt"
+
+    @patch("os.name", "nt")
+    def test_windows_resolves_relative_to_absolute_then_prefixes(self):
+        result = _to_win_long_path(Path("relative\\path"))
+        assert result.startswith("\\\\?\\")
+        assert os.path.isabs(result[4:])
+
+
+class TestCopytree:
+    def test_copies_directory_tree(self, source_dest):
+        src, dst = source_dest
+        _copytree(src, dst)
+        assert dst.exists()
+        assert (dst / "file.txt").read_text() == "imasourcedirfile"
+
+    @pytest.mark.parametrize("hidden_name", [".hidden", "._apple_double"])
+    def test_skips_hidden_files(self, source_dir, tmp_path, hidden_name):
+        src = source_dir
+        dst = tmp_path / "dest"
+        (src / hidden_name).write_text("hidden")
+
+        _copytree(src, dst)
+
+        assert (dst / "file.txt").exists()
+        assert not (dst / hidden_name).exists()
+
+    def test_skips_hidden_directories(self, source_dir, tmp_path):
+        src = source_dir
+        dst = tmp_path / "dest"
+        (src / ".git").mkdir()
+        (src / ".git" / "config").write_text("config")
+
+        _copytree(src, dst)
+
+        assert (dst / "file.txt").exists()
+        assert not (dst / ".git").exists()
+
+    def test_passes_dirs_exist_ok(self, source_dest):
+        src, dst = source_dest
+        dst.mkdir()
+
+        _copytree(src, dst, dirs_exist_ok=True)
+
+        assert (dst / "file.txt").exists()
+
+    def test_raises_on_existing_dest_without_dirs_exist_ok(self, source_dest):
+        src, dst = source_dest
+        dst.mkdir()
+
+        with pytest.raises(FileExistsError):
+            _copytree(src, dst)
+
+    @pytest.mark.parametrize(
+        "is_windows, expect_wrapped",
+        [
+            (False, False),
+            (True, True),
+        ],
+    )
+    def test_path_wrapping(self, source_dir, tmp_path, is_windows, expect_wrapped):
+        src = source_dir
+        dst = tmp_path / "dest"
+
+        with patch("os.name", "nt" if is_windows else "posix"):
+            with patch(
+                "preprocessing.utils.file_utils.shutil.copytree"
+            ) as mock_copytree:
+                _copytree(src, dst, dirs_exist_ok=True)
+
+        call_args, call_kwargs = mock_copytree.call_args
+        src_arg, dst_arg = call_args[0], call_args[1]
+        assert call_kwargs["dirs_exist_ok"] is True
+
+        if expect_wrapped:
+            assert isinstance(src_arg, str)
+            assert isinstance(dst_arg, str)
+            assert src_arg.startswith("\\\\?\\")
+            assert dst_arg.startswith("\\\\?\\")
+        else:
+            assert isinstance(src_arg, Path)
+            assert isinstance(dst_arg, Path)


### PR DESCRIPTION
fixed some typos, along side with adding a function to prevent the stimulus folder copying to fail on windows because the path names are to long. also ignoring hidden files while copying the stimulus folder. Pymovements version is fixed in Project toml but i don't remember why, so if it should stay as on the main branch I will take it out,  just let me know. and added two more eye tracker name variants, since they came up in one of the data collections