### PR TITLE
feat(PT): Implement global RT filtering, LexTALE scoring, and expand overview metrics

### DIFF
--- a/docs/guide/psychometric_tests.md
+++ b/docs/guide/psychometric_tests.md
@@ -96,9 +96,14 @@ consistent with the maximum attainable score in the current version.
 
 - `LWMC_MU_score`: Memory Update task score
 - `LWMC_OS_score`: Operation Span task score
+- `LWMC_OS_processingTask_score`: Equation accuracy for Operation Span
 - `LWMC_SS_score`: Sentence Span task score
+- `LWMC_SentS_processingTask_score`: Sentence truth-value accuracy for Sentence Span
 - `LWMC_SSTM_score`: Spatial Short-Term Memory task score
 - `LWMC_Total_score_mean`: Average score across all four tasks
+
+*Note: The processing task scores (OS and SentS) are included in the overview to validate
+participant engagement.*
 
 *Detailed outputs*:
 
@@ -140,6 +145,11 @@ the automatic tendency to read words while naming the font color. The difference
 between congruent (word matches color) and incongruent (word conflicts with color) trials provides
 a sensitive measure of inhibitory control {cite:p}`Stroop1935`.
 
+To ensure data quality, reaction times below a minimum threshold (default 200ms) or above a
+maximum threshold (default infinity) are excluded from all calculations (reaction time means,
+accuracy, and trial counts) as they likely represent accidental key presses or lapses in
+attention.
+
 **Mathematical Formulas**:
 
 For each condition (incongruent, congruent, neutral), basic metrics are calculated as:
@@ -158,16 +168,23 @@ $$\mathrm{RTEffect}_{\mathrm{sec}} = \mathrm{RT}_{\mathrm{incongruent}} - \mathr
 
 - `StroopAccuracyEffect`: Accuracy interference effect
 - `StroopRTEffect_sec`: Reaction time interference effect
+- `Stroop_incongruent_correct_rt_mean_sec`: Mean RT for correct incongruent trials
+- `Stroop_congruent_correct_rt_mean_sec`: Mean RT for correct congruent trials
 
 *Detailed outputs*:
 
-- `Stroop_incongruent_rt_mean_sec`: Mean RT for incongruent trials
+- `Stroop_incongruent_rt_mean_sec`: Mean RT for incongruent trials (filtered by minimum RT)
+- `Stroop_incongruent_correct_rt_mean_sec`: Mean RT for correct incongruent trials (filtered by
+  minimum RT)
 - `Stroop_incongruent_accuracy`: Accuracy for incongruent trials
 - `Stroop_incongruent_num_items`: Number of incongruent trials
-- `Stroop_congruent_rt_mean_sec`: Mean RT for congruent trials
+- `Stroop_congruent_rt_mean_sec`: Mean RT for congruent trials (filtered by minimum RT)
+- `Stroop_congruent_correct_rt_mean_sec`: Mean RT for correct congruent trials (filtered by minimum
+  RT)
 - `Stroop_congruent_accuracy`: Accuracy for congruent trials
 - `Stroop_congruent_num_items`: Number of congruent trials
-- `Stroop_neutral_rt_mean_sec`: Mean RT for neutral trials
+- `Stroop_neutral_rt_mean_sec`: Mean RT for neutral trials (filtered by minimum RT)
+- `Stroop_neutral_correct_rt_mean_sec`: Mean RT for correct neutral trials (filtered by minimum RT)
 - `Stroop_neutral_accuracy`: Accuracy for neutral trials
 - `Stroop_neutral_num_items`: Number of neutral trials
 
@@ -181,6 +198,9 @@ distractors. The task creates conflict between automatic attentional capture by 
 goal-directed focus on the target. Like the Stroop, the difference between incongruent and congruent
 conditions provides a measure of cognitive control, but through spatial rather than semantic
 interference {cite:p}`Eriksen1974`.
+
+By default, no minimum reaction time filter is applied to the Flanker task, as processing of
+purely visual stimuli is faster and simpler than semantic processing.
 
 **Mathematical Formulas**:
 
@@ -200,13 +220,17 @@ $$\mathrm{RTEffect}_{\mathrm{sec}} = \mathrm{RT}_{\mathrm{incongruent}} - \mathr
 
 - `FlankerAccuracyEffect`: Accuracy interference effect
 - `FlankerRTEffect_sec`: Reaction time interference effect
+- `Flanker_incongruent_correct_rt_mean_sec`: Mean RT for correct incongruent trials
+- `Flanker_congruent_correct_rt_mean_sec`: Mean RT for correct congruent trials
 
 *Detailed outputs*:
 
 - `Flanker_incongruent_rt_mean_sec`: Mean RT for incongruent trials
+- `Flanker_incongruent_correct_rt_mean_sec`: Mean RT for correct incongruent trials
 - `Flanker_incongruent_accuracy`: Accuracy for incongruent trials
 - `Flanker_incongruent_num_items`: Number of incongruent trials
 - `Flanker_congruent_rt_mean_sec`: Mean RT for congruent trials
+- `Flanker_congruent_correct_rt_mean_sec`: Mean RT for correct congruent trials
 - `Flanker_congruent_accuracy`: Accuracy for congruent trials
 - `Flanker_congruent_num_items`: Number of congruent trials
 
@@ -224,6 +248,10 @@ language learning {cite:p}`Pimsleur2004`.
 
 - `PLAB_rt_mean_sec`: Mean reaction time across all PLAB trials
 - `PLAB_accuracy`: Overall accuracy across all PLAB trials
+- `PLAB_set1_accuracy`: Accuracy for items 1-4
+- `PLAB_set2_accuracy`: Accuracy for items 5-15
+- `PLAB_set1_rt_mean_sec`: Mean RT for items 1-4
+- `PLAB_set2_rt_mean_sec`: Mean RT for items 5-15
 
 *Detailed outputs*:
 
@@ -241,6 +269,11 @@ The balanced scoring approach (averaging performance on real and pseudo-words) h
 individual response tendencies, such as a bias towards accepting or rejecting items, and makes it
 comparable across languages with different writing systems and vocabulary structures {cite:p}
 `vanRijn2023`.
