### PR TITLE
feat: Detect stimulus folder changes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,6 +43,15 @@ number of sessions and the size of the data. However, for the size of the Multip
 it can take a few hours.
 :::
 
+:::{dropdown} What happens when the stimulus folder is updated?
+:open:
+
+The pipeline remembers which stimulus files it copied last time.
+If the source folder has changed since then (for example, after a team uploads
+a corrected version), the pipeline notices the difference and copies the updated
+folder automatically. No manual action needed.
+:::
+
 (faq_equipment)=
 
 ## Eye-Tracking Equipment

--- a/docs/guide/pipeline_stages.md
+++ b/docs/guide/pipeline_stages.md
@@ -53,7 +53,9 @@ old-format psychometric test data that needs restructuring from task-first to se
 
 The function is `prepare_language_folder()` in `scripts.prepare_language_folder`. It also
 copies stimulus images, question images, and configuration files into the output folder so
-the pipeline has everything it needs in one place.
+the pipeline has everything it needs in one place. If the stimulus folder has changed since
+the last run (e.g. after a team upload), the pipeline detects this automatically and
+re-copies everything on the next run.
 
 (preprocessing_step_1)=
 

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -1,21 +1,22 @@
 import argparse
+import hashlib
+import os
 import re
 import shutil
-import os
 import tarfile
 from pathlib import Path
 
 import pandas as pd
 
 from ..models.dcn import Dcn
+from ..scripts.restructure_psycho_tests import fix_psycho_tests_structure
 from ..utils.data_path_utils import check_data_collection_exists
 from ..utils.file_utils import _copytree, _to_win_long_path
-from ..utils.logging import get_logger
-from ..scripts.restructure_psycho_tests import fix_psycho_tests_structure
 from ..utils.fix_multipleye_aoi_files import (
     remap_space_to_following_word,
     repair_word_labels,
 )
+from ..utils.logging import get_logger
 
 logger = get_logger()
 
@@ -207,14 +208,24 @@ def prepare_language_folder(data_collection_name: str | None = None):
         / f"aoi_stimuli_{dcn.lang.lower()}_{dcn.country.lower()}_{dcn.lab}"
     )
 
