### PR TITLE
feat: Rewrite reading times, use pymovements message parsing

### DIFF
--- a/preprocessing.ipynb
+++ b/preprocessing.ipynb
@@ -325,7 +325,7 @@
     "    lab_config=sess.lab_config,\n",
     "    sid=sess.sid,\n",
     "    trial_cols=settings.TRIAL_COLS,\n",
-    "    messages=settings.ANSWER_MSG_PATTERNS,  # for comprehension questions later - see Stage 4.\n",
+    "    messages=settings.EXPERIMENT_MSG_PATTERNS,  # for comprehension questions later - see Stage 4.\n",
     ")"
    ]
   },

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -425,9 +425,9 @@ class Settings:
         #: Subfolder name for psychometric tests output (overview + detailed CSVs).
         self.PSYCHOMETRIC_TESTS_FOLDER = Path("psychometric_tests/")
 
-        #: Regex patterns for relevant ASC messages for comprehension questions,
-        #: reading times, breaks, and sanity checks.
-        self.ANSWER_MSG_PATTERNS = [
+        #: Regex patterns for ASC messages used during the experiment
+        #: (recording start/stop, breaks, screens, comprehension answers).
+        self.EXPERIMENT_MSG_PATTERNS = [
             r"start_recording_.*",
             r"stop_recording_.*",
             r"(optional|obligatory)_break.*",

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -233,7 +233,7 @@ class Settings:
             return self.__dict__["RAW_DATA_FILENAME_REGEX"]
         trial_col = self.TRIAL_COL
         stimulus_col = self.STIMULUS_COL
-        return rf"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<{trial_col}>(PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_raw_data"
+        return rf".*?(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(?:\.0)?)_raw_data"
 
     @RAW_DATA_FILENAME_REGEX.setter
     def RAW_DATA_FILENAME_REGEX(self, value: str) -> None:
@@ -246,7 +246,7 @@ class Settings:
             return self.__dict__["EVENT_DATA_FILENAME_REGEX"]
         trial_col = self.TRIAL_COL
         stimulus_col = self.STIMULUS_COL
-        return rf"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<{trial_col}>(PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_{{event_type}}.csv"
+        return rf".*?(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(?:\.0)?)_{{event_type}}.csv"
 
     @EVENT_DATA_FILENAME_REGEX.setter
     def EVENT_DATA_FILENAME_REGEX(self, value: str) -> None:
@@ -257,7 +257,7 @@ class Settings:
         """Regex to extract trial and stimulus info from reading measures filenames."""
         if "READING_MEASURES_FILENAME_REGEX" in self.__dict__:
             return self.__dict__["READING_MEASURES_FILENAME_REGEX"]
-        return r"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<trial>(PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv"
+        return r".*?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv"
 
     @READING_MEASURES_FILENAME_REGEX.setter
     def READING_MEASURES_FILENAME_REGEX(self, value: str) -> None:

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -195,7 +195,7 @@ class Settings:
         pattern = (
             r"(?P<type>start_recording)_"
             rf"(?P<{self.TRIAL_COL}>(PRACTICE_)?trial_\d\d?)_"
-            rf"stimulus__(?P<stimulus_id>\d+)_(?P<{self.PAGE_COL}>\S*)"
+            rf"stimulus_(?P<stimulus_name>\S+?)_(?P<stimulus_id>\d+)_(?P<{self.PAGE_COL}>\S+)"
         )
         return re.compile(pattern)
 
@@ -214,8 +214,8 @@ class Settings:
         pattern = (
             r"(?P<type>stop_recording)_"
             rf"(?P<{self.TRIAL_COL}>(PRACTICE_)?trial_\d\d?)_"
-            r"stimulus_(?P<stimulus_name>\S*?_\S*?)_"
-            rf"\d+_(?P<stimulus_id>\d+)_(?P<{self.PAGE_COL}>{self.PAGE_COL}_\d+)"
+            r"stimulus_(?P<stimulus_name>\S+?)_"
+            rf"(?P<stimulus_id>\d+)_(?P<{self.PAGE_COL}>\S+)"
         )
         return re.compile(pattern)
 
@@ -257,7 +257,7 @@ class Settings:
         """Regex to extract trial and stimulus info from reading measures filenames."""
         if "READING_MEASURES_FILENAME_REGEX" in self.__dict__:
             return self.__dict__["READING_MEASURES_FILENAME_REGEX"]
-        return r"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<trial>(PRACTICE_)?trial_\d+)_(?P<stimulus>[^_]+_[^_]+_\d+(\.0)?)_reading_measures.csv"
+        return r"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<trial>(PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv"
 
     @READING_MEASURES_FILENAME_REGEX.setter
     def READING_MEASURES_FILENAME_REGEX(self, value: str) -> None:
@@ -425,14 +425,32 @@ class Settings:
         #: Subfolder name for psychometric tests output (overview + detailed CSVs).
         self.PSYCHOMETRIC_TESTS_FOLDER = Path("psychometric_tests/")
 
-        #: Regex patterns for relevant ASC messages for comprehension questions.
+        #: Regex patterns for relevant ASC messages for comprehension questions,
+        #: reading times, breaks, and sanity checks.
         self.ANSWER_MSG_PATTERNS = [
-            r"start_recording_.*_question_\d+",
+            r"start_recording_.*",
+            r"stop_recording_.*",
+            r"(optional|obligatory)_break.*",
+            r"welcome_screen",
+            r"informed_consent_screen",
+            r"start_experiment",
+            r"stimulus_order_version",
+            r"showing_instruction_screen",
+            r"camera_setup_screen",
+            r"practice_text_starting_screen",
+            r"transition_screen",
+            r"final_validation",
+            r"show_final_screen",
+            r"optional_break_screen",
+            r"fixation_trigger:.*",
+            r"recalibration",
+            r"empty_screen",
+            r"screen_image_onset",
+            r"screen_image_offset",
             r".*_preliminary_answer_.*",
             r"question_screen_image_offset",
             r".*_final_answer_given_is_.*",
             r".*_answer_given_is_correct:.*",
-            r"stop_recording_.*_question_\d+",
         ]
 
         # --- PIPELINE STAGES ---
@@ -755,7 +773,7 @@ class Settings:
     def _apply_logging_settings(self) -> None:
         """Apply logging settings from configuration to the active logger."""
         # Use the package-level setup_logging to ensure consistent behaviour
-        from .utils.logging import setup_logging, clear_log_file
+        from .utils.logging import clear_log_file, setup_logging
 
         log_file = self.DATASET_DIR / "preprocessing_logs.txt"
         if not self.DATASET_DIR.exists():

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -193,8 +193,9 @@ class Settings:
             return self.__dict__["START_RECORDING_REGEX"]
         # Use placeholders for trial and page column names to satisfy static analysis
         pattern = (
-            rf"MSG\s+(?P<timestamp>\d+)\s+(?P<type>start_recording)_"
-            rf"(?P<{self.TRIAL_COL}>(?:PRACTICE_)?trial_\d\d?)_(?P<{self.PAGE_COL}>.+)"
+            r"(?P<type>start_recording)_"
+            rf"(?P<{self.TRIAL_COL}>(PRACTICE_)?trial_\d\d?)_"
+            rf"stimulus__(?P<stimulus_id>\d+)_(?P<{self.PAGE_COL}>\S*)"
         )
         return re.compile(pattern)
 
@@ -211,8 +212,10 @@ class Settings:
         if "STOP_RECORDING_REGEX" in self.__dict__:
             return self.__dict__["STOP_RECORDING_REGEX"]
         pattern = (
-            rf"MSG\s+(?P<timestamp>\d+)\s+(?P<type>stop_recording)_"
-            rf"(?P<{self.TRIAL_COL}>(?:PRACTICE_)?trial_\d\d?)_(?P<{self.PAGE_COL}>.+)"
+            r"(?P<type>stop_recording)_"
+            rf"(?P<{self.TRIAL_COL}>(PRACTICE_)?trial_\d\d?)_"
+            r"stimulus_(?P<stimulus_name>\S*?_\S*?)_"
+            rf"\d+_(?P<stimulus_id>\d+)_(?P<{self.PAGE_COL}>{self.PAGE_COL}_\d+)"
         )
         return re.compile(pattern)
 
@@ -230,7 +233,7 @@ class Settings:
             return self.__dict__["RAW_DATA_FILENAME_REGEX"]
         trial_col = self.TRIAL_COL
         stimulus_col = self.STIMULUS_COL
-        return rf".+?(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_raw_data"
+        return rf"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<{trial_col}>(PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_raw_data"
 
     @RAW_DATA_FILENAME_REGEX.setter
     def RAW_DATA_FILENAME_REGEX(self, value: str) -> None:
@@ -243,11 +246,22 @@ class Settings:
             return self.__dict__["EVENT_DATA_FILENAME_REGEX"]
         trial_col = self.TRIAL_COL
         stimulus_col = self.STIMULUS_COL
-        return rf".+?(?P<{trial_col}>(?:PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_{{event_type}}.csv"
+        return rf"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<{trial_col}>(PRACTICE_)?trial_\d+)_(?P<{stimulus_col}>[^_]+_[^_]+_\d+(\.0)?)_{{event_type}}.csv"
 
     @EVENT_DATA_FILENAME_REGEX.setter
     def EVENT_DATA_FILENAME_REGEX(self, value: str) -> None:
         self.__dict__["EVENT_DATA_FILENAME_REGEX"] = value
+
+    @property
+    def READING_MEASURES_FILENAME_REGEX(self) -> str:
+        """Regex to extract trial and stimulus info from reading measures filenames."""
+        if "READING_MEASURES_FILENAME_REGEX" in self.__dict__:
+            return self.__dict__["READING_MEASURES_FILENAME_REGEX"]
+        return r"[^_]+_[^_]+_[^_]+_[^_]+_[^_]+_(?P<trial>(PRACTICE_)?trial_\d+)_(?P<stimulus>[^_]+_[^_]+_\d+(\.0)?)_reading_measures.csv"
+
+    @READING_MEASURES_FILENAME_REGEX.setter
+    def READING_MEASURES_FILENAME_REGEX(self, value: str) -> None:
+        self.__dict__["READING_MEASURES_FILENAME_REGEX"] = value
 
     @property
     def GAZE_PATTERNS(self) -> list[Any]:
@@ -565,6 +579,9 @@ class Settings:
         #: Glob pattern for event data files.
         self.EVENT_DATA_FILE_GLOB = "*_{event_type}.csv"
 
+        #: Glob pattern for reading measures files.
+        self.READING_MEASURES_GLOB = "*_reading_measures.csv"
+
         #: Regex to extract the stimulus order version from ASC files.
         self.STIMULUS_ORDER_VERSION_REGEX = re.compile(
             r"MSG\s+\d+\s+stimulus_order_version:\s+(?P<version_num>\d\d?\d?)\n"
@@ -573,6 +590,43 @@ class Settings:
         #: Regex to extract stimulus order version from logfiles.
         self.LOGFILE_ORDER_VERSION_REGEX = re.compile(
             r"(STIMULUS_ORDER_VERSION_)(?P<order_version>\d+)"
+        )
+
+        multipleye_messages = {
+            "other_screens": [
+                "welcome_screen",
+                "informed_consent_screen",
+                "start_experiment",
+                "stimulus_order_version",
+                "showing_instruction_screen",
+                "camera_setup_screen",
+                "practice_text_starting_screen",
+                "transition_screen",
+                "final_validation",
+                "show_final_screen",
+                "optional_break_screen",
+                "fixation_trigger:skipped_by_experimenter",
+                "fixation_trigger:experimenter_calibration_triggered",
+                "recalibration",
+                "empty_screen",
+                "obligatory_break",
+                "optional_break",
+            ],
+            "break_msgs": [
+                "optional_break_duration",
+                "optional_break_end",
+                "optional_break",
+                "obligatory_break_duration",
+                "obligatory_break_end",
+                "obligatory_break",
+            ],
+        }
+
+        self.BREAK_REGEX = re.compile(
+            "|".join(map(re.escape, multipleye_messages["break_msgs"]))
+        )
+        self.OTHER_SCREENS_REGEX = re.compile(
+            "|".join(map(re.escape, multipleye_messages["other_screens"]))
         )
 
         # --- HARDWARE AND STIMULI MAPPINGS ---

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import shutil
-
 import subprocess
 import warnings
 from functools import partial
@@ -17,31 +16,34 @@ import yaml
 from polars.exceptions import ComputeError
 from tqdm import tqdm
 
-from ..models.sid import Sid
-from ..models.dcn import Dcn
-from ..config import settings
-from ..utils.data_path_utils import _ci_resolve
-from ..utils.conversion import convert_to_time_str
-from ..utils.data_collection_utils import _report_to_file
-from ..utils.logging import get_logger
-from ..checks.et_quality_checks import (
-    check_comprehension_question_answers,
-    check_metadata,
-    report_to_file_metadata as report_meta,
-    check_validation_requirements,
-)
-from ..checks.formal_experiment_checks import (
-    check_all_screens_logfile,
-    sanity_check_gaze_frame,
-    check_messages,
-)
-from ..data_collection.session import Session
-from ..data_collection.stimulus import LabConfig, Stimulus
-from ..plotting.plot import plot_gaze, plot_main_sequence
-from ..utils.fix_questionnaire_data import remap_wrong_pq_values
 from preprocessing.scripts.prepare_language_folder import (
     extract_stimulus_version_number_from_asc,
 )
+
+from ..checks.et_quality_checks import (
+    check_comprehension_question_answers,
+    check_metadata,
+    check_validation_requirements,
+)
+from ..checks.et_quality_checks import (
+    report_to_file_metadata as report_meta,
+)
+from ..checks.formal_experiment_checks import (
+    check_all_screens_logfile,
+    check_messages,
+    sanity_check_gaze_frame,
+)
+from ..config import settings
+from ..data_collection.session import Session
+from ..data_collection.stimulus import LabConfig, Stimulus
+from ..models.dcn import Dcn
+from ..models.sid import Sid
+from ..plotting.plot import plot_gaze, plot_main_sequence
+from ..utils.conversion import convert_to_time_str
+from ..utils.data_collection_utils import _report_to_file
+from ..utils.data_path_utils import _ci_resolve
+from ..utils.fix_questionnaire_data import remap_wrong_pq_values
+from ..utils.logging import get_logger
 
 
 def eyelink(method):
@@ -550,7 +552,9 @@ class MultipleyeDataCollection:
         if not output_dir:
             output_dir = self.output_dir
 
-        session_results = output_dir / session_name / self.reports_folder
+        session_results = (
+            Path(output_dir) / settings.SANITY_CHECKS_FOLDER / session_name
+        )
         os.makedirs(session_results, exist_ok=True)
 
         self.sessions[session_name].uncategorized_messages = self.parse_messages(
@@ -565,8 +569,13 @@ class MultipleyeDataCollection:
 
             messages = self.sessions[session_name].messages
 
-            if not messages:
-                self.logger.warning(f"No messages found in asc file of {session_name}.")
+            if isinstance(messages, pl.DataFrame):
+                messages_for_check = [
+                    {"message": row["content"], "timestamp": row["time"]}
+                    for row in messages.iter_rows(named=True)
+                ]
+            else:
+                messages_for_check = messages or []
 
             stimuli = self.sessions[session_name].stimuli
 
@@ -600,7 +609,10 @@ class MultipleyeDataCollection:
             _report_to_file("## Gaze Frame", report_file_path)
             self._check_stimuli_gaze_frame(gaze, stimuli, session_name)
             _report_to_file("## ASC Messages", report_file_path)
-            self._check_asc_messages(stimuli, messages, session_name)
+            if messages_for_check:
+                self._check_asc_messages(stimuli, messages_for_check, session_name)
+            else:
+                self.logger.warning(f"No messages found in asc file of {session_name}.")
             _report_to_file("## Validation & Calibration", report_file_path)
             self._check_asc_validation(session_name)
             self._load_psychometric_tests(session_name)
@@ -905,7 +917,6 @@ class MultipleyeDataCollection:
                     trial_ids[trial_ids.index(trial)] = f"trial_{int(trial)}"
                 except TypeError:
                     trial_ids = trial_ids
-                    pass
 
         stimulus_names = completed_stimuli["stimulus_name"].to_list()
         stimuli_trial_mapping = {
@@ -1088,44 +1099,60 @@ class MultipleyeDataCollection:
         other_screens: list[dict] = []
         uncategorized_msgs: list[dict] = []
 
-        trial_col = settings.TRIAL_COL
         page_col = settings.PAGE_COL
 
         initial_ts = 0
-        messages = self.sessions[session_identifier].messages.copy()
+        messages = self.sessions[session_identifier].messages
 
-        for msg in messages:
+        if messages is None:
+            return (
+                reading_times_df,
+                break_msg,
+                other_screens,
+                uncategorized_msgs,
+                initial_ts,
+            )
+
+        if isinstance(messages, pl.DataFrame) and messages.is_empty():
+            return (
+                reading_times_df,
+                break_msg,
+                other_screens,
+                uncategorized_msgs,
+                initial_ts,
+            )
+
+        if isinstance(messages, pl.DataFrame):
+            row_iter = messages.iter_rows(named=True)
+        else:
+            row_iter = messages.copy()
+
+        for msg in row_iter:
+            content = msg.get("content", msg.get("message", ""))
+            ts_val = msg.get("time", msg.get("timestamp", ""))
+
+            timestamp = str(ts_val)
             if not initial_ts:
-                initial_ts = msg["timestamp"]
+                initial_ts = timestamp
 
-            if settings.BREAK_REGEX.match(msg["message"]):
-                break_msg.append(msg)
-            elif settings.OTHER_SCREENS_REGEX.match(msg["message"]):
-                other_screens.append(msg)
-            elif match := settings.START_RECORDING_REGEX.match(msg["message"]):
+            if settings.BREAK_REGEX.match(content):
+                break_msg.append({"message": content, "timestamp": timestamp})
+            elif settings.OTHER_SCREENS_REGEX.match(content):
+                other_screens.append({"message": content, "timestamp": timestamp})
+            elif match := settings.START_RECORDING_REGEX.match(content):
                 event = match.groupdict()
-                event["start_ts"] = msg["timestamp"]
-                trial = event.get(trial_col, "")
-                stimulus_name = self.sessions[
-                    session_identifier
-                ].stimuli_trial_mapping.get(trial)
-                if stimulus_name:
-                    event["stimulus_name"] = stimulus_name
+                event["start_ts"] = timestamp
                 reading_times_df = reading_times_df.update(
                     pl.DataFrame(event), on=["stimulus_name", page_col], how="left"
                 )
-            elif match := settings.STOP_RECORDING_REGEX.match(msg["message"]):
+            elif match := settings.STOP_RECORDING_REGEX.match(content):
                 event = match.groupdict()
-                event["stop_ts"] = msg["timestamp"]
-                sn = event.get("stimulus_name", "")
-                sid = event.get("stimulus_id", "")
-                if sn and sid:
-                    event["stimulus_name"] = f"{sn}_{sid}"
+                event["stop_ts"] = timestamp
                 reading_times_df = reading_times_df.update(
                     pl.DataFrame(event), on=["stimulus_name", page_col], how="left"
                 )
             else:
-                uncategorized_msgs.append(msg)
+                uncategorized_msgs.append({"message": content, "timestamp": timestamp})
 
         return (
             reading_times_df,
@@ -1138,7 +1165,7 @@ class MultipleyeDataCollection:
     def _document_other_screens(
         self, session_idf: str, other_screens: list[dict]
     ) -> None:
-        result_folder = self.output_dir / session_idf / self.reports_folder
+        result_folder = self.output_dir / self.reports_folder / session_idf
         os.makedirs(result_folder, exist_ok=True)
 
         data = {
@@ -1152,7 +1179,7 @@ class MultipleyeDataCollection:
         )
 
     def _document_breaks(self, session_idf: str, breaks: list[dict]) -> None:
-        result_folder = self.output_dir / session_idf / self.reports_folder
+        result_folder = self.output_dir / self.reports_folder / session_idf
         os.makedirs(result_folder, exist_ok=True)
 
         breaks_df: dict[str, list] = {
@@ -1221,7 +1248,7 @@ class MultipleyeDataCollection:
         self._document_other_screens(session_identifier, other_screens)
         self._document_breaks(session_identifier, break_msg)
 
-        result_folder = self.output_dir / session_identifier / self.reports_folder
+        result_folder = self.output_dir / self.reports_folder / session_identifier
         os.makedirs(result_folder, exist_ok=True)
         self._document_reading_times(
             initial_ts,
@@ -1281,7 +1308,7 @@ class MultipleyeDataCollection:
         total_reading_duration_ms = 0
 
         for start, stop in zip(reading_times["start_ts"], reading_times["stop_ts"]):
-            time_ms = int(stop) - int(start)
+            time_ms = int(float(stop)) - int(float(start))
             time_str = convert_to_time_str(time_ms)
             reading_times["duration_ms"].append(time_ms)
             reading_times["duration_str"].append(time_str)
@@ -1299,7 +1326,7 @@ class MultipleyeDataCollection:
             reading_times["pages"],
             reading_times["trials"],
         ):
-            time_ms = int(start) - int(stop)
+            time_ms = int(float(start)) - int(float(stop))
             time_str = convert_to_time_str(time_ms)
             reading_times["duration_ms"].append(time_ms)
             reading_times["duration_str"].append(time_str)

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -102,8 +102,9 @@ class MultipleyeDataCollection:
         self.data_collection_name = data_collection_name
 
         self.include_pilots = kwargs.get("include_pilots", False)
-        self.reports_dir = kwargs.get("output_dir", "")
+        self.output_dir = kwargs.get("output_dir", "")
         self.pilot_folder = kwargs.get("pilot_folder", "")
+        self.reports_folder = "reports"
 
         for short_name, long_name in settings.EYETRACKER_NAMES.items():
             if eye_tracker in long_name:
@@ -133,10 +134,6 @@ class MultipleyeDataCollection:
             f"MultipleyeDataCollection initialized. data_root: {self.data_root}"
         )
         self.logger.info(f"Main config loaded from {self.config_file}")
-
-        if not self.reports_dir:
-            self.reports_dir = self.data_root.parent / "quality_reports"
-            self.reports_dir.mkdir(exist_ok=True)
 
         self.add_recorded_sessions(self.data_root, self.session_folder_regex)
 
@@ -421,6 +418,7 @@ class MultipleyeDataCollection:
         include_pilots: bool = False,
         excluded_sessions: list[str] | None = None,
         included_sessions: list[str] | None = None,
+        output_dir: Path | None = None,
     ) -> "MultipleyeDataCollection":
         """
         :param data_dir: str  path to the data folder
@@ -523,6 +521,7 @@ class MultipleyeDataCollection:
             ps_tests_path=ps_tests_path,
             included_sessions=included_sessions,
             excluded_sessions=excluded_sessions,
+            output_dir=output_dir,
         )
 
     def create_sanity_check_report(
@@ -549,12 +548,14 @@ class MultipleyeDataCollection:
             return
 
         if not output_dir:
-            output_dir = self.reports_dir
+            output_dir = self.output_dir
 
-        session_results = (
-            Path(output_dir) / settings.SANITY_CHECKS_FOLDER / session_name
-        )
+        session_results = output_dir / session_name / self.reports_folder
         os.makedirs(session_results, exist_ok=True)
+
+        self.sessions[session_name].uncategorized_messages = self.parse_messages(
+            session_name
+        )
 
         report_file_path = session_results / f"{session_name}_{self.city}_report.md"
         self.sessions[session_name].sanity_report_path = report_file_path
@@ -725,7 +726,6 @@ class MultipleyeDataCollection:
                 self.sessions[session].completed_stimuli_names,
                 self.sessions[session].stimuli_trial_mapping,
             ) = self._load_session_completed_stimuli(session)
-            self.sessions[session].messages = self._parse_asc(session)
             self.sessions[session].logfile = self._load_session_logfile(session)
             self.sessions[
                 session
@@ -1035,162 +1035,249 @@ class MultipleyeDataCollection:
                 f"Please add the used stimulus folder from the experiment. Or check the stimulus order versions file for missing IDs or duplicates."
             )
 
-    def _parse_asc(self, session_identifier: str):
-        """
-        qick fix for now, should be replaced by the summary experiment frame later on, however the extraction of the
-        stimulus order version is essential for other code parts, it cannot be removed without further alterations
-        """
-
-        other_screens = [
-            "welcome_screen",
-            "informed_consent_screen",
-            "start_experiment",
-            "stimulus_order_version",
-            "showing_instruction_screen",
-            "camera_setup_screen",
-            "practice_text_starting_screen",
-            "transition_screen",
-            "final_validation",
-            "show_final_screen",
-            "fixation_trigger:skipped_by_experimenter",
-            "fixation_trigger:experimenter_calibration_triggered",
-            "recalibration",
-            "empty_screen",
-            "obligatory_break",
-            "optional_break",
-        ]
-
-        asc_file = self.sessions[session_identifier].asc_path
-        stimuli_trial_mapping = self.sessions[session_identifier].stimuli_trial_mapping
-
-        other_screen_appearance = {
-            "timestamp": [],
-            "screen": [],
+    def _create_empty_rt_frame(self, session_identifier: str) -> pl.DataFrame:
+        session = self.sessions[session_identifier]
+        mapping = session.stimuli_trial_mapping
+        num_of_pages_per_trial = {
+            stimulus.name: [page.number for page in stimulus.pages]
+            for stimulus in session.stimuli
         }
 
-        reading_times = {
-            "start_ts": [],
-            "stop_ts": [],
-            "start_msg": [],
-            "stop_msg": [],
-            "duration_ms": [],
-            "duration_str": [],
-            "trials": [],
-            "pages": [],
-            "status": [],
-            "stimulus_name": [],
-        }
+        trial_col = settings.TRIAL_COL
+        page_col = settings.PAGE_COL
 
-        breaks = {
+        rows: list[dict] = []
+        for stimulus_name in mapping.values():
+            if stimulus_name not in num_of_pages_per_trial:
+                continue
+            for page_num in num_of_pages_per_trial[stimulus_name]:
+                rows.append(
+                    {
+                        "stimulus_name": stimulus_name,
+                        "start_ts": None,
+                        "stop_ts": None,
+                        "start_msg": None,
+                        "stop_msg": None,
+                        "duration_ms": None,
+                        "duration_str": None,
+                        trial_col: None,
+                        page_col: f"page_{page_num}",
+                        "status": None,
+                    }
+                )
+
+        schema = {
+            "stimulus_name": pl.String,
+            "start_ts": pl.String,
+            "stop_ts": pl.String,
+            "start_msg": pl.String,
+            "stop_msg": pl.String,
+            "duration_ms": pl.String,
+            "duration_str": pl.String,
+            trial_col: pl.String,
+            page_col: pl.String,
+            "status": pl.String,
+        }
+        return (
+            pl.DataFrame(rows, schema=schema) if rows else pl.DataFrame(schema=schema)
+        )
+
+    def _categorize_asc_messages(self, session_identifier: str):
+        reading_times_df = self._create_empty_rt_frame(session_identifier)
+        break_msg: list[dict] = []
+        other_screens: list[dict] = []
+        uncategorized_msgs: list[dict] = []
+
+        trial_col = settings.TRIAL_COL
+        page_col = settings.PAGE_COL
+
+        initial_ts = 0
+        messages = self.sessions[session_identifier].messages.copy()
+
+        for msg in messages:
+            if not initial_ts:
+                initial_ts = msg["timestamp"]
+
+            if settings.BREAK_REGEX.match(msg["message"]):
+                break_msg.append(msg)
+            elif settings.OTHER_SCREENS_REGEX.match(msg["message"]):
+                other_screens.append(msg)
+            elif match := settings.START_RECORDING_REGEX.match(msg["message"]):
+                event = match.groupdict()
+                event["start_ts"] = msg["timestamp"]
+                trial = event.get(trial_col, "")
+                stimulus_name = self.sessions[
+                    session_identifier
+                ].stimuli_trial_mapping.get(trial)
+                if stimulus_name:
+                    event["stimulus_name"] = stimulus_name
+                reading_times_df = reading_times_df.update(
+                    pl.DataFrame(event), on=["stimulus_name", page_col], how="left"
+                )
+            elif match := settings.STOP_RECORDING_REGEX.match(msg["message"]):
+                event = match.groupdict()
+                event["stop_ts"] = msg["timestamp"]
+                sn = event.get("stimulus_name", "")
+                sid = event.get("stimulus_id", "")
+                if sn and sid:
+                    event["stimulus_name"] = f"{sn}_{sid}"
+                reading_times_df = reading_times_df.update(
+                    pl.DataFrame(event), on=["stimulus_name", page_col], how="left"
+                )
+            else:
+                uncategorized_msgs.append(msg)
+
+        return (
+            reading_times_df,
+            break_msg,
+            other_screens,
+            uncategorized_msgs,
+            initial_ts,
+        )
+
+    def _document_other_screens(
+        self, session_idf: str, other_screens: list[dict]
+    ) -> None:
+        result_folder = self.output_dir / session_idf / self.reports_folder
+        os.makedirs(result_folder, exist_ok=True)
+
+        data = {
+            "timestamp": [m["timestamp"] for m in other_screens],
+            "screen": [m["message"] for m in other_screens],
+        }
+        pd.DataFrame(data).to_csv(
+            result_folder / f"other_screens_{session_idf}.tsv",
+            sep="\t",
+            index=False,
+        )
+
+    def _document_breaks(self, session_idf: str, breaks: list[dict]) -> None:
+        result_folder = self.output_dir / session_idf / self.reports_folder
+        os.makedirs(result_folder, exist_ok=True)
+
+        breaks_df: dict[str, list] = {
             "start_ts": [],
             "stop_ts": [],
             "duration_ms": [],
             "type": [],
         }
-
-        messages = []
-
-        initial_ts = 0
-
-        result_folder = self.reports_dir / session_identifier
-        os.makedirs(result_folder, exist_ok=True)
         in_break = False
 
-        with open(asc_file, encoding="utf-8") as f:
-            for line in f.readlines():
-                if match := settings.MESSAGE_REGEX.match(line):
-                    messages.append(match.groupdict())
-                    msg = match.groupdict()["message"]
-                    ts = match.groupdict()["timestamp"]
+        for entry in breaks:
+            msg = entry["message"]
+            ts = entry["timestamp"]
 
-                    if not initial_ts:
-                        initial_ts = ts
+            if msg == "optional_break" and not in_break:
+                in_break = True
+                breaks_df["start_ts"].append(ts)
+                breaks_df["type"].append("optional")
+            elif msg == "optional_break_end" and in_break:
+                in_break = False
+                breaks_df["stop_ts"].append(ts)
+            elif msg.split()[0] == "optional_break_duration:":
+                breaks_df["duration_ms"].append(msg.split()[1])
+            elif msg == "obligatory_break" and not in_break:
+                in_break = True
+                breaks_df["start_ts"].append(ts)
+                breaks_df["type"].append("obligatory")
+            elif msg == "obligatory_break_end" and in_break:
+                in_break = False
+                breaks_df["stop_ts"].append(ts)
+            elif msg.split()[0] == "obligatory_break_duration:":
+                breaks_df["duration_ms"].append(msg.split()[1])
 
-                    for screen in other_screens:
-                        if screen in line:
-                            other_screen_appearance["screen"].append(msg)
-                            other_screen_appearance["timestamp"].append(ts)
-
-                    if msg == "optional_break" and not in_break:
-                        in_break = True
-                        breaks["start_ts"].append(ts)
-                        breaks["type"].append("optional")
-                    elif msg == "optional_break_end" and in_break:
-                        in_break = False
-                        breaks["stop_ts"].append(ts)
-                    elif msg.split()[0] == "optional_break_duration:":
-                        breaks["duration_ms"].append(msg.split()[1])
-
-                    elif msg == "obligatory_break" and not in_break:
-                        in_break = True
-                        breaks["start_ts"].append(ts)
-                        breaks["type"].append("obligatory")
-                    elif msg == "obligatory_break_end" and in_break:
-                        in_break = False
-                        breaks["stop_ts"].append(ts)
-                    elif msg.split()[0] == "obligatory_break_duration:":
-                        breaks["duration_ms"].append(msg.split()[1])
-
-                if match := settings.START_RECORDING_REGEX.match(line):
-                    reading_times["start_ts"].append(match.groupdict()["timestamp"])
-                    reading_times["start_msg"].append(match.groupdict()["type"])
-
-                    trial = match.groupdict()["trial"]
-                    # trial = trial.replace('trial_', '')
-                    reading_times["trials"].append(trial)
-
-                    if trial in stimuli_trial_mapping:
-                        reading_times["stimulus_name"].append(
-                            stimuli_trial_mapping[trial]
-                        )
-                    else:
-                        reading_times["stimulus_name"].append("unknown")
-
-                    reading_times["pages"].append(match.groupdict()["page"])
-                    reading_times["status"].append("reading time")
-                elif match := settings.STOP_RECORDING_REGEX.match(line):
-                    reading_times["stop_ts"].append(match.groupdict()["timestamp"])
-                    reading_times["stop_msg"].append(match.groupdict()["type"])
-
-            self._document_reading_times(
-                initial_ts, reading_times, result_folder, session_identifier
+        if in_break:
+            breaks_df["stop_ts"].append(None)
+            self.logger.warning(
+                f"Session {session_idf} did not finish a break properly, "
+                f"missing end message."
             )
 
-            other_screens_df = pd.DataFrame(other_screen_appearance)
-            other_screens_df.to_csv(
-                result_folder / f"other_screens_{session_identifier}.tsv",
-                sep="\t",
-                index=False,
-            )
+        max_len = max(
+            len(breaks_df["start_ts"]),
+            len(breaks_df["stop_ts"]),
+            len(breaks_df["duration_ms"]),
+            len(breaks_df["type"]),
+        )
+        for col in ("start_ts", "stop_ts", "duration_ms", "type"):
+            while len(breaks_df[col]) < max_len:
+                breaks_df[col].append(None)
 
-            if not in_break:
-                breaks_df = pd.DataFrame(breaks)
-                breaks_df.to_csv(
-                    result_folder / f"breaks_{session_identifier}.tsv",
-                    sep="\t",
-                    index=False,
-                )
-            else:
-                self.logger.warning(
-                    f"Session {session_identifier} did not finish a break properly, "
-                    f"missing end message."
-                )
+        pd.DataFrame(breaks_df).to_csv(
+            result_folder / f"breaks_{session_idf}.tsv",
+            sep="\t",
+            index=False,
+        )
 
-        return messages
+    def parse_messages(self, session_identifier: str) -> list[dict]:
+        (
+            stimulus_times_df,
+            break_msg,
+            other_screens,
+            uncategorized_msgs,
+            initial_ts,
+        ) = self._categorize_asc_messages(session_identifier)
+
+        self._document_other_screens(session_identifier, other_screens)
+        self._document_breaks(session_identifier, break_msg)
+
+        result_folder = self.output_dir / session_identifier / self.reports_folder
+        os.makedirs(result_folder, exist_ok=True)
+        self._document_reading_times(
+            initial_ts,
+            stimulus_times_df,
+            result_folder,
+            session_identifier,
+        )
+
+        return uncategorized_msgs
 
     def _document_reading_times(
         self, initial_ts, reading_times, result_folder, session_identifier
     ):
-        """
-        TODO: improve this function!! this is terrible and buggy
-        :param initial_ts:
-        :param reading_times:
-        :param result_folder:
-        :param session_identifier:
-        :return:
-        """
+        """Document reading times from categorized messages.
 
+        :param initial_ts: Timestamp of the first message.
+        :param reading_times: A polars DataFrame or dict of lists with start_ts/stop_ts per page.
+        :param result_folder: Output directory for TSV files.
+        :param session_identifier: The session identifier.
+        """
         stimuli_trial_mapping = self.sessions[session_identifier].stimuli_trial_mapping
+
+        if isinstance(reading_times, pl.DataFrame):
+            valid = reading_times.filter(
+                pl.col("start_ts").is_not_null() & pl.col("stop_ts").is_not_null()
+            )
+            reading_times_dict: dict[str, list] = {
+                "start_ts": valid["start_ts"].to_list(),
+                "stop_ts": valid["stop_ts"].to_list(),
+                "start_msg": [],
+                "stop_msg": [],
+                "duration_ms": [],
+                "duration_str": [],
+                "trials": [],
+                "pages": valid["page"].to_list(),
+                "status": [],
+                "stimulus_name": [],
+            }
+            stimuli_trial_mapping = self.sessions[
+                session_identifier
+            ].stimuli_trial_mapping
+            for row in valid.iter_rows(named=True):
+                reading_times_dict["start_msg"].append("start_recording")
+                reading_times_dict["stop_msg"].append("stop_recording")
+                reading_times_dict["status"].append("reading time")
+                page = row["page"]
+                stim = row["stimulus_name"]
+                trial = None
+                for t, s in stimuli_trial_mapping.items():
+                    if s == stim:
+                        trial = t
+                        break
+                reading_times_dict["trials"].append(trial or "unknown")
+                reading_times_dict["stimulus_name"].append(stim)
+            reading_times = reading_times_dict
+
         total_reading_duration_ms = 0
 
         for start, stop in zip(reading_times["start_ts"], reading_times["stop_ts"]):

--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -33,6 +33,7 @@ class Session:
     question_order: dict[str, list[str]] = field(default="unknown", init=False)
     stimulus_order_ids: list[int] = field(default="unknown", init=False)
     messages: list[dict[str, str]] = field(default="unknown", init=False)
+    uncategorized_messages: list[dict[str, str]] = field(default="unknown", init=False)
     stimuli_trial_mapping: dict[str, str] = field(default="unknown", init=False)
     stimulus_start_end_ts: dict[str, list[str]] = field(default="unknown", init=False)
 

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from glob import glob
 from pathlib import Path
 from typing import Literal
@@ -90,7 +90,6 @@ class ComprehensionQuestion:
 class Stimulus:
     id: int
     name: str
-    full_identifier: str
     type: Literal["experiment", "practice", "test_practice", "test_experiment"]
     pages: list[StimulusPage]
     text_stimulus: pm.stimulus.TextStimulus
@@ -98,6 +97,11 @@ class Stimulus:
     instructions: list[Instruction]
     ratings: list[Rating]
     trial_id: str
+    full_identifier: str = field(default="")
+
+    def __post_init__(self):
+        if not self.full_identifier:
+            self.full_identifier = f"{self.name}_{self.id}"
 
     @classmethod
     def load(

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -90,6 +90,7 @@ class ComprehensionQuestion:
 class Stimulus:
     id: int
     name: str
+    full_identifier: str
     type: Literal["experiment", "practice", "test_practice", "test_experiment"]
     pages: list[StimulusPage]
     text_stimulus: pm.stimulus.TextStimulus
@@ -277,6 +278,7 @@ class Stimulus:
         stim = cls(
             id=stimulus_id,
             name=stimulus_name,
+            full_identifier=stimulus_name + f"_{stimulus_id}",
             type=stimulus_type,
             pages=pages,
             text_stimulus=text_stimulus,

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -200,6 +200,10 @@ def load_trial_level_raw_data(
 
         gaze.experiment = exp
 
+        messages_path = metadata_path / "messages.csv"
+        if messages_path.exists():
+            gaze.messages = pl.read_csv(messages_path)
+
     return gaze
 
 

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -305,7 +305,7 @@ def load_trial_level_events_data(
 
 def load_reading_measures(
     sid: Sid,
-    file_pattern: str = r".+?(?P<trial>(?:PRACTICE_)?trial_\d+)_(?P<stimulus>.+)_reading_measures\.csv",
+    file_pattern: str | None = None,
 ) -> pl.DataFrame:
     """Load reading measures from CSV files.
 
@@ -315,6 +315,7 @@ def load_reading_measures(
         The session identifier.
     file_pattern : str, optional
         Regex pattern to extract trial and stimulus from filenames.
+        Defaults to ``settings.READING_MEASURES_FILENAME_REGEX``.
 
     Returns
     -------
@@ -322,23 +323,24 @@ def load_reading_measures(
         A DataFrame containing the concatenated reading measures data.
     """
     data_folder = sid.reading_measures_dir
-    # Use glob to find all csv files first, as Path.glob() does not support regex
-    files = [f for f in data_folder.glob("*.csv") if re.match(file_pattern, f.name)]
-
-    if len(files) == 0:
-        raise ValueError(f"No files found in {data_folder} with pattern {file_pattern}")
+    glob_pattern = settings.READING_MEASURES_GLOB
+    regex = file_pattern or settings.READING_MEASURES_FILENAME_REGEX
 
     all_trials = []
 
-    for file in files:
+    for file in data_folder.glob(glob_pattern):
+        match = re.match(regex, file.name)
+        if not match:
+            continue
+
         df = pl.read_csv(file)
-        # get trial and stimulus from file name
-        match = re.match(file_pattern, file.name)
         trial_df = df.with_columns(
             pl.lit(match.group("trial")).alias("trial"),
             pl.lit(match.group("stimulus")).alias("stimulus"),
         )
-
         all_trials.append(trial_df)
+
+    if not all_trials:
+        raise ValueError(f"No reading measures files found in {data_folder}")
 
     return pl.concat(all_trials)

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -216,3 +216,9 @@ def save_session_metadata(sid: Sid, gaze: pm.Gaze) -> None:
 
     calibrations.write_csv(metadata_directory / "calibrations.tsv", separator="\t")
     gaze.save_calibrations(metadata_directory / "calibrations.feather")
+
+    if gaze.messages is not None and not gaze.messages.is_empty():
+        gaze.messages.write_csv(
+            metadata_directory / "messages.csv",
+            include_header=True,
+        )

--- a/preprocessing/metrics/calculate.py
+++ b/preprocessing/metrics/calculate.py
@@ -19,7 +19,9 @@ def calculate_reading_measures(gaze: pm.Gaze, stimuli: list[Stimulus]) -> pl.Dat
     for stim in stimuli:
         aois = stim.text_stimulus.aois
         words_only = all_tokens_from_aois(aois, trial=stim.trial_id)
-        words_only = words_only.with_columns(pl.lit(stim.name).alias("stimulus"))
+        words_only = words_only.with_columns(
+            pl.lit(stim.full_identifier).alias("stimulus")
+        )
         words_only_all_trials.append(words_only)
 
     words_df = pl.concat(words_only_all_trials)

--- a/preprocessing/metrics/reading/words.py
+++ b/preprocessing/metrics/reading/words.py
@@ -1,5 +1,7 @@
 import polars as pl
 
+from ...config import settings
+
 
 def all_tokens_from_aois(
     aois: pl.DataFrame,
@@ -9,8 +11,6 @@ def all_tokens_from_aois(
     Returns every AOI token on the page:
     words, spaces, punctuation — everything that has a word_idx.
     """
-    from ...config import settings
-
     aois = (
         aois.with_columns([pl.lit(trial).cast(pl.Utf8).alias(settings.TRIAL_COL)])
         if settings.TRIAL_COL not in aois.columns
@@ -29,8 +29,6 @@ def all_tokens_from_aois(
 def mark_skipped_tokens(
     all_tokens: pl.DataFrame, fixations: pl.DataFrame
 ) -> pl.DataFrame:
-    from ...config import settings
-
     fixated_tokens = (
         fixations.select([settings.TRIAL_COL, settings.PAGE_COL, settings.WORD_IDX_COL])
         .drop_nulls()

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -108,7 +108,7 @@ def run_preprocessing(config_path: str | None = None):
 
             if gaze is not None and gaze.messages is None and asc.exists():
                 tmp = pm.gaze.from_asc(
-                    asc, patterns=[], messages=settings.ANSWER_MSG_PATTERNS
+                    asc, patterns=[], messages=settings.EXPERIMENT_MSG_PATTERNS
                 )
                 gaze.messages = tmp.messages
 
@@ -119,7 +119,7 @@ def run_preprocessing(config_path: str | None = None):
                 lab_config=sess.lab_config,
                 sid=sess.sid,
                 trial_cols=settings.TRIAL_COLS,
-                messages=settings.ANSWER_MSG_PATTERNS,
+                messages=settings.EXPERIMENT_MSG_PATTERNS,
             )
 
             # filter gaze to only contain data of completed stimuli

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -48,6 +48,7 @@ def run_preprocessing(config_path: str | None = None):
             include_pilots=settings.INCLUDE_PILOTS,
             excluded_sessions=settings.EXCLUDE_SESSIONS,
             included_sessions=settings.INCLUDE_SESSIONS,
+            output_dir=settings.OUTPUT_DIR,
         )
 
     elif settings.EXPERIMENT_TYPE == "MeRID":
@@ -133,6 +134,7 @@ def run_preprocessing(config_path: str | None = None):
         sess.pm_gaze_metadata = gaze._metadata
         sess.calibrations = gaze.calibrations
         sess.validations = gaze.validations
+        sess.messages = gaze.messages
 
         # Store measure-based data loss values (computed above and in load_gaze_data).
         sess._measure_total_data_loss_ratio = getattr(

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -106,6 +106,12 @@ def run_preprocessing(config_path: str | None = None):
                 load_metadata=True,
             )
 
+            if gaze is not None and gaze.messages is None and asc.exists():
+                tmp = pm.gaze.from_asc(
+                    asc, patterns=[], messages=settings.ANSWER_MSG_PATTERNS
+                )
+                gaze.messages = tmp.messages
+
         else:
             pbar.set_description(f"Extracting samples {sess.sid}:")
             gaze = preprocessing.load_gaze_data(

--- a/tests/unit/preprocessing/data_collection/test_reading_times.py
+++ b/tests/unit/preprocessing/data_collection/test_reading_times.py
@@ -140,25 +140,25 @@ class TestCreateEmptyRtFrame:
 
 class TestCategorizeAscMessages:
     def test_categorizes_start_recording_messages(self) -> None:
-        stim = _mock_stimulus("PopSci_MultiplEYE_1", num_pages=2)
+        stim = _mock_stimulus("PopSci_MultiplEYE", num_pages=2)
         dc = _mock_dc(
             stimuli=[stim],
-            stimuli_trial_mapping={"trial_1": "PopSci_MultiplEYE_1"},
+            stimuli_trial_mapping={"trial_1": "PopSci_MultiplEYE"},
             messages=[
                 {
-                    "message": "start_recording_trial_1_stimulus__1_page_1",
+                    "message": "start_recording_trial_1_stimulus_PopSci_MultiplEYE_1_page_1",
                     "timestamp": "1000",
                 },
                 {
-                    "message": "stop_recording_trial_1_stimulus_PopSci_MultiplEYE_1_1_page_1",
+                    "message": "stop_recording_trial_1_stimulus_PopSci_MultiplEYE_1_page_1",
                     "timestamp": "5000",
                 },
                 {
-                    "message": "start_recording_trial_1_stimulus__1_page_2",
+                    "message": "start_recording_trial_1_stimulus_PopSci_MultiplEYE_1_page_2",
                     "timestamp": "5200",
                 },
                 {
-                    "message": "stop_recording_trial_1_stimulus_PopSci_MultiplEYE_1_1_page_2",
+                    "message": "stop_recording_trial_1_stimulus_PopSci_MultiplEYE_1_page_2",
                     "timestamp": "9000",
                 },
             ],
@@ -246,7 +246,7 @@ class TestDocumentBreaks:
             {"message": "optional_break_end", "timestamp": "5000"},
         ]
         dc = _mock_dc()
-        output_dir = dc.output_dir / "test_session" / dc.reports_folder
+        output_dir = dc.output_dir / dc.reports_folder / "test_session"
         os.makedirs(output_dir, exist_ok=True)
 
         MultipleyeDataCollection._document_breaks(dc, "test_session", breaks)
@@ -264,7 +264,7 @@ class TestDocumentBreaks:
             {"message": "obligatory_break", "timestamp": "1000"},
         ]
         dc = _mock_dc()
-        output_dir = dc.output_dir / "test_session" / dc.reports_folder
+        output_dir = dc.output_dir / dc.reports_folder / "test_session"
         os.makedirs(output_dir, exist_ok=True)
 
         MultipleyeDataCollection._document_breaks(dc, "test_session", breaks)
@@ -277,7 +277,7 @@ class TestDocumentBreaks:
 
     def test_handles_empty_breaks(self) -> None:
         dc = _mock_dc()
-        output_dir = dc.output_dir / "test_session" / dc.reports_folder
+        output_dir = dc.output_dir / dc.reports_folder / "test_session"
         os.makedirs(output_dir, exist_ok=True)
 
         MultipleyeDataCollection._document_breaks(dc, "test_session", [])

--- a/tests/unit/preprocessing/data_collection/test_reading_times.py
+++ b/tests/unit/preprocessing/data_collection/test_reading_times.py
@@ -1,0 +1,288 @@
+import polars as pl
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+from preprocessing.data_collection.multipleye_data_collection import (
+    MultipleyeDataCollection,
+)
+from preprocessing.data_collection.stimulus import Stimulus, StimulusPage
+
+
+def _mock_page(number: int) -> Mock:
+    page = Mock(spec=StimulusPage)
+    page.number = number
+    return page
+
+
+def _mock_stimulus(
+    name: str, num_pages: int, stimulus_type: str = "experiment"
+) -> Mock:
+    stim = Mock(spec=Stimulus)
+    stim.name = name
+    stim.type = stimulus_type
+    stim.pages = [_mock_page(i) for i in range(1, num_pages + 1)]
+    return stim
+
+
+def _mock_dc(
+    output_dir: Path | None = None,
+    stimuli: list[Mock] | None = None,
+    stimuli_trial_mapping: dict[str, str] | None = None,
+    messages: list[dict[str, str]] | None = None,
+) -> MultipleyeDataCollection:
+    dc = Mock(spec=MultipleyeDataCollection)
+    dc.output_dir = output_dir or Path(tempfile.mkdtemp())
+    dc.reports_folder = "reports"
+
+    session = Mock()
+    session.stimuli = stimuli or []
+    session.stimuli_trial_mapping = stimuli_trial_mapping or {}
+    session.messages = messages or []
+
+    dc.sessions = {"test_session": session}
+    dc.logger = Mock()
+
+    dc._create_empty_rt_frame = lambda sid: (
+        MultipleyeDataCollection._create_empty_rt_frame(dc, sid)
+    )
+    return dc
+
+
+class TestCreateEmptyRtFrame:
+    def test_creates_dataframe_with_correct_schema(self) -> None:
+        stim = _mock_stimulus("Stim_A_1", num_pages=3)
+        dc = _mock_dc(
+            stimuli=[stim],
+            stimuli_trial_mapping={"trial_1": "Stim_A_1"},
+        )
+
+        df = MultipleyeDataCollection._create_empty_rt_frame(dc, "test_session")
+
+        assert isinstance(df, pl.DataFrame)
+        expected_cols = {
+            "stimulus_name",
+            "start_ts",
+            "stop_ts",
+            "start_msg",
+            "stop_msg",
+            "duration_ms",
+            "duration_str",
+            "trial",
+            "page",
+            "status",
+        }
+        assert set(df.columns) == expected_cols
+
+    def test_row_count_matches_total_pages(self) -> None:
+        stim_a = _mock_stimulus("Stim_A_1", num_pages=2)
+        stim_b = _mock_stimulus("Stim_B_2", num_pages=4)
+        dc = _mock_dc(
+            stimuli=[stim_a, stim_b],
+            stimuli_trial_mapping={
+                "trial_1": "Stim_A_1",
+                "trial_2": "Stim_B_2",
+            },
+        )
+
+        df = MultipleyeDataCollection._create_empty_rt_frame(dc, "test_session")
+
+        assert len(df) == 6  # 2 + 4 pages
+
+    def test_page_values_are_correct(self) -> None:
+        stim = _mock_stimulus("Stim_X_1", num_pages=3)
+        dc = _mock_dc(
+            stimuli=[stim],
+            stimuli_trial_mapping={"trial_1": "Stim_X_1"},
+        )
+
+        df = MultipleyeDataCollection._create_empty_rt_frame(dc, "test_session")
+
+        pages = df["page"].to_list()
+        assert pages == ["page_1", "page_2", "page_3"]
+
+    def test_stimulus_name_filled_from_mapping(self) -> None:
+        stim = _mock_stimulus("Stim_Q_5", num_pages=1)
+        dc = _mock_dc(
+            stimuli=[stim],
+            stimuli_trial_mapping={"trial_3": "Stim_Q_5"},
+        )
+
+        df = MultipleyeDataCollection._create_empty_rt_frame(dc, "test_session")
+
+        assert df["stimulus_name"].to_list() == ["Stim_Q_5"]
+
+    def test_start_ts_stop_ts_are_null_initially(self) -> None:
+        stim = _mock_stimulus("Stim_A_1", num_pages=2)
+        dc = _mock_dc(
+            stimuli=[stim],
+            stimuli_trial_mapping={"trial_1": "Stim_A_1"},
+        )
+
+        df = MultipleyeDataCollection._create_empty_rt_frame(dc, "test_session")
+
+        assert df["start_ts"].null_count() == 2
+        assert df["stop_ts"].null_count() == 2
+
+    def test_skips_stimuli_not_in_mapping(self) -> None:
+        stim_a = _mock_stimulus("Stim_A_1", num_pages=2)
+        stim_b = _mock_stimulus("Stim_B_2", num_pages=2)
+        dc = _mock_dc(
+            stimuli=[stim_a, stim_b],
+            stimuli_trial_mapping={"trial_1": "Stim_A_1"},  # B not in mapping
+        )
+
+        df = MultipleyeDataCollection._create_empty_rt_frame(dc, "test_session")
+
+        assert len(df) == 2  # only A's pages
+
+
+class TestCategorizeAscMessages:
+    def test_categorizes_start_recording_messages(self) -> None:
+        stim = _mock_stimulus("PopSci_MultiplEYE_1", num_pages=2)
+        dc = _mock_dc(
+            stimuli=[stim],
+            stimuli_trial_mapping={"trial_1": "PopSci_MultiplEYE_1"},
+            messages=[
+                {
+                    "message": "start_recording_trial_1_stimulus__1_page_1",
+                    "timestamp": "1000",
+                },
+                {
+                    "message": "stop_recording_trial_1_stimulus_PopSci_MultiplEYE_1_1_page_1",
+                    "timestamp": "5000",
+                },
+                {
+                    "message": "start_recording_trial_1_stimulus__1_page_2",
+                    "timestamp": "5200",
+                },
+                {
+                    "message": "stop_recording_trial_1_stimulus_PopSci_MultiplEYE_1_1_page_2",
+                    "timestamp": "9000",
+                },
+            ],
+        )
+
+        rt_df, breaks, screens, uncat, initial_ts = (
+            MultipleyeDataCollection._categorize_asc_messages(dc, "test_session")
+        )
+
+        assert isinstance(rt_df, pl.DataFrame)
+        assert initial_ts == "1000"
+
+        row1 = rt_df.filter(pl.col("page") == "page_1")
+        assert row1["start_ts"][0] == "1000"
+        assert row1["stop_ts"][0] == "5000"
+
+        row2 = rt_df.filter(pl.col("page") == "page_2")
+        assert row2["start_ts"][0] == "5200"
+        assert row2["stop_ts"][0] == "9000"
+
+    def test_categorizes_break_messages(self) -> None:
+        dc = _mock_dc(
+            messages=[
+                {"message": "optional_break", "timestamp": "2000"},
+                {"message": "optional_break_end", "timestamp": "6000"},
+                {"message": "obligatory_break", "timestamp": "8000"},
+                {"message": "obligatory_break_end", "timestamp": "10000"},
+            ],
+        )
+
+        _, breaks, _, _, _ = MultipleyeDataCollection._categorize_asc_messages(
+            dc, "test_session"
+        )
+
+        assert len(breaks) == 4
+        assert breaks[0]["message"] == "optional_break"
+
+    def test_categorizes_other_screen_messages(self) -> None:
+        dc = _mock_dc(
+            messages=[
+                {"message": "welcome_screen", "timestamp": "100"},
+                {"message": "start_experiment", "timestamp": "200"},
+            ],
+        )
+
+        _, _, screens, _, _ = MultipleyeDataCollection._categorize_asc_messages(
+            dc, "test_session"
+        )
+
+        assert len(screens) == 2
+        assert screens[0]["message"] == "welcome_screen"
+
+    def test_uncategorized_messages_are_returned(self) -> None:
+        dc = _mock_dc(
+            messages=[
+                {"message": "unknown_msg_format", "timestamp": "100"},
+            ],
+        )
+
+        _, _, _, uncat, _ = MultipleyeDataCollection._categorize_asc_messages(
+            dc, "test_session"
+        )
+
+        assert len(uncat) == 1
+        assert uncat[0]["message"] == "unknown_msg_format"
+
+    def test_handles_empty_messages(self) -> None:
+        dc = _mock_dc(messages=[])
+
+        rt_df, breaks, screens, uncat, initial_ts = (
+            MultipleyeDataCollection._categorize_asc_messages(dc, "test_session")
+        )
+
+        assert len(rt_df) == 0  # no stimuli in mapping
+        assert len(breaks) == 0
+        assert len(screens) == 0
+        assert len(uncat) == 0
+        assert initial_ts == 0
+
+
+class TestDocumentBreaks:
+    def test_writes_break_tsv(self) -> None:
+        breaks = [
+            {"message": "optional_break", "timestamp": "1000"},
+            {"message": "optional_break_end", "timestamp": "5000"},
+        ]
+        dc = _mock_dc()
+        output_dir = dc.output_dir / "test_session" / dc.reports_folder
+        os.makedirs(output_dir, exist_ok=True)
+
+        MultipleyeDataCollection._document_breaks(dc, "test_session", breaks)
+
+        csv_path = output_dir / "breaks_test_session.tsv"
+        assert csv_path.exists()
+
+        df = pl.read_csv(csv_path, separator="\t")
+        assert str(df["start_ts"][0]) == "1000"
+        assert str(df["stop_ts"][0]) == "5000"
+        assert df["type"][0] == "optional"
+
+    def test_handles_unclosed_break(self) -> None:
+        breaks = [
+            {"message": "obligatory_break", "timestamp": "1000"},
+        ]
+        dc = _mock_dc()
+        output_dir = dc.output_dir / "test_session" / dc.reports_folder
+        os.makedirs(output_dir, exist_ok=True)
+
+        MultipleyeDataCollection._document_breaks(dc, "test_session", breaks)
+
+        csv_path = output_dir / "breaks_test_session.tsv"
+        df = pl.read_csv(csv_path, separator="\t")
+        assert str(df["start_ts"][0]) == "1000"
+        assert df["stop_ts"][0] is None
+        dc.logger.warning.assert_called_once()
+
+    def test_handles_empty_breaks(self) -> None:
+        dc = _mock_dc()
+        output_dir = dc.output_dir / "test_session" / dc.reports_folder
+        os.makedirs(output_dir, exist_ok=True)
+
+        MultipleyeDataCollection._document_breaks(dc, "test_session", [])
+
+        csv_path = output_dir / "breaks_test_session.tsv"
+        assert csv_path.exists()
+        df = pl.read_csv(csv_path, separator="\t")
+        assert len(df) == 0

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -136,12 +136,12 @@ def test_load_gaze_data_with_patterns(synthetic_asc, lab_config):
         asc_file=synthetic_asc,
         lab_config=lab_config,
         sid=Sid("001_SV_CH_Zurich_S1_ET1"),
-        messages=settings.ANSWER_MSG_PATTERNS,
+        messages=settings.EXPERIMENT_MSG_PATTERNS,
     )
 
     # Assertions
     assert gaze.messages is not None
-    # ANSWER_MSG_PATTERNS now includes start_recording_.* so page_1 messages
+    # EXPERIMENT_MSG_PATTERNS now includes start_recording_.* so page_1 messages
     # are expected along with question messages
     assert gaze.messages["content"].str.contains("page_1").any()
     # Question start should be here

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -141,9 +141,8 @@ def test_load_gaze_data_with_patterns(synthetic_asc, lab_config):
 
     # Assertions
     assert gaze.messages is not None
-    # 'start_recording_trial_1_stimulus_Lit_MagicMountain_6_page_1' should NOT be here
-    # because it doesn't match any pattern in ANSWER_MSG_PATTERNS
-    # (page_1 is not _question_)
-    assert not gaze.messages["content"].str.contains("page_1").any()
-    # But question start should be here
+    # ANSWER_MSG_PATTERNS now includes start_recording_.* so page_1 messages
+    # are expected along with question messages
+    assert gaze.messages["content"].str.contains("page_1").any()
+    # Question start should be here
     assert gaze.messages["content"].str.contains("question_6111").any()

--- a/tests/unit/preprocessing/test_config.py
+++ b/tests/unit/preprocessing/test_config.py
@@ -327,7 +327,7 @@ def test_settings_regex_reactivity(settings_obj):
 
     # Verify it works
     match = settings_obj.START_RECORDING_REGEX.match(
-        "MSG 123 start_recording_trial_1_page_1"
+        "start_recording_trial_1_stimulus_Test_1_page_1"
     )
     assert match is not None
     assert match.group("my_trial") == "trial_1"


### PR DESCRIPTION
This PR replaces the manual `_parse_asc` with message categorization using pymovements' already-parsed `gaze.messages` -> no more double ASC parsing as requested in #176.
This PR also improves the reading times as per #25 and supersedes #58.

The new pipeline in `MultipleyeDataCollection`:
- `_create_empty_rt_frame` builds a pre-populated DataFrame from the session's stimulus/page mapping, one row per expected page. Start/stop timestamps are filled later by the categorizer.
- `_categorize_asc_messages` iterates `gaze.messages`, routing each message using compiled regexes: reading times (match start/stop recording), breaks (match break start/end/duration), other screens (welcome, instructions, etc.), or uncategorized.
- `parse_messages` runs categorization then documents breaks to `breaks_{session}.tsv`, screens to `other_screens_{session}.tsv`, and reading times to three outputs:
  - `times_per_page_{session}.tsv`: per-page start, stop, duration_ms, stimulus, trial
  - `times_per_stimulus_{session}.tsv`: per-stimulus aggregates (summed duration, min/max timestamps)
  - `total_reading_times.tsv`: cumulative session-level totals (reading time, non-reading time, pages, trials)
- All reports go to `{output_dir}/reports/{sid}/`, the sanity check to `{output_dir}/sanity_checks/{sid}/`.

Messages are loaded via `sess.messages = gaze.messages` in the preprocessing script (key #176 change). Other cleanups from #58: `full_identifier` on `Stimulus`, `uncategorized_messages` on `Session`, `output_dir` param for `create_from_data_folder`, and `reading_measures_glob` in config.
Regexes match the actual ASC message format (`stimulus_Name_ID_page_N`). `ANSWER_MSG_PATTERNS` expanded to capture all message types (recording, breaks, screens, questions) instead of just comprehension questions. Messages are also extracted via a lightweight ASC read when loading cached gaze data, and persisted to `messages.csv` for future runs.


Closes #25, #176
Supersedes #58
Part of tracking issue #168