### PR TITLE
fix: Crash in `load_gaze_data` when computing blink loss

### DIFF
--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -6,9 +6,9 @@ import re
 from pathlib import Path
 
 import polars as pl
-import yaml
-
 import pymovements as pm
+import yaml
+from pymovements import transforms
 from pymovements.events import Events
 
 from ..config import settings
@@ -89,7 +89,20 @@ def load_gaze_data(
     trial_cols = gaze.trial_columns or ["trial", "stimulus", "page"]
 
     if gaze.events is not None and not gaze.events.frame.is_empty():
-        blink_expr = gaze.measure_events_ratio("blink_eyelink", sampling_rate=sr)
+        # Use transforms.events2timeratio directly with trial_columns=None
+        # for session-level blink loss. gaze.measure_events_ratio() always
+        # passes self.trial_columns, which produces a per-row expression
+        # that crashes .item() on multi-sample DataFrames.
+        # TODO: switch back to gaze.measure_events_ratio(trial_columns=None)
+        # once https://github.com/pymovements/pymovements/issues/1673 ships.
+        blink_expr = transforms.events2timeratio(
+            events=gaze.events.frame,
+            samples=gaze.samples,
+            name="blink_eyelink",
+            time_column="time",
+            trial_columns=None,
+            sampling_rate=sr,
+        )
         gaze._measure_blink_loss_ratio = gaze.samples.select(blink_expr).item()
 
     # Clear parsed events to avoid save_raw_data crash.

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -1,8 +1,9 @@
 import polars as pl
 import pytest
-from preprocessing.io.load import load_gaze_data
-from preprocessing.data_collection.stimulus import LabConfig
+
 from preprocessing.config import settings
+from preprocessing.data_collection.stimulus import LabConfig
+from preprocessing.io.load import load_gaze_data
 from preprocessing.models.sid import Sid
 
 


### PR DESCRIPTION
`gaze.measure_events_ratio()` always passes `self.trial_columns`, which triggers a per-row expression in `events2timeratio`. Calling `.select().item()` on a multi-row DataFrame crashed with `ValueError` on sessions that have blink events (e.g. 017_DE_DE_1_ET1).

Fix: Call `transforms.events2timeratio()` directly with `trial_columns=None` for the session-level computation. A `TODO` comment references pymovements/pymovements#1673 to switch back once `measure_events_ratio` supports overriding trial columns.

Tested with real session which triggered the bug.