+
+Reaction times are filtered by a minimum threshold (default 200ms) and a maximum threshold
+(default infinity) to exclude extreme responses (e.g., accidental key presses or attention
+lapses). Trials outside this range are excluded from all metrics, including the balanced LexTALE
+score.
 
 - Large, representative item pools from Wikipedia
 - Balanced scoring controls for response biases
@@ -261,9 +294,12 @@ $$\mathrm{Incorrect\_Correct\_Score} = \frac{\mathrm{Real\_Correct} + \mathrm{Ps
 
 **Returned Results**:
 
-- `WikiVocab_rt_mean_sec`: Mean reaction time across all trials
+- `WikiVocab_rt_mean_sec`: Mean reaction time across all trials (filtered by minimum RT)
 - `WikiVocab_accuracy`: Overall accuracy across all trials
 - `WikiVocab_incorrect_correct_score`: Balanced LexTALE-style score
+- `WikiVocab_correct_words_rt_mean_sec`: Mean RT for correct real word responses
+- `WikiVocab_correct_pseudowords_rt_mean_sec`: Mean RT for correct pseudoword responses
+- `WikiVocab_ratio_items`: Ratio of real words to pseudowords (detailed only)
 
 *Detailed outputs*:
 

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -522,6 +522,26 @@ class Settings:
         #: Event name for saccades.
         self.SACCADE = "saccade"
 
+        # --- PSYCHOMETRIC TEST THRESHOLDS ---
+
+        #: Minimum reaction time for WikiVocab in seconds.
+        self.PSYM_WIKIVOCAB_MIN_RT = 0.2
+
+        #: Maximum reaction time for WikiVocab in seconds.
+        self.PSYM_WIKIVOCAB_MAX_RT = float("inf")
+
+        #: Minimum reaction time for Stroop in seconds.
+        self.PSYM_STROOP_MIN_RT = 0.2
+
+        #: Maximum reaction time for Stroop in seconds.
+        self.PSYM_STROOP_MAX_RT = float("inf")
+
+        #: Minimum reaction time for Flanker in seconds.
+        self.PSYM_FLANKER_MIN_RT = 0.0
+
+        #: Maximum reaction time for Flanker in seconds.
+        self.PSYM_FLANKER_MAX_RT = float("inf")
+
         # --- REGULAR EXPRESSIONS ---
 
         #: Regex to parse generic messages from eye tracker logs.

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -51,7 +51,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
        - Stroop & Flanker: AccuracyEffect and TREffect only
        - WikiVocab: rt_mean, accuracy, incorrect_correct_score
        - RAN: Reaction time for two trials
-       - PLAB: RT mean and accuracy
+       - PLAB: RT mean and accuracy (overall and split for sets 1 and 2)
 
     2. **Per-session detailed CSV** saved to
        ``OUTPUT_DIR / PSYCHOMETRIC_TESTS_FOLDER / {session_name}``
@@ -166,13 +166,15 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 res_lwmc = preprocess_lwmc(lwmc_dir)  # dict
                 # detailed: all LWMC metrics
                 detailed_row.update(res_lwmc)
-                # overview: LWMC scores only
+                # overview: selected scores and processing tasks
                 for k in [
                     "LWMC_MU_score",
                     "LWMC_OS_score",
                     "LWMC_SS_score",
                     "LWMC_SSTM_score",
                     "LWMC_Total_score_mean",
+                    "LWMC_OS_processingTask_score",
+                    "LWMC_SentS_processingTask_score",
                 ]:
                     if k in res_lwmc:
                         overview_row[k] = res_lwmc[k]
@@ -209,6 +211,12 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                     - res_stroop["Stroop_congruent_accuracy"],
                     "StroopRTEffect_sec": res_stroop["Stroop_incongruent_rt_mean_sec"]
                     - res_stroop["Stroop_congruent_rt_mean_sec"],
+                    "Stroop_incongruent_correct_rt_mean_sec": res_stroop[
+                        "Stroop_incongruent_correct_rt_mean_sec"
+                    ],
+                    "Stroop_congruent_correct_rt_mean_sec": res_stroop[
+                        "Stroop_congruent_correct_rt_mean_sec"
+                    ],
                 }
                 # overview: only effects
                 overview_row.update(stroop_effects)
@@ -230,6 +238,12 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                         "Flanker_incongruent_rt_mean_sec"
                     ]
                     - res_flanker["Flanker_congruent_rt_mean_sec"],
+                    "Flanker_incongruent_correct_rt_mean_sec": res_flanker[
+                        "Flanker_incongruent_correct_rt_mean_sec"
+                    ],
+                    "Flanker_congruent_correct_rt_mean_sec": res_flanker[
+                        "Flanker_congruent_correct_rt_mean_sec"
+                    ],
                 }
                 # overview: only effects
                 overview_row.update(flanker_effects)
@@ -256,6 +270,8 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                     "WikiVocab_rt_mean_sec",
                     "WikiVocab_accuracy",
                     "WikiVocab_incorrect_correct_score",
+                    "WikiVocab_correct_words_rt_mean_sec",
+                    "WikiVocab_correct_pseudowords_rt_mean_sec",
                 ]:
                     overview_row[key] = res_wv[key]
                 overview_row["WikiVocab_Done"] = 1
@@ -273,6 +289,14 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 detailed_row.update(res_plab)
                 overview_row["PLAB_rt_mean_sec"] = res_plab["PLAB_rt_mean_sec"]
                 overview_row["PLAB_accuracy"] = res_plab["PLAB_accuracy"]
