### PR TITLE
fix: Windows test failures in cross-platform unit tests

### DIFF
--- a/tests/unit/preprocessing/plotting/test_plot_gaze_fallback.py
+++ b/tests/unit/preprocessing/plotting/test_plot_gaze_fallback.py
@@ -62,9 +62,17 @@ def mock_gaze():
 
 
 @patch("PIL.Image.open")
+@patch("matplotlib.pyplot.plot")
+@patch("matplotlib.pyplot.close")
 @patch("matplotlib.pyplot.subplots")
 def test_plot_gaze_aoi_fallback(
-    mock_subplots, mock_image_open, mock_gaze, mock_stimulus, tmp_path
+    mock_subplots,
+    mock_plt_close,
+    mock_plt_plot,
+    mock_image_open,
+    mock_gaze,
+    mock_stimulus,
+    tmp_path,
 ):
     mock_ax = MagicMock()
     mock_fig = MagicMock()
@@ -91,9 +99,17 @@ def test_plot_gaze_aoi_fallback(
 
 
 @patch("PIL.Image.open")
+@patch("matplotlib.pyplot.plot")
+@patch("matplotlib.pyplot.close")
 @patch("matplotlib.pyplot.subplots")
 def test_plot_gaze_aoi_no_fallback(
-    mock_subplots, mock_image_open, mock_gaze, mock_stimulus, tmp_path
+    mock_subplots,
+    mock_plt_close,
+    mock_plt_plot,
+    mock_image_open,
+    mock_gaze,
+    mock_stimulus,
+    tmp_path,
 ):
     mock_ax = MagicMock()
     mock_fig = MagicMock()

--- a/tests/unit/preprocessing/utils/test_file_utils.py
+++ b/tests/unit/preprocessing/utils/test_file_utils.py
@@ -31,6 +31,7 @@ class TestToWinLongPath:
             "/home/user/my documents/file.txt",
         ],
     )
+    @patch("os.name", "posix")
     def test_unix_returns_absolute_path_without_prefix(self, path_str):
         result = _to_win_long_path(Path(path_str))
         assert result == os.path.abspath(path_str)
@@ -43,6 +44,7 @@ class TestToWinLongPath:
             "another/./docs/../file.txt",
         ],
     )
+    @patch("os.name", "posix")
     def test_unix_resolves_relative_to_absolute(self, path_str):
         result = _to_win_long_path(Path(path_str))
         assert result == os.path.abspath(path_str)


### PR DESCRIPTION
Two test suites passed on macOS but failed on Windows. Fix both so they run everywhere:

- `test_file_utils.py`: `test_unix_*` long-path tests now mock `os.name = "posix"`, matching how the `test_windows_*` tests mock `"nt"`. Previously the Unix-only assertions ran the Windows code path on Windows and failed on the `\\?\` prefix.
- `test_plot_gaze_fallback.py`: gaze tests now also mock `matplotlib.pyplot.plot` and `matplotlib.pyplot.close`, not just `subplots`. On Windows the real `plt.plot()` call against the mocked subplots raised `ValueError: not enough values to unpack`.

All tests pass on macOS. To be tested on other os. @saphjra please run tests.