-    # Always copy stimulus assets (config, xlsx, images) before AOI checks
-    # so files stay in sync even when AOIs are already fixed.
-    _copy_stimulus_assets(
-        stimulus_folder_path,
-        preprocessed_stimulus_path,
-        eye_tracking_sessions_path,
-        dcn,
-    )
+    # Check if stimulus assets have changed since last copy
+    checksum_path = preprocessed_stimulus_path / ".copy_checksum"
+    source_checksum = _compute_stimulus_checksum(stimulus_folder_path)
+    stored = checksum_path.read_text().strip() if checksum_path.exists() else None
+
+    if source_checksum == stored:
+        logger.info("Stimulus assets unchanged. Skipping copy.")
+    else:
+        if stored is not None:
+            logger.info("Stimulus assets changed. Recopying.")
+            shutil.rmtree(str(preprocessed_stimulus_path))
+        _copy_stimulus_assets(
+            stimulus_folder_path,
+            preprocessed_stimulus_path,
+            eye_tracking_sessions_path,
+            dcn,
+        )
+        checksum_path.write_text(source_checksum)
 
     if (  # check if it already contains 24 files and the fixed marker
         destination_aoi_path.exists()
@@ -388,6 +399,14 @@ def extract_stimulus_version_number_from_asc(asc_file_path: Path) -> int:
                 return int(match.group("version_num"))
 
         return -1
+
+
+def _compute_stimulus_checksum(source_dir: Path) -> str:
+    entries = []
+    for f in sorted(source_dir.rglob("*")):
+        if f.is_file():
+            entries.append(f"{f.relative_to(source_dir)}:{f.stat().st_size}")
+    return hashlib.sha256("\n".join(entries).encode()).hexdigest()
 
 
 def parse_args():

--- a/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
+++ b/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
@@ -1,10 +1,14 @@
-import pytest
 import pandas as pd
-from preprocessing.scripts.prepare_language_folder import prepare_language_folder
+import pytest
+
 from preprocessing import settings
-from preprocessing.models.dcn import Dcn
 from preprocessing.data_collection.multipleye_data_collection import (
     MultipleyeDataCollection,
+)
+from preprocessing.models.dcn import Dcn
+from preprocessing.scripts.prepare_language_folder import (
+    _compute_stimulus_checksum,
+    prepare_language_folder,
 )
 
 
@@ -267,3 +271,128 @@ def test_prepare_language_folder_no_pt_data(
 
     # Should not raise
     prepare_language_folder(data_collection_name)
+
+
+def test_checksum_deterministic(tmp_path):
+    source = tmp_path / "stimuli"
+    source.mkdir()
+    (source / "config").mkdir()
+    (source / "config" / "a.py").write_text("x=1")
+    (source / "data.csv").write_text("col\n1\n")
+
+    assert _compute_stimulus_checksum(source) == _compute_stimulus_checksum(source)
+
+
+def test_checksum_different_content_changes_hash(tmp_path):
+    source = tmp_path / "stimuli"
+    source.mkdir()
+    f = source / "data.csv"
+    f.write_text("col\n1\n")
+
+    h1 = _compute_stimulus_checksum(source)
+    f.write_text("col\n1\n2\n")
+    h2 = _compute_stimulus_checksum(source)
+
+    assert h1 != h2
+
+
+def test_checksum_added_file_changes_hash(tmp_path):
+    source = tmp_path / "stimuli"
+    source.mkdir()
+    (source / "a.csv").write_text("x")
+
+    h1 = _compute_stimulus_checksum(source)
+    (source / "b.csv").write_text("y")
+    h2 = _compute_stimulus_checksum(source)
+
+    assert h1 != h2
+
+
+def test_checksum_removed_file_changes_hash(tmp_path):
+    source = tmp_path / "stimuli"
+    source.mkdir()
+    (source / "a.csv").write_text("x")
+    (source / "b.csv").write_text("y")
+
+    h1 = _compute_stimulus_checksum(source)
+    (source / "b.csv").unlink()
+    h2 = _compute_stimulus_checksum(source)
+
+    assert h1 != h2
+
+
+@pytest.mark.parametrize(
+    "subdirs",
+    [
+        [],
+        ["subdir"],
+    ],
+)
+def test_checksum_no_files_returns_64_char_hex(tmp_path, subdirs):
+    source = tmp_path / "stimuli"
+    source.mkdir()
+    for sub in subdirs:
+        (source / sub).mkdir()
+
+    h = _compute_stimulus_checksum(source)
+
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_checksum_mtime_independent(tmp_path):
+    source = tmp_path / "stimuli"
+    source.mkdir()
+    f = source / "f.txt"
+    f.write_text("hello")
+
+    h1 = _compute_stimulus_checksum(source)
+    f.touch()
+    h2 = _compute_stimulus_checksum(source)
+
+    assert h1 == h2
+
+
+@pytest.fixture
+def first_run(mock_data_collection_factory):
+    def _run(data_collection_name):
+        tmp_path, data_collection_name, aoi_dir = mock_data_collection_factory(
+            data_collection_name
+        )
+        setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
+        prepare_language_folder(data_collection_name)
+        preprocessed_stim_dir = (
+            tmp_path
+            / "preprocessed_data"
+            / data_collection_name
+            / f"stimuli_{data_collection_name}"
+        )
+        checksum_path = preprocessed_stim_dir / ".copy_checksum"
+        return tmp_path, data_collection_name, preprocessed_stim_dir, checksum_path
+
+    return _run
+
+
+@pytest.mark.parametrize("data_collection_name", ["MultiplEYE_DA_DK_Aalborg_1_2026"])
+def test_second_run_skips_copy_when_unchanged(first_run, data_collection_name):
+    _, _, _, checksum_path = first_run(data_collection_name)
+    first_hash = checksum_path.read_text().strip()
+
+    prepare_language_folder(data_collection_name)
+
+    assert checksum_path.read_text().strip() == first_hash
+
+
+@pytest.mark.parametrize("data_collection_name", ["MultiplEYE_DA_DK_Aalborg_1_2026"])
+def test_stimulus_change_triggers_recopy(first_run, data_collection_name):
+    tmp_path, _, stim_dir, checksum_path = first_run(data_collection_name)
+    first_hash = checksum_path.read_text().strip()
+
+    stimuli_dir = (
+        tmp_path / "data" / data_collection_name / f"stimuli_{data_collection_name}"
+    )
+    (stimuli_dir / "config" / "new_version.csv").write_text("version,2")
+    prepare_language_folder(data_collection_name)
+
+    assert checksum_path.read_text().strip() != first_hash
+    assert (stim_dir / "config" / "new_version.csv").exists()


### PR DESCRIPTION
When a team uploads an updated stimulus zip (e.g. corrected CSV), stale preprocessed copies persist because `_copy_stimulus_assets` skips files that already exist.

This PR adds a manifest-based sha256 checksum at `preprocessed_stimuli/.copy_checksum`. 

- `_compute_stimulus_checksum(source_dir)` computes a sha256 hash of a sorted `relative_path:file_size` manifest of all files under the source stimulus folder. Only file path and size is used (no mtime).
- Before copying, compare the checksum of the source stimulus folder against the stored one. On mismatch (or first run), delete the entire preprocessed stimuli folder and let `_copy_stimulus_assets()` re-copy from scratch. New checksum is written. This also then lets the AOI fixes be recalculated.
- On match, no copy is needed and `prepare_language_folder` with unchanged stimuli passes quickly.

Example: The team fixes a typo in `multipleye_stimuli_experiment_DE.xlsx` and re-uploads the zip. The file has the same name but a different size, so the manifest hash changes. The pipeline detects the mismatch, wipes the stale preprocessed copy, and re-copies everything from the updated source.

This makes the need of a manual flag obsolete.

Closes #138, relates to #143.