### PR TITLE
fix: Format sanity check report messages as markdown list items

### DIFF
--- a/preprocessing/checks/formal_experiment_checks.py
+++ b/preprocessing/checks/formal_experiment_checks.py
@@ -74,7 +74,7 @@ def check_all_screens_logfile(
             if f"{page.number}" not in stimulus_frame["page_number"].to_list():
                 # print(f"Missing page {stimulus.name} {page.number} in Logfile")
                 _report_to_file(
-                    f" {stimulus.name}: Missing page{page.number} in Logfile",
+                    f"- {stimulus.name}: Missing page {page.number} in Logfile",
                     report_file,
                 )
         # check if all questions are present
@@ -85,7 +85,7 @@ def check_all_screens_logfile(
             ):
                 # print(f"{stimulus.name}: Missing question_{question.id} in Logfile")
                 _report_to_file(
-                    f"{stimulus.name}: Missing question_{question.id} in Logfile",
+                    f"- {stimulus.name}: Missing question_{question.id} in Logfile",
                     report_file,
                 )
             # print(stimulus_frame["screen"])
@@ -94,7 +94,7 @@ def check_all_screens_logfile(
             if f"{rating.name}" not in stimulus_frame["page_number"].to_list():
                 # print(f"{stimulus.name}: Missing rating screen {rating.name}")
                 _report_to_file(
-                    f"{stimulus.name}: Missing rating screen {rating.name} in Logfile",
+                    f"- {stimulus.name}: Missing rating screen {rating.name} in Logfile",
                     report_file,
                 )
 
@@ -116,7 +116,9 @@ def sanity_check_gaze_frame(gaze, stimuli, report_file):
                 not in stimulus_frame[settings.PAGE_COL].to_list()
             ):
                 # print(f"Missing page {page.number}")
-                _report_to_file(f"Missing page {page.number} in asc file", report_file)
+                _report_to_file(
+                    f"- Missing page {page.number} in asc file", report_file
+                )
         # check if all questions are present
         for question in stimulus.questions:
             if (
@@ -126,7 +128,7 @@ def sanity_check_gaze_frame(gaze, stimuli, report_file):
                 not in stimulus_frame[settings.PAGE_COL].to_list()
             ):
                 _report_to_file(
-                    f"Missing {settings.QUESTION_PREFIX}{question.name} in asc file or in experiment frame",
+                    f"- Missing {settings.QUESTION_PREFIX}{question.name} in asc file or in experiment frame",
                     report_file,
                 )
             # print(stimulus_frame["screen"])
@@ -135,7 +137,7 @@ def sanity_check_gaze_frame(gaze, stimuli, report_file):
             if f"{rating.name}" not in stimulus_frame[settings.PAGE_COL].to_list():
                 # print(f"Missing instruction {rating.name}")
                 _report_to_file(
-                    f"Missing rating {rating.name} in asc file", report_file
+                    f"- Missing rating {rating.name} in asc file", report_file
                 )
 
 
@@ -254,7 +256,7 @@ def check_messages(
 
                 if current_pattern not in trial_messages_only:
                     _report_to_file(
-                        f"{current_stimulus.name}: Missing {current_pattern} Messages in ASC file",
+                        f"- {current_stimulus.name}: Missing {current_pattern} Messages in ASC file",
                         report_file,
                     )
 
@@ -353,7 +355,7 @@ def _check_one_time_screens(messages_only: list[str], report_file: Path):
 
             if not found:
                 _report_to_file(
-                    f"Missing one time screen {one_time_screen} in asc file",
+                    f"- Missing one time screen {one_time_screen} in asc file",
                     report_file,
                 )
 
@@ -380,7 +382,7 @@ def _check_question_screens(
                 )
                 if current_pattern not in messages:
                     _report_to_file(
-                        f"{current_stimulus.name}: Missing {current_pattern} Messages in ASC file",
+                        f"- {current_stimulus.name}: Missing {current_pattern} Messages in ASC file",
                         report_file,
                     )
 
@@ -431,7 +433,7 @@ def _check_validation_screen(messages, file, stimulus_name):
         # check if instead a recalibration screen was shown
         if "recalibration" not in messages:
             _report_to_file(
-                f"{stimulus_name}: Missing validation_before_stimulus and no recalibration screen in asc file. One should be there.",
+                f"- {stimulus_name}: Missing validation_before_stimulus and no recalibration screen in asc file. One should be there.",
                 file,
             )
 
@@ -441,7 +443,7 @@ def _check_validation_screen(messages, file, stimulus_name):
             for index in indices_recal:
                 # get five next messages, there should be a calibration
                 next_messages = messages[index : index + 5]
-                _report_to_file("Recalibration screen found", file)
+                _report_to_file("- Recalibration screen found", file)
                 if "!CAL " not in next_messages:
                     # check if there is a validation
                     for msg in next_messages:
@@ -450,19 +452,19 @@ def _check_validation_screen(messages, file, stimulus_name):
                             for msg in messages[index : index + 20]:
                                 if msg == "!CAL ":
                                     _report_to_file(
-                                        "Calibration screen after recalibration screen found.",
+                                        "- Calibration screen after recalibration screen found.",
                                         file,
                                     )
                                     break
                             else:
                                 _report_to_file(
-                                    "Missing calibration screen found after recalibration screen. Please check manually in the asc file.",
+                                    "- Missing calibration screen found after recalibration screen. Please check manually in the asc file.",
                                     file,
                                 )
 
                 else:
                     _report_to_file(
-                        "Calibration screen after recalibration screen found.", file
+                        "- Calibration screen after recalibration screen found.", file
                     )
 
 
@@ -470,4 +472,4 @@ def _check_rating_screens(messages, file):
     for rating in RATING_SCREENS:
         if f"{rating}" not in messages:
             # print(f"Missing instruction {instruction}")
-            _report_to_file(f"Missing rating {rating} in asc file", file)
+            _report_to_file(f"- Missing rating {rating} in asc file", file)

--- a/preprocessing/checks/formal_experiment_checks.py
+++ b/preprocessing/checks/formal_experiment_checks.py
@@ -117,7 +117,8 @@ def sanity_check_gaze_frame(gaze, stimuli, report_file):
             ):
                 # print(f"Missing page {page.number}")
                 _report_to_file(
-                    f"- Missing page {page.number} in asc file", report_file
+                    f"- {stimulus.name}: Missing page {page.number} in asc file",
+                    report_file,
                 )
         # check if all questions are present
         for question in stimulus.questions:

--- a/tests/unit/preprocessing/checks/test_formal_experiment_checks.py
+++ b/tests/unit/preprocessing/checks/test_formal_experiment_checks.py
@@ -1,0 +1,163 @@
+"""Unit tests for the formal experiment sanity check report formatting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import polars as pl
+
+from preprocessing.checks.formal_experiment_checks import (
+    check_all_screens_logfile,
+    check_messages,
+    sanity_check_gaze_frame,
+)
+from preprocessing.data_collection.stimulus import (
+    ComprehensionQuestion,
+    Rating,
+    Stimulus,
+    StimulusPage,
+)
+
+
+def _empty_path() -> Path:
+    return Path("")
+
+
+def _make_stimulus() -> Stimulus:
+    """Build a stimulus with one page/question/rating missing from any data."""
+    return Stimulus(
+        id=3,
+        name="Lit_BrokenApril",
+        type="experiment",
+        pages=[
+            StimulusPage(
+                number=1,
+                text="",
+                image_path=_empty_path(),
+                aoi_image_path=_empty_path(),
+            ),
+            StimulusPage(
+                number=2,
+                text="",
+                image_path=_empty_path(),
+                aoi_image_path=_empty_path(),
+            ),
+            StimulusPage(
+                number=3,
+                text="",
+                image_path=_empty_path(),
+                aoi_image_path=_empty_path(),
+            ),
+        ],
+        text_stimulus=None,
+        questions=[
+            ComprehensionQuestion(
+                name="q1101",
+                id="1101",
+                snippet_no=1,
+                question="",
+                target="",
+                distractor_a="",
+                distractor_b="",
+                distractor_c="",
+                image_path=_empty_path(),
+                aoi_image_path=_empty_path(),
+            )
+        ],
+        instructions=[],
+        ratings=[
+            Rating(
+                id=15,
+                name="showing_subject_difficulty_screen",
+                text="",
+                image_path=_empty_path(),
+            )
+        ],
+        trial_id="trial_5",
+    )
+
+
+def test_check_all_screens_logfile_report_lines_have_bullet_prefix(
+    tmp_path: Path,
+) -> None:
+    stimulus = _make_stimulus()
+    logfile = pl.DataFrame(
+        {
+            "stimulus_number": ["3", "3", "3"],
+            "trial_number": ["5", "5", "5"],
+            "page_number": ["1", "2", "2"],
+        }
+    )
+    report_file = tmp_path / "report.md"
+
+    check_all_screens_logfile(logfile, [stimulus], report_file)
+
+    lines = report_file.read_text(encoding="utf-8").splitlines()
+    assert lines, "expected report lines to be written"
+    assert all(line.startswith("- ") for line in lines), lines
+    assert "- Lit_BrokenApril: Missing page 3 in Logfile" in lines
+    assert "- Lit_BrokenApril: Missing question_1101 in Logfile" in lines
+    assert (
+        "- Lit_BrokenApril: Missing rating screen showing_subject_difficulty_screen in Logfile"
+        in lines
+    )
+
+
+def test_sanity_check_gaze_frame_report_lines_have_bullet_prefix(
+    tmp_path: Path,
+) -> None:
+    stimulus = _make_stimulus()
+    gaze = SimpleNamespace(
+        samples=pl.DataFrame(
+            {
+                "stimulus": ["Lit_BrokenApril_3", "Lit_BrokenApril_3"],
+                "page": ["page_1", "page_2"],
+            }
+        )
+    )
+    report_file = tmp_path / "report.md"
+
+    sanity_check_gaze_frame(gaze, [stimulus], report_file)
+
+    lines = report_file.read_text(encoding="utf-8").splitlines()
+    assert lines, "expected report lines to be written"
+    assert all(line.startswith("- ") for line in lines), lines
+    assert "- Missing page 3 in asc file" in lines
+    assert "- Missing question_q1101 in asc file or in experiment frame" in lines
+    assert "- Missing rating showing_subject_difficulty_screen in asc file" in lines
+
+
+def test_check_messages_report_lines_have_bullet_prefix(tmp_path: Path) -> None:
+    stimulus = _make_stimulus()
+    messages = [
+        {
+            "message": "start_recording_trial_1_stimulus_Lit_BrokenApril_3_page_1",
+            "timestamp": "1000",
+        },
+        {
+            "message": "stop_recording_trial_1_stimulus_Lit_BrokenApril_3_page_1",
+            "timestamp": "2000",
+        },
+    ]
+    report_file = tmp_path / "report.md"
+
+    check_messages(messages, [stimulus], report_file, stimuli_order=[3])
+
+    lines = report_file.read_text(encoding="utf-8").splitlines()
+    assert lines, "expected report lines to be written"
+    assert all(line.startswith("- ") for line in lines), lines
+    assert (
+        "- Lit_BrokenApril: Missing page_screen_image_onset Messages in ASC file"
+        in lines
+    )
+    assert (
+        "- Lit_BrokenApril: Missing stop_recording_trial_1_stimulus_Lit_BrokenApril_3_page_1 Messages in ASC file"
+        in lines
+    )
+    assert (
+        "- Lit_BrokenApril: Missing validation_before_stimulus and no recalibration screen in asc file. One should be there."
+        in lines
+    )
+    assert "- Missing one time screen welcome_screen in asc file" in lines
+    assert "- Missing rating showing_subject_difficulty_screen in asc file" in lines

--- a/tests/unit/preprocessing/checks/test_formal_experiment_checks.py
+++ b/tests/unit/preprocessing/checks/test_formal_experiment_checks.py
@@ -123,7 +123,7 @@ def test_sanity_check_gaze_frame_report_lines_have_bullet_prefix(
     lines = report_file.read_text(encoding="utf-8").splitlines()
     assert lines, "expected report lines to be written"
     assert all(line.startswith("- ") for line in lines), lines
-    assert "- Missing page 3 in asc file" in lines
+    assert "- Lit_BrokenApril: Missing page 3 in asc file" in lines
     assert "- Missing question_q1101 in asc file or in experiment frame" in lines
     assert "- Missing rating showing_subject_difficulty_screen in asc file" in lines
 


### PR DESCRIPTION
Fixes #136

The sanity check report lines written by `formal_experiment_checks.py` were missing the `- ` markdown list prefix, so messages ran together into a single paragraph (e.g. "Lit_BrokenApril: Missing page9 in Logfile Arg_PISACowsMilk: Missing page7 in Logfile") and were hard to read.

- Add `- ` bullet prefix to all 15 `_report_to_file()` calls across the logfile, gaze frame, and ASC message checks, completing the markdown syntax from #102 / #130.
- Fix the "Missing page9" spacing bug and stray leading space in the logfile page-missing message.
- Add unit tests asserting every report line renders as a list item

## Logfile
Before:
Lit_BrokenApril: Missing page9 in Logfile Arg_PISACowsMilk: Missing page7 in Logfile

After:
- Lit_BrokenApril: Missing page 9 in Logfile
- Arg_PISACowsMilk: Missing page 7 in Logfile

## Gaze Frame
Before:
Missing page 10 in asc file

After:
- Missing page 10 in asc file

## ASC Messages
Before:
1: Ins_LearningMobility: 13.26 minutes Ins_LearningMobility: Missing start_recording_trial_1_stimulus_Ins_LearningMobility_3_page_10 Messages in ASC file Ins_LearningMobility: Missing stop_recording_trial_1_stimulus_Ins_LearningMobility_3_page_10 Messages in ASC file

After:
- 1: Ins_LearningMobility: 13.26 minutes
- Ins_LearningMobility: Missing start_recording_trial_1_stimulus_Ins_LearningMobility_3_page_10 Messages in ASC file
- Ins_LearningMobility: Missing stop_recording_trial_1_stimulus_Ins_LearningMobility_3_page_10 Messages in ASC file