+                overview_row["PLAB_set1_accuracy"] = res_plab["PLAB_set1_accuracy"]
+                overview_row["PLAB_set2_accuracy"] = res_plab["PLAB_set2_accuracy"]
+                overview_row["PLAB_set1_rt_mean_sec"] = res_plab[
+                    "PLAB_set1_rt_mean_sec"
+                ]
+                overview_row["PLAB_set2_rt_mean_sec"] = res_plab[
+                    "PLAB_set2_rt_mean_sec"
+                ]
                 overview_row["PLAB_Done"] = 1
             except ValueError as err:
                 warnings.warn(
@@ -537,14 +561,31 @@ def preprocess_stroop(stroop_flanker_dir: Path) -> dict:
         reaction_time_col="stroop_key.rt",
         correctness_col="stroop_key.corr",
         group_by_col="stim_type",
+        min_rt=settings.PSYM_STROOP_MIN_RT,
+        max_rt=settings.PSYM_STROOP_MAX_RT,
+    )
+    # RT for correct responses only
+    result_df_acc = _reaction_time_accuracy(
+        df,
+        reaction_time_col="stroop_key.rt",
+        correctness_col="stroop_key.corr",
+        group_by_col="stim_type",
+        correct_only=True,
+        min_rt=settings.PSYM_STROOP_MIN_RT,
+        max_rt=settings.PSYM_STROOP_MAX_RT,
     )
 
     result_df.rename(columns={"rt_mean": "rt_mean_sec"}, inplace=True)
+    result_df_acc.rename(columns={"rt_mean": "correct_rt_mean_sec"}, inplace=True)
 
     result_dict = {}
     for cond in ["incongruent", "congruent", "neutral"]:
         for metric in ("rt_mean_sec", "accuracy", "num_items"):
             result_dict[f"Stroop_{cond}_{metric}"] = float(result_df.loc[cond, metric])
+        # Add correct RT mean
+        result_dict[f"Stroop_{cond}_correct_rt_mean_sec"] = float(
+            result_df_acc.loc[cond, "correct_rt_mean_sec"]
+        )
 
     return result_dict
 
@@ -625,14 +666,31 @@ def preprocess_flanker(stroop_flanker_dir: Path) -> dict:
         reaction_time_col="Flanker_key.rt",
         correctness_col="Flanker_key.corr",
         group_by_col="stim_type",
+        min_rt=settings.PSYM_FLANKER_MIN_RT,
+        max_rt=settings.PSYM_FLANKER_MAX_RT,
+    )
+    # RT for correct responses only
+    result_df_acc = _reaction_time_accuracy(
+        df,
+        reaction_time_col="Flanker_key.rt",
+        correctness_col="Flanker_key.corr",
+        group_by_col="stim_type",
+        correct_only=True,
+        min_rt=settings.PSYM_FLANKER_MIN_RT,
+        max_rt=settings.PSYM_FLANKER_MAX_RT,
     )
 
     result_df.rename(columns={"rt_mean": "rt_mean_sec"}, inplace=True)
+    result_df_acc.rename(columns={"rt_mean": "correct_rt_mean_sec"}, inplace=True)
 
     result_dict = {}
     for cond in ["incongruent", "congruent"]:
         for metric in ("rt_mean_sec", "accuracy", "num_items"):
             result_dict[f"Flanker_{cond}_{metric}"] = float(result_df.loc[cond, metric])
+        # Add correct RT mean
+        result_dict[f"Flanker_{cond}_correct_rt_mean_sec"] = float(
+            result_df_acc.loc[cond, "correct_rt_mean_sec"]
+        )
 
     return result_dict
 
@@ -696,8 +754,10 @@ def preprocess_lwmc(lwmc_dir: Path) -> dict:
         "mu_key_resp_recall.rt",  # MU columns
         "os_key_resp_recall.corr",
         "os_key_resp_recall.rt",  # OS columns
+        "os_key_resp_equation.corr",  # OS processing task
         "ss_key_resp_recall.corr",
         "ss_key_resp_recall.rt",  # SS columns
+        "ss_key_resp_sentence.corr",  # SS processing task
     ]
     try:
         df = _find_one_filetype_with_columns(lwmc_dir, required_cols, allow_nan=True)
@@ -776,6 +836,15 @@ def preprocess_lwmc(lwmc_dir: Path) -> dict:
         "ss_key_resp_recall.corr", "ss_key_resp_recall.rt", "SS"
     )
 
+    # 2b) Compute processing task scores for OS and SS
+    def _compute_processing_score(col: str) -> float:
+        if col not in df.columns:
+            return nan
+        return float(df[col].mean())
+
+    os_proc_score = _compute_processing_score("os_key_resp_equation.corr")
+    ss_proc_score = _compute_processing_score("ss_key_resp_sentence.corr")
+
     # 3) SSTM from legacy .dat
     def _participant_id_from_dir(d: Path) -> str:
         stem = d.parent.stem
@@ -815,8 +884,10 @@ def preprocess_lwmc(lwmc_dir: Path) -> dict:
         "LWMC_MU_time_sec": mu_time,
         "LWMC_OS_score": os_score,
         "LWMC_OS_time_sec": os_time,
+        "LWMC_OS_processingTask_score": os_proc_score,
         "LWMC_SS_score": ss_score,
         "LWMC_SS_time_sec": ss_time,
+        "LWMC_SentS_processingTask_score": ss_proc_score,
         "LWMC_SSTM_score": sstm_score,
         "LWMC_Total_score_mean": total,
     }
@@ -914,6 +985,7 @@ def preprocess_wikivocab(wv_dir: Path) -> dict:
     - Pseudo word accuracy = correct_pseudo_words / num_pseudo_words
     - Balanced score = (real_word_accuracy + pseudo_word_accuracy) / 2
       (Equivalent to LexTALE scoring: https://www.lextale.com/scoring.html)
+    - Reaction times are filtered by a minimum threshold (default 200ms).
 
     Parameters
     ----------
@@ -964,6 +1036,49 @@ def preprocess_wikivocab(wv_dir: Path) -> dict:
             f"Please check if the experiment was interrupted or if the data was recorded correctly.{see_also} "
             f"\nDetail: {err}"
         ) from err
+
+    try:
+        # Validate correct_answer values
+        if not df["correct_answer"].isin([0, 1]).all():
+            invalid_vals = df.loc[
+                ~df["correct_answer"].isin([0, 1]), "correct_answer"
+            ].unique()
+            raise ValueError(
+                f"WikiVocab 'correct_answer' contains invalid values: {invalid_vals}. "
+                "Expected 0 (pseudoword) or 1 (real word)."
+            )
+
+        # Validate RT values are numeric before filtering
+        if not pd.api.types.is_numeric_dtype(df["RT"]):
+            raise ValueError("Reaction time column contains non-numeric values.")
+
+        # Filter by RT thresholds if provided
+        df = df.copy()
+        df = df[
+            (df["RT"] >= settings.PSYM_WIKIVOCAB_MIN_RT)
+            & (df["RT"] <= settings.PSYM_WIKIVOCAB_MAX_RT)
+        ]
+    except ValueError as err:
+        # Re-use the same error wrapping logic for consistent reporting
+        try:
+            psym_dir = settings.PSYCHOMETRIC_TESTS_DIR
+            if (
+                wv_dir.is_absolute()
+                and psym_dir.is_absolute()
+                and wv_dir.is_relative_to(psym_dir)
+            ):
+                display_path = str(wv_dir.relative_to(psym_dir))
+            else:
+                display_path = wv_dir.name
+        except (ValueError, AttributeError):
+            display_path = wv_dir.name
+
+        raise ValueError(
+            f"WikiVocab results missing or incomplete in '{display_path}'. "
+            f"Please check if the experiment was interrupted or if the data was recorded correctly. "
+            f"\nDetail: {err}"
+        ) from err
+
     df["correctness"] = df["correct_answer"] == df["real_answer"]
 
     # Calculate additional metrics
@@ -985,10 +1100,56 @@ def preprocess_wikivocab(wv_dir: Path) -> dict:
     # Calculate incorrect_correct score
     incorrect_correct = (real_correct + pseudo_correct) / 2
 
+    # Ratio of items
+    ratio_items = num_real / num_pseudo if num_pseudo > 0 else nan
+
     try:
+        # Overall RT and accuracy
         rt_acc = _reaction_time_accuracy(
-            df, reaction_time_col="RT", correctness_col="correctness"
+            df,
+            reaction_time_col="RT",
+            correctness_col="correctness",
+            min_rt=settings.PSYM_WIKIVOCAB_MIN_RT,
+            max_rt=settings.PSYM_WIKIVOCAB_MAX_RT,
         )
+
+        # Correct RT for all items
+        rt_acc_all = _reaction_time_accuracy(
+            df,
+            reaction_time_col="RT",
+            correctness_col="correctness",
+            correct_only=True,
+            min_rt=settings.PSYM_WIKIVOCAB_MIN_RT,
+            max_rt=settings.PSYM_WIKIVOCAB_MAX_RT,
+        )
+
+        # Correct RT for real words
+        df_words = df[df["correct_answer"] == 1]
+        if not df_words.empty:
+            rt_acc_words = _reaction_time_accuracy(
+                df_words,
+                reaction_time_col="RT",
+                correctness_col="correctness",
+                correct_only=True,
+                min_rt=settings.PSYM_WIKIVOCAB_MIN_RT,
+                max_rt=settings.PSYM_WIKIVOCAB_MAX_RT,
+            )
+        else:
+            rt_acc_words = (nan, nan, 0)
+
+        # Correct RT for pseudowords
+        df_pseudo = df[df["correct_answer"] == 0]
+        if not df_pseudo.empty:
+            rt_acc_pseudo = _reaction_time_accuracy(
+                df_pseudo,
+                reaction_time_col="RT",
+                correctness_col="correctness",
+                correct_only=True,
+                min_rt=settings.PSYM_WIKIVOCAB_MIN_RT,
+                max_rt=settings.PSYM_WIKIVOCAB_MAX_RT,
+            )
+        else:
+            rt_acc_pseudo = (nan, nan, 0)
     except ValueError as err:
         # Determine display path for the outer error message
         try:
@@ -1025,16 +1186,21 @@ def preprocess_wikivocab(wv_dir: Path) -> dict:
         "WikiVocab_num_items": rt_acc[2],
         "WikiVocab_num_pseudo_words": num_pseudo,
         "WikiVocab_num_real_words": num_real,
+        "WikiVocab_ratio_items": ratio_items,
         "WikiVocab_incorrect_correct_score": incorrect_correct,
         "WikiVocab_pseudo_correct": pseudo_correct,
         "WikiVocab_real_correct": real_correct,
+        "WikiVocab_correct_all_rt_mean_sec": rt_acc_all[0],
+        "WikiVocab_correct_words_rt_mean_sec": rt_acc_words[0],
+        "WikiVocab_correct_pseudowords_rt_mean_sec": rt_acc_pseudo[0],
     }
 
 
 def preprocess_plab(plab_dir: Path) -> dict:
     """Preprocess PLAB (Pimsleur Language Aptitude Battery) test CSV data.
 
-    Computes mean reaction time and overall accuracy.
+    Computes mean reaction time and overall accuracy, as well as split accuracy
+    and reaction time for items 1-4 and 5-15.
 
     **PLAB test**: The PLAB test is Pimsleur Language Aptitude Battery test.
     It is a test of language aptitude that is designed to measure an individual's ability to learn
@@ -1044,7 +1210,8 @@ def preprocess_plab(plab_dir: Path) -> dict:
     Pimsleur Language Aptitude Battery: PLAB : Manual.
     Second Language Testing Foundation, North Bethesda, 2004 edition, 2004.
 
-    **Calculation**: Mean RT and overall accuracy across all PLAB trials.
+    **Calculation**: Mean RT and overall accuracy across all PLAB trials, and
+    for two specific sets of items (1-4 and 5-15).
 
     Parameters
     ----------
@@ -1054,7 +1221,8 @@ def preprocess_plab(plab_dir: Path) -> dict:
     Returns
     -------
     dict
-        A dictionary with 'PLAB_rt_mean_sec', 'PLAB_accuracy', and 'PLAB_num_items'.
+        A dictionary with 'PLAB_rt_mean_sec', 'PLAB_accuracy', 'PLAB_num_items',
+        and split metrics for sets 1 and 2.
 
     Raises
     ------
@@ -1063,7 +1231,7 @@ def preprocess_plab(plab_dir: Path) -> dict:
     """
     try:
         df = _find_one_filetype_with_columns(
-            plab_dir, ["rt", "correctness"], allow_nan=True
+            plab_dir, ["rt", "correctness", "question_id"], allow_nan=True
         )
     except ValueError as err:
         # Determine display path for the outer error message
@@ -1096,12 +1264,45 @@ def preprocess_plab(plab_dir: Path) -> dict:
         ) from err
 
     rt_mean, accuracy, num_items = _reaction_time_accuracy(
-        df, reaction_time_col="rt", correctness_col="correctness"
+        df,
+        reaction_time_col="rt",
+        correctness_col="correctness",
+        min_rt=0.0,
+        max_rt=float("inf"),
     )
+
+    # Split accuracy and RT for set 1 (items 1-4) and set 2 (items 5-15)
+    df_set1 = df[df["question_id"].isin([1, 2, 3, 4])]
+    df_set2 = df[df["question_id"].isin(range(5, 16))]
+
+    rt_set1, acc_set1, num_set1 = (nan, nan, 0)
+    if not df_set1.empty:
+        rt_set1, acc_set1, num_set1 = _reaction_time_accuracy(
+            df_set1,
+            reaction_time_col="rt",
+            correctness_col="correctness",
+            min_rt=0.0,
+            max_rt=float("inf"),
+        )
+
+    rt_set2, acc_set2, num_set2 = (nan, nan, 0)
+    if not df_set2.empty:
+        rt_set2, acc_set2, num_set2 = _reaction_time_accuracy(
+            df_set2,
+            reaction_time_col="rt",
+            correctness_col="correctness",
+            min_rt=0.0,
+            max_rt=float("inf"),
+        )
+
     return {
         "PLAB_rt_mean_sec": rt_mean,
         "PLAB_accuracy": accuracy,
         "PLAB_num_items": num_items,
+        "PLAB_set1_accuracy": acc_set1,
+        "PLAB_set2_accuracy": acc_set2,
+        "PLAB_set1_rt_mean_sec": rt_set1,
+        "PLAB_set2_rt_mean_sec": rt_set2,
     }
 
 
@@ -1111,6 +1312,8 @@ def _reaction_time_accuracy(
     correctness_col: str,
     group_by_col: str | None = None,
     correct_only: bool = False,
+    min_rt: float | None = None,
+    max_rt: float | None = None,
 ) -> DataFrame | tuple[float, float, int]:
     """
     Calculate reaction time mean and accuracy, optionally grouped.
@@ -1131,6 +1334,12 @@ def _reaction_time_accuracy(
         If True, compute reaction time on correct trials only. For grouped outputs,
         reaction time is averaged over correct trials per group, while accuracy is
         still computed as the mean of the correctness column per group. Default False.
+    min_rt : float, optional
+        Minimum reaction time to include. Trials with RT below this threshold
+        are excluded from all calculations (RT mean, accuracy, and num_items).
+    max_rt : float, optional
+        Maximum reaction time to include. Trials with RT above this threshold
+        are excluded from all calculations (RT mean, accuracy, and num_items).
 
     Returns
     -------
@@ -1151,8 +1360,8 @@ def _reaction_time_accuracy(
     -----
     - NaN handling: rows with NaN in either reaction time or correctness are
       allowed, but their NaN positions must match to ensure paired calculations.
-    - ``correct_only`` applies only to reaction time, accuracy always uses the full
-      correctness column within each scope (grouped or ungrouped).
+    - Filtering (min_rt, max_rt): Trials outside the specified range are
+      completely removed from the dataset before any calculations.
     """
     if not all(col in df.columns for col in [reaction_time_col, correctness_col]):
         raise ValueError(
@@ -1161,25 +1370,34 @@ def _reaction_time_accuracy(
     # Validate inputs once
     __validate_rt_acc_inputs(df, reaction_time_col, correctness_col)
 
+    # Filter by RT thresholds if provided
+    filtered_df = df.copy()
+    if min_rt is not None:
+        filtered_df = filtered_df[filtered_df[reaction_time_col] >= min_rt]
+    if max_rt is not None:
+        filtered_df = filtered_df[filtered_df[reaction_time_col] <= max_rt]
+
     # Grouped case: vectorised aggregations
     if group_by_col is not None:
-        if group_by_col not in df.columns:
+        if group_by_col not in filtered_df.columns:
             raise ValueError(
                 f"DataFrame must contain group_by column '{group_by_col}'."
             )
 
         # Get the grouped data
-        grouped = df.groupby(group_by_col, dropna=True)
+        grouped = filtered_df.groupby(group_by_col, dropna=True)
 
         # Accuracy per group
         acc = grouped[correctness_col].mean().rename("accuracy")
 
         # Reaction time per group (optionally only on correct trials)
         if correct_only:
-            rt_series = df[df[correctness_col] == 1]
+            rt_series = filtered_df[filtered_df[correctness_col] == 1]
             rt = rt_series.groupby(group_by_col, dropna=True)[reaction_time_col].mean()
         else:
-            rt = grouped[reaction_time_col].mean()
+            rt = filtered_df.groupby(group_by_col, dropna=True)[
+                reaction_time_col
+            ].mean()
         rt = rt.rename("rt_mean")
 
         # Number of items per group
@@ -1189,11 +1407,13 @@ def _reaction_time_accuracy(
 
     # Ungrouped case
     if correct_only:
-        rt_mean = df[df[correctness_col] == 1][reaction_time_col].mean()
+        rt_mean = filtered_df[filtered_df[correctness_col] == 1][
+            reaction_time_col
+        ].mean()
     else:
-        rt_mean = df[reaction_time_col].mean()
-    accuracy = df[correctness_col].mean()
-    num_items = df[reaction_time_col].notna().sum()
+        rt_mean = filtered_df[reaction_time_col].mean()
+    accuracy = filtered_df[correctness_col].mean()
+    num_items = filtered_df[reaction_time_col].notna().sum()
 
     return rt_mean, accuracy, num_items
 

--- a/templates_and_notes/multipleye_settings_preprocessing.template.yaml
+++ b/templates_and_notes/multipleye_settings_preprocessing.template.yaml
@@ -70,6 +70,25 @@ acceptable_recording_durations: [600, 7200]
 acceptable_num_practice_trials: 2
 acceptable_num_trials: 10
 
+# --- PSYCHOMETRIC TEST THRESHOLDS ---
+# Minimum reaction time for WikiVocab in seconds.
+psym_wikivocab_min_rt: 0.2
+
+# Maximum reaction time for WikiVocab in seconds. `.inf` (infinite) means no upper limit.
+psym_wikivocab_max_rt: .inf
+
+# Minimum reaction time for Stroop in seconds.
+psym_stroop_min_rt: 0.2
+
+# Maximum reaction time for Stroop in seconds.
+psym_stroop_max_rt: .inf
+
+# Minimum reaction time for Flanker in seconds.
+psym_flanker_min_rt: 0.0
+
+# Maximum reaction time for Flanker in seconds.
+psym_flanker_max_rt: .inf
+
 # --- EYE TRACKER LABELS (do not change) ---
 tracked_eye: ["L", "R", "RIGHT", "LEFT"]
 

--- a/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
@@ -60,11 +60,20 @@ def test__reaction_time_accuracy_errors(rt_values, correctness_values, error_mes
 
 
 @pytest.mark.parametrize(
-    "rt_values, correctness_values, correct_only, expected_rt_mean_sec, expected_acc, expected_num",
+    "rt_values, correctness_values, correct_only, expected_rt_mean_sec, expected_acc, expected_num, min_rt, max_rt",
     [
-        ([100, 200, 300], [1, 0, 1], False, 200.0, 2 / 3, 3),
-        ([None, 100, 200, 300], [None, 1, 0, 1], False, 200.0, 2 / 3, 3),
-        ([math.nan, 100, 200, 300], [math.nan, 1, 0, 1], False, 200.0, 2 / 3, 3),
+        ([100, 200, 300], [1, 0, 1], False, 200.0, 2 / 3, 3, None, None),
+        ([None, 100, 200, 300], [None, 1, 0, 1], False, 200.0, 2 / 3, 3, None, None),
+        (
+            [math.nan, 100, 200, 300],
+            [math.nan, 1, 0, 1],
+            False,
+            200.0,
+            2 / 3,
+            3,
+            None,
+            None,
+        ),
         (
             [float("nan"), 100, 200, 300],
             [float("nan"), 1, 0, 1],
@@ -72,6 +81,8 @@ def test__reaction_time_accuracy_errors(rt_values, correctness_values, error_mes
             200.0,
             2 / 3,
             3,
+            None,
+            None,
         ),
         (
             [float64("nan"), 100, 200, 300],
@@ -80,6 +91,8 @@ def test__reaction_time_accuracy_errors(rt_values, correctness_values, error_mes
             200.0,
             2 / 3,
             3,
+            None,
+            None,
         ),
         (
             [100, 200, 300, float64("nan")],
@@ -88,13 +101,23 @@ def test__reaction_time_accuracy_errors(rt_values, correctness_values, error_mes
             200.0,
             2 / 3,
             3,
+            None,
+            None,
         ),
-        ([100, 200, 300], [1, 0, 1], True, 200.0, 2 / 3, 3),
-        ([100, 200, 300], [True, False, True], False, 200.0, 2 / 3, 3),
-        ([100, 200, 300], [True, True, False], False, 200.0, 2 / 3, 3),
-        ([100, 200, 300], [True, True, False], True, 150.0, 2 / 3, 3),
-        ([1], [True], False, 1, 1, 1),
-        ([1, 2, 3, 4, 5], [True, True, True, True, True], False, 3, 1, 5),
+        ([100, 200, 300], [1, 0, 1], True, 200.0, 2 / 3, 3, None, None),
+        ([100, 200, 300], [True, False, True], False, 200.0, 2 / 3, 3, None, None),
+        ([100, 200, 300], [True, True, False], False, 200.0, 2 / 3, 3, None, None),
+        ([100, 200, 300], [True, True, False], True, 150.0, 2 / 3, 3, None, None),
+        ([1], [True], False, 1, 1, 1, None, None),
+        ([1, 2, 3, 4, 5], [True, True, True, True, True], False, 3, 1, 5, None, None),
+        # Test min_rt filtering (affects all)
+        ([0.1, 0.2, 0.3], [1, 0, 1], False, 0.25, 0.5, 2, 0.2, None),
+        ([0.1, 0.2, 0.3], [1, 1, 1], True, 0.25, 1.0, 2, 0.2, None),
+        # Test max_rt filtering (affects all)
+        ([0.1, 0.2, 0.3], [1, 0, 1], False, 0.15, 0.5, 2, None, 0.2),
+        ([0.1, 0.2, 0.3], [1, 1, 1], True, 0.15, 1.0, 2, None, 0.2),
+        # Both min and max
+        ([0.1, 0.2, 0.3], [1, 0, 1], False, 0.2, 0.0, 1, 0.2, 0.2),
     ],
 )
 def test__reaction_time_accuracy(
@@ -104,11 +127,13 @@ def test__reaction_time_accuracy(
     expected_rt_mean_sec,
     expected_acc,
     expected_num,
+    min_rt,
+    max_rt,
 ):
     df = pd.DataFrame({"rt": rt_values, "correctness": correctness_values})
 
     rt_mean, acc, num = _reaction_time_accuracy(
-        df, "rt", "correctness", correct_only=correct_only
+        df, "rt", "correctness", correct_only=correct_only, min_rt=min_rt, max_rt=max_rt
     )
 
     if math.isnan(expected_rt_mean_sec):
@@ -402,6 +427,9 @@ def test_preprocess_stroop_basic(tmp_path: Path, make_text_file, rows, expected)
     body = "".join(f"{s},{rt},{corr}\n" for s, rt, corr in rows)
     make_text_file(folder / "stroop.csv", header=header, body=body)
 
+    # Use a small min_rt to ensure we can test filtering
+    settings.PSYM_STROOP_MIN_RT = 0.0
+
     res = preprocess_stroop(folder)
     # res is a dict with namespaced keys
     for key, exp in expected.items():
@@ -470,6 +498,8 @@ def test_preprocess_flanker_basic(tmp_path: Path, make_text_file, rows, expected
     body = "".join(f"{s},{rt},{corr}\n" for s, rt, corr in rows)
     make_text_file(folder / "flanker.csv", header=header, body=body)
 
+    settings.PSYM_FLANKER_MIN_RT = 0.0
+
     res = preprocess_flanker(folder)
     # res is a dict with namespaced keys
     for key, exp in expected.items():
@@ -516,19 +546,26 @@ def test_preprocess_flanker_errors(
 @pytest.mark.parametrize(
     "rows, expected",
     [
-        ([(100, 1), (200, 0), (300, 1)], (200.0, 2 / 3, 3)),
-        ([(1, 1)], (1.0, 1.0, 1)),
+        (
+            [(100, 1, 1), (200, 0, 2), (300, 1, 5)],
+            {
+                "PLAB_rt_mean_sec": 200.0,
+                "PLAB_accuracy": 2 / 3,
+                "PLAB_num_items": 3,
+                "PLAB_set1_accuracy": 0.5,
+                "PLAB_set2_accuracy": 1.0,
+            },
+        ),
     ],
 )
 def test_preprocess_plab_basic(tmp_path: Path, make_text_file, rows, expected):
     folder = tmp_path / "session" / "PLAB"
-    header = "rt,correctness\n"
-    body = "".join(f"{rt},{corr}\n" for rt, corr in rows)
+    header = "rt,correctness,question_id\n"
+    body = "".join(f"{rt},{corr},{qid}\n" for rt, corr, qid in rows)
     make_text_file(folder / "plab.csv", header=header, body=body)
     out = preprocess_plab(folder)
-    assert out["PLAB_rt_mean_sec"] == pytest.approx(expected[0])
-    assert out["PLAB_accuracy"] == pytest.approx(expected[1])
-    assert out["PLAB_num_items"] == expected[2]
+    for key, exp in expected.items():
+        assert out[key] == pytest.approx(exp)
 
 
 @pytest.mark.parametrize(
@@ -551,12 +588,21 @@ def test_preprocess_plab_errors(
     tmp_path: Path, make_text_file, header, body, error_msg
 ):
     folder = tmp_path / "p3" / "PLAB"
+    # Ensure header has question_id if it's missing but not part of the error test
+    if "question_id" not in header and "required columns" not in error_msg:
+        header = header.strip() + ",question_id\n"
+        body = "\n".join(
+            line.strip() + ",1" for line in body.split("\n") if line.strip()
+        )
     make_text_file(folder / "plab.csv", header=header, body=body)
     if (
         "No CSV files with the required columns" in error_msg
         or "PLAB results missing" in error_msg
     ):
         with pytest.raises(ValueError, match="PLAB results missing"):
+            preprocess_plab(folder)
+    elif "question_id" in error_msg:
+        with pytest.raises(ValueError, match="question_id"):
             preprocess_plab(folder)
     else:
         with pytest.raises(ValueError, match=error_msg):
@@ -654,6 +700,8 @@ def test_preprocess_wikivocab_basic(tmp_path: Path, make_text_file, rows, expect
     body = "".join(f"{c},{r},{rt}\n" for c, r, rt in rows)
     make_text_file(folder / "wv.csv", header=header, body=body)
 
+    settings.PSYM_WIKIVOCAB_MIN_RT = 0.0
+
     out = preprocess_wikivocab(folder)
     for key, exp in expected.items():
         val = out[key]
@@ -680,6 +728,12 @@ def test_preprocess_wikivocab_basic(tmp_path: Path, make_text_file, rows, expect
             "1,1,fast\n",
             "Reaction time column contains non-numeric values",
         ),
+        # Invalid correct_answer values
+        (
+            "correct_answer,real_answer,RT\n",
+            "2,1,100\n",
+            "WikiVocab 'correct_answer' contains invalid values",
+        ),
     ],
 )
 def test_preprocess_wikivocab_errors(
@@ -693,6 +747,7 @@ def test_preprocess_wikivocab_errors(
         or "NaN values found" in error_msg
         or "Required columns" in error_msg
         or "Reaction time column contains" in error_msg
+        or "WikiVocab 'correct_answer' contains invalid values" in error_msg
     ):
         # The wrapper adds more context, so we match the wrapper's prefix
         with pytest.raises(ValueError, match="WikiVocab results missing"):
@@ -708,16 +763,18 @@ def _make_wmc_csv(folder: Path, make_text_file):
         "is_practice,base_text_intertrial.started,"
         "mu_key_resp_recall.is_correct,mu_key_resp_recall.rt,"
         "os_key_resp_recall.corr,os_key_resp_recall.rt,"
-        "ss_key_resp_recall.corr,ss_key_resp_recall.rt\n"
+        "os_key_resp_equation.corr,"
+        "ss_key_resp_recall.corr,ss_key_resp_recall.rt,"
+        "ss_key_resp_sentence.corr\n"
     )
     body = "".join(
         [
             # Trial 1
-            "False,1,1,100,1,10,0,5\n",
-            "False,,0,200,,,1,15\n",
+            "False,1,1,100,1,10,1,0,5,1\n",
+            "False,,0,200,,,1,1,15,0\n",
             # Trial 2
-            "False,2,1,300,0,30,1,25\n",
-            "False,,1,400,,,0,35\n",
+            "False,2,1,300,0,30,0,1,25,1\n",
+            "False,,1,400,,,1,0,35,0\n",
         ]
     )
     make_text_file(folder / "wmc.csv", header=header, body=body)
@@ -743,8 +800,10 @@ def test_preprocess_lwmc_basic(tmp_path: Path, make_text_file):
     assert out["LWMC_MU_time_sec"] == pytest.approx(250.0)
     assert out["LWMC_OS_score"] == pytest.approx(0.5)
     assert out["LWMC_OS_time_sec"] == pytest.approx(20.0)
+    assert out["LWMC_OS_processingTask_score"] == pytest.approx(0.75)
     assert out["LWMC_SS_score"] == pytest.approx(0.5)
     assert out["LWMC_SS_time_sec"] == pytest.approx(20.0)
+    assert out["LWMC_SentS_processingTask_score"] == pytest.approx(0.5)
     assert out["LWMC_SSTM_score"] == pytest.approx(0.5)
     assert out["LWMC_Total_score_mean"] == pytest.approx((0.75 + 0.5 + 0.5 + 0.5) / 4)
 
@@ -760,9 +819,11 @@ def test_preprocess_lwmc_basic(tmp_path: Path, make_text_file):
                     "is_practice,base_text_intertrial.started,"
                     "mu_key_resp_recall.is_correct,mu_key_resp_recall.rt,"
                     "os_key_resp_recall.corr,os_key_resp_recall.rt,"
-                    "ss_key_resp_recall.corr,ss_key_resp_recall.rt\n"
+                    "os_key_resp_equation.corr,"
+                    "ss_key_resp_recall.corr,ss_key_resp_recall.rt,"
+                    "ss_key_resp_sentence.corr\n"
                 ),
-                body="""True,1,1,100,1,10,1,5\nTrue,,1,100,1,10,1,5\n""",
+                body="""True,1,1,100,1,10,1,1,5,1\nTrue,,1,100,1,10,1,1,5,1\n""",
             ),
             "No non-practice trials found",
         ),
@@ -803,9 +864,11 @@ def test_preprocess_lwmc_basic(tmp_path: Path, make_text_file):
                     "is_practice,base_text_intertrial.started,"
                     "mu_key_resp_recall.is_correct,mu_key_resp_recall.rt,"
                     "os_key_resp_recall.corr,os_key_resp_recall.rt,"
-                    "ss_key_resp_recall.corr,ss_key_resp_recall.rt\n"
+                    "os_key_resp_equation.corr,"
+                    "ss_key_resp_recall.corr,ss_key_resp_recall.rt,"
+                    "ss_key_resp_sentence.corr\n"
                 ),
-                body=("False,1,,100,1,10,1,5\nFalse,,,200,,,1,15\n"),
+                body=("False,1,,100,1,10,1,1,5,1\nFalse,,,200,,,1,1,15,1\n"),
             ),
             "No valid MU trials found",
         ),


### PR DESCRIPTION
This pull request implements feedback from the Tartu meeting, Eva and Ana collected. The changes focus on data quality through reaction time (RT) filtering and added metrics.


#### Summary of Added Metrics

| Metric | File(s) | Description |
| :--- | :--- | :--- |
| `LWMC_OS_processingTask_score` | Overview & Detailed | Accuracy of the math processing task in Operation Span. |
| `LWMC_SentS_processingTask_score` | Overview & Detailed | Accuracy of the sentence processing task in Sentence Span. |
| `Stroop_{cond}_correct_rt_mean_sec` | Overview & Detailed | Mean RT for correct responses only in {cond} trials. |
| `Flanker_{cond}_correct_rt_mean_sec` | Overview & Detailed | Mean RT for correct responses only in {cond} trials. |
| `WikiVocab_correct_words_rt_mean_sec` | Overview & Detailed | Mean RT for correct responses to real words. |
| `WikiVocab_correct_pseudowords_rt_mean_sec` | Overview & Detailed | Mean RT for correct responses to pseudowords. |
| `WikiVocab_ratio_items` | Detailed | Ratio of real words to pseudowords in the session. |
| `PLAB_set1_accuracy` / `rt_mean_sec` | Overview & Detailed | Accuracy and mean RT for PLAB items 1–4. |
| `PLAB_set2_accuracy` / `rt_mean_sec` | Overview & Detailed | Accuracy and mean RT for PLAB items 5–15. |

**Global Filtering**: Existing accuracy and RT metrics for Stroop and WikiVocab now reflect the exclusion of trials with RTs below 200ms. These trials are removed entirely from the dataset before any scores are calculated.


#### 1. Global Reaction Time (RT) Filtering

To improve data quality, we implemented participant-level RT thresholds to exclude extreme responses (outliers) from all calculations. (WikiVocab, Stroop, Flanker)

- **Minimum RT**: Responses below a threshold (default: 200ms for WikiVocab and Stroop) are excluded. In psycholinguistics, responses faster than 200ms are generally considered physiologically impossible for stimulus-driven processing and likely represent accidental key presses.
- **Maximum RT**: Responses above a threshold (default: infinity) are excluded. Very long RTs often reflect lapses of attention or non-automatic processing rather than the cognitive process under study.
- **Global Impact**: Unlike before, where filtering only affected RT means, these trials are now removed from **all metrics**, including accuracy scores and trial counts. For example, an accidental key press at 50ms will no longer penalize a participant's accuracy score.

#### 2. Overview Metrics

`psychometric_overview.csv`:
- LWMC Processing Scores: `LWMC_OS_processingTask_score` and `LWMC_SentS_processingTask_score`. These validate that participants were engaged with the processing task (math/sentences). A common research practice is to exclude participants with processing accuracy below a certain threshold (e.g., 85%).
- Stroop & Flanker Correct RTs: Added mean RT for correct responses per condition, allowing researchers to analyze raw speed alongside interference effects.
- WikiVocab Lexicality Splits: Added `WikiVocab_correct_words_rt_mean_sec` and `WikiVocab_correct_pseudowords_rt_mean_sec`. The difference in RT between real words and pseudowords (the lexicality effect) is a robust indicator of lexical access efficiency.

#### 3. WikiVocab Balanced Scoring (LexTALE)

The WikiVocab scoring (balanced LexTALE formula) is now calculated **only using trials that pass the RT filtering**, ensuring that accidental responses do not skew the vocabulary assessment. This improves the reliability of the score by removing physiologically impossible reaction times.

$$\mathrm{LexTALE\_Score} = \frac{\frac{\mathrm{Correct\_Real}}{\mathrm{Total\_Real}} + \frac{\mathrm{Correct\_Pseudo}}{\mathrm{Total\_Pseudo}}}{2}$$

#### 5. Data Integrity

- Validation: Added checks for WikiVocab input data to ensure `correct_answer` is binary (0/1).
- Graceful Handling: The pipeline now gracefully handles cases where a participant might have zero correct responses in a sub-category (e.g., zero correct pseudowords), returning `NaN` for the corresponding RT means instead of crashing.