### PR TITLE
feat: Per-trial data loss and blink ratios in sanity check report

### DIFF
--- a/docs/guide/pipeline_stages.md
+++ b/docs/guide/pipeline_stages.md
@@ -207,7 +207,7 @@ The relevant modules are in `answers/`: `msg_parser.py`, `experiment_log_parser.
 
 **Generate quality reports at the session and dataset level.** This stage produces text
 reports on calibration quality, validation scores, data loss, fixation statistics per page,
-and logfile consistency. It also creates plots (gaze-over-stimulus, main sequence) that
+per-trial data loss, and logfile consistency. It also creates plots (gaze-over-stimulus, main sequence) that
 help spot problematic sessions visually.
 
 Session overviews and a dataset overview YAML are written to the metadata folder. The

--- a/docs/guide/sanity_check_report.md
+++ b/docs/guide/sanity_check_report.md
@@ -335,6 +335,27 @@ ratio.** Practice trials have 2 questions; main trials have 6. Stimulus names ar
 
 ---
 
+## Per-trial Data Loss
+
+**Mean per-trial data loss and blink loss ratios, plus a TSV breakdown per trial.**
+The markdown section shows the mean across all trials. The full trial-level detail is
+written to `per_trial_data_loss_{session}.tsv` in the same directory.
+
+Columns in the TSV:
+
+- `trial`, `stimulus`, `page` -- trial identifiers
+- `data_loss_ratio` -- fraction of missing samples per trial
+- `blink_loss_ratio` -- fraction of trial time lost to blinks
+- `blink_duration_ms` -- total blink duration in that trial
+- `trial_duration_ms` -- trial recording duration
+
+*Acceptable:* Per-trial data loss below 10%.
+
+*Problematic:* Individual trials exceeding 20% suggest tracking failures for that
+particular stimulus.
+
+---
+
 ## Emoji Legend
 
 **Legend block appearing at the bottom of the report after a `---` horizontal rule.**

--- a/docs/guide/sanity_check_report.md
+++ b/docs/guide/sanity_check_report.md
@@ -2,14 +2,13 @@
 
 # Sanity Check Report
 
-**The sanity check report is a per-session markdown file produced by
-{ref}`preprocessing_step_11`.** It is written to the session results directory as
+**The sanity check report is a per-session markdown file produced by {ref}`preprocessing_step_11`.**
+It is written to the session results directory as
 `{session}_{city}_report.md`. This page describes every output field in the report, grouped by
 section. Each field entry explains what the value means, what an example looks like, what the
 acceptable range is, and what values signal a problem. Where code-configured thresholds exist, the
-configuration key is noted.
-Finally in {ref}`reading-the-sanity-report`, there are important takeaways on how to interpret the
-report.
+configuration key is noted. Finally in {ref}`reading-the-sanity-report`, there are important
+takeaways on how to interpret the report.
 
 ---
 
@@ -39,15 +38,15 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
   session or host-PC issues.
 
 - **Number of validations:** The actual number of validations performed. A validation must be
-  performed before every trial (one may be omitted between the two practice trials), plus one at
-  the end of the session. Fewer than 12 is unacceptable.
+  performed before every trial (one may be omitted between the two practice trials), plus one at the
+  end of the session. Fewer than 12 is unacceptable.
 
   *Example:* `23`
 
   *Acceptable:* 13–30 (`ACCEPTABLE_NUM_VALIDATION`).
 
-  *Problematic:* Fewer than 12 means trials ran without validation, so calibration quality cannot
-  be assessed for those trials.
+  *Problematic:* Fewer than 12 means trials ran without validation, so calibration quality cannot be
+  assessed for those trials.
 
 - **AVG validation scores:** Comma-separated list of average validation error scores, one per
   validation. The average angular error across all grid points, visible to the experimenter on the
@@ -59,10 +58,10 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
 
   *Problematic:* Consistently above 0.3 means recalibration was needed but skipped.
 
-- **MAX validation scores:** Comma-separated list of maximum validation error scores per
-  validation. High max scores indicate poor accuracy at certain grid points even if the average
-  was acceptable. If the plots show gaze drift or misalignment, whilst having a good average score the max score
-  is another indicator of calibration quality an can point to one very badly calibrated area.
+- **MAX validation scores:** Comma-separated list of maximum validation error scores per validation.
+  High max scores indicate poor accuracy at certain grid points even if the average was acceptable.
+  If the plots show gaze drift or misalignment, whilst having a good average score the max score is
+  another indicator of calibration quality an can point to one very badly calibrated area.
 
   *Example:* `1.15, 0.46, 0.87, 0.61, 0.68, 0.86, ...`
 
@@ -71,19 +70,19 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
   *Problematic:* Values above 1.5 mean the eye-tracker lost accuracy at certain positions.
 
 - **Tracked eye:** The eye reported as tracked by the eye-tracker. Should stay the same across
-  trials. May mismatch if experimenter change the tracked eye during session, has to be checked if documented.
-  critical if not.
+  trials. May mismatch if experimenter change the tracked eye during session, has to be checked if
+  documented. critical if not.
 
   *Example:* `R`
 
   *Acceptable:* `L`, `R`, `LEFT`, `RIGHT`.
 
-  *Problematic:* Inconsistent with validation tracked eyes or a value outside the accepted set. Both indicates a
-  set-up issue and have to be checked if documented, if not this is a critical issue and the session has to be discarded.
+  *Problematic:* Inconsistent with validation tracked eyes or a value outside the accepted set. Both
+  indicates a set-up issue and have to be checked if documented, if not this is a critical issue and
+  the session has to be discarded.
 
-- **Validation tracked eyes:** Comma-separated list of which eye was tracked during each
-  validation. Each entry corresponds to one validation event. All should match the tracked eye
-  value above.
+- **Validation tracked eyes:** Comma-separated list of which eye was tracked during each validation.
+  Each entry corresponds to one validation event. All should match the tracked eye value above.
 
   *Example:* `right, right, right, right, ...` (23 entries)
 
@@ -101,8 +100,8 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
 
   *Problematic:* Above 2% is a warning signal. Above 10% is substantial.
 
-- **Data loss ratio due to blinks:** Proportion of samples lost to blinks specifically. Should be
-  a fraction of total data loss; discrepancies suggest non-blink sources of missing data.
+- **Data loss ratio due to blinks:** Proportion of samples lost to blinks specifically. Should be a
+  fraction of total data loss; discrepancies suggest non-blink sources of missing data.
 
   *Example:* `1.065%`
 
@@ -110,18 +109,17 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
 
   *Problematic:* Above 2% or exceeding total data loss ratio.
 
-- **Total recording duration:** Time from the first trial's start message to the last question's
-  end message, reported in minutes.
+- **Total recording duration:** Time from the first trial's start message to the last question's end
+  message, reported in minutes.
 
   *Example:* `50.56`
 
   *Acceptable:* 600–7200 seconds (`ACCEPTABLE_RECORDING_DURATIONS`).
 
-  *Problematic:* <10 minutes = incomplete session. >120 minutes = extended pauses or host-PC
-  issues.
+  *Problematic:* <10 minutes = incomplete session. >120 minutes = extended pauses or host-PC issues.
 
-- **Sampling rate:** Measured sampling frequency of the eye-tracker hardware. Expected 1000 Hz
-  for MultiplEYE core data collection.
+- **Sampling rate:** Measured sampling frequency of the eye-tracker hardware. Expected 1000 Hz for
+  MultiplEYE core data collection.
 
   *Example:* `1000.0`
 
@@ -135,17 +133,19 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
 
 **Checks that all stimulus pages, questions, and rating screens are recorded in the experiment
 logfile.** For each stimulus, verifies that the logfile contains entries for every page, every
-comprehension question, and every rating screen defined in the stimulus configuration. Missing
-items are reported as bullet entries; an empty section means everything is present.
+comprehension question, and every rating screen defined in the stimulus configuration. Missing items
+are reported as bullet entries; an empty section means everything is present.
 
 *Example:* (empty -- entries only appear on failure)
 
 *Acceptable:* Empty section (no missing entries).
 
-*Problematic:* Missing pages are most critical, check if the corresponding page is also missing in the asc file.
-If the message is also missing in the asc file and no lost message msg is present in the report, the experiment did no run correctly.
-Missing pages means no gaze data for that stimulus, because the respective page was never shown to the participant.
-This indicates a serious issue with the experiment and should be reported to the experimenter immediately and has to be fixed before further data collection.
+*Problematic:* Missing pages are most critical, check if the corresponding page is also missing in
+the asc file. If the message is also missing in the asc file and no lost message msg is present in
+the report, the experiment did no run correctly. Missing pages means no gaze data for that stimulus,
+because the respective page was never shown to the participant. This indicates a serious issue with
+the experiment and should be reported to the experimenter immediately and has to be fixed before
+further data collection.
 
 
 ---
@@ -160,18 +160,18 @@ and ratings per stimulus. Only failures are reported.
 
 *Acceptable:* Empty section (all screens present in ASC).
 
-*Problematic:* If no lost message msg is present in the report, this means the experiment did no run correctly.
-Missing pages means no gaze data for that stimulus, because the respective page was never shown to the participant.
-This indicates a serious issue with the experiment and should be reported to the experimenter
-It has to be fixed before further data collection.
+*Problematic:* If no lost message msg is present in the report, this means the experiment did no run
+correctly. Missing pages means no gaze data for that stimulus, because the respective page was never
+shown to the participant. This indicates a serious issue with the experiment and should be reported
+to the experimenter It has to be fixed before further data collection.
 
 ---
 
 ## ASC Messages
 
-**Analyses messages embedded in the ASC file to report trial durations, one-time screens,
-optional screens, breaks, and recalibrations.** Output varies by sub-check; most failures produce
-bullet entries.
+**Analyses messages embedded in the ASC file to report trial durations, one-time screens, optional
+screens, breaks, and recalibrations.** Output varies by sub-check; most failures produce bullet
+entries.
 
 ### Trial durations
 
@@ -200,9 +200,10 @@ and `stop_recording`.
 
 *Acceptable:* Empty (all expected messages present).
 
-*Problematic:* Any missing pattern disrupts gaze-to-stimulus alignment.
-This indicates a serious issue with the experiment and should be reported to the experimenter immediately.
-It has to be fixed before further data collection.
+*Problematic:* Any missing pattern disrupts gaze-to-stimulus alignment. This indicates a serious
+issue with the experiment and should be reported to the experimenter immediately. It has to be fixed
+before further data collection.
+
 ### One-time screens
 
 Checks that all one-time experiment screens appear in the ASC file. Screens checked include:
@@ -253,9 +254,9 @@ Checks that the three rating screens are present: `showing_subject_difficulty_sc
 
 ## Validation & Calibration
 
-**A chronological timeline of validations and stimulus boundaries, followed by a structured
-summary of validation quality.** Uses thresholds: Good (<0.305), Moderate (0.305–<0.45), Bad
-(≥0.45). Configured in code, not via config keys.
+**A chronological timeline of validations and stimulus boundaries, followed by a structured summary
+of validation quality.** Uses thresholds: Good (<0.305), Moderate (0.305–<0.45), Bad (≥0.45).
+Configured in code, not via config keys.
 
 ### Per-trial timeline
 
@@ -295,11 +296,11 @@ Bad validations: 3/23
   validation, meaning the experimenter did not recalibrate before running the trial.
 - **Missing calibrations after bad/moderate validations** -- ⚠️ Bad or moderate validations not
   followed by a recalibration.
-- **Necessary calibrations after bad validations** -- ✅ Forced recalibrations performed after a
-  bad validation.
+- **Necessary calibrations after bad validations** -- ✅ Forced recalibrations performed after a bad
+  validation.
 - **No validation before stimulus start** -- ⚠️ A trial started with no prior validation at all.
-- **Validation/calibration during stimulus presentation** -- ⚠️ A validation or calibration
-  occurred while a stimulus was running, meaning the experimenter interrupted a trial.
+- **Validation/calibration during stimulus presentation** -- ⚠️ A validation or calibration occurred
+  while a stimulus was running, meaning the experimenter interrupted a trial.
 - **Bad validations** -- Individual listing (❌) of all bad validations with scores.
 - **Moderate validations** -- Individual listing (⚠️) of all moderate validations with scores.
 - **Final validation** -- `✅ Final validation` if present, `❌ No final validation!` if missing.
@@ -328,8 +329,9 @@ ratio.** Practice trials have 2 questions; main trials have 6. Stimulus names ar
 
 *Acceptable:* >35% overall.
 
-*Alarming:* 25% - 35% overall, suggest random guessing or disengagement with the task, as this is around the expected
- accuracy for random guessing (1/64 = 0.25). Stimuli with 0 correct answers warrant manual review.
+*Alarming:* 25% - 35% overall, suggest random guessing or disengagement with the task, as this is
+around the expected accuracy for random guessing (1/64 = 0.25). Stimuli with 0 correct answers
+warrant manual review.
 
 *Problematic:* Below 25% suggests disengagement, as this value is even below randomly guessing.
 
@@ -338,21 +340,21 @@ ratio.** Practice trials have 2 questions; main trials have 6. Stimulus names ar
 ## Per-trial Data Loss
 
 **Mean per-trial data loss and blink loss ratios, plus a TSV breakdown per trial.**
-The markdown section shows the mean across all trials. The full trial-level detail is
-written to `per_trial_data_loss_{session}.tsv` in the same directory.
+The markdown section shows the mean across all trials. The full trial-level detail is written to
+`per_trial_data_loss_{session}.tsv` in the same directory.
 
 Columns in the TSV:
 
-- `trial`, `stimulus`, `page` -- trial identifiers
-- `data_loss_ratio` -- fraction of missing samples per trial
-- `blink_loss_ratio` -- fraction of trial time lost to blinks
-- `blink_duration_ms` -- total blink duration in that trial
-- `trial_duration_ms` -- trial recording duration
+- `trial`, `stimulus`, `page`: trial identifiers
+- `data_loss_ratio`: fraction of missing samples per trial
+- `blink_loss_ratio`: fraction of trial time lost to blinks
+- `blink_duration_ms`: total blink duration in that trial
+- `trial_duration_ms`: trial recording duration
 
 *Acceptable:* Per-trial data loss below 10%.
 
-*Problematic:* Individual trials exceeding 20% suggest tracking failures for that
-particular stimulus.
+*Problematic:* Individual trials exceeding 20% suggest tracking failures for that particular
+stimulus.
 
 ---
 
@@ -369,8 +371,8 @@ particular stimulus.
 
 | Emoji | Meaning | Usage                                                                                                                                                                                  |
 |-------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `✅`   | Pass    | Metadata in range; good validation; necessary calibration found; final validation present                                                                                              |
-| `❌`   | Fail    | Stimulus after bad validation; bad validation score; calibration after last stimulus; no final validation                                                                              |
+| `✅`  | Pass    | Metadata in range; good validation; necessary calibration found; final validation present                                                                                              |
+| `❌`  | Fail    | Stimulus after bad validation; bad validation score; calibration after last stimulus; no final validation                                                                              |
 | `⚠️`  | Warning | Moderate validation; start after moderate validation; missing calibration after bad; no validation before start; validation/calibration during stimulus; post-last-stimulus validation |
 
 ---
@@ -379,55 +381,57 @@ particular stimulus.
 
 ## Reading the report
 
-**How to interpret the report holistically rather than field-by-field.** The patterns below
-help distinguish normal sessions from problematic ones. These are heuristics, not hard rules --
-revise them as domain knowledge evolves.
+**How to interpret the report holistically rather than field-by-field.** The patterns below help
+distinguish normal sessions from problematic ones. These are heuristics, not hard rules -- revise
+them as domain knowledge evolves.
+
 ### Normal session
 
-A clean session typically shows: 12-15 validations, mostly good (score <0.305), no bad
-validations, data loss under 2%, and comprehension accuracy above 60%. Stimulus starts
-should always follow a good validation, and the final validation should be present (without an
-intervening calibration).
+A clean session typically shows: 12-15 validations, mostly good (score <0.305), no bad validations,
+data loss under 2%, and comprehension accuracy above 60%. Stimulus starts should always follow a
+good validation, and the final validation should be present (without an intervening calibration).
 
 ### Cross-field patterns
 
 - **Good scores, bad gaze overlay.** Plots can show scan-path misalignment or drift even when
   validation errors are below 0.3. This is non-obvious and should always be checked against the
-  gaze-over-stimulus plots. The validation score is an average; poor tracking at individual
-  points can still degrade reading measures. If additionally many more validations than calibrations are present,
-  this is a strong signal that the experimenter only achieved better validation score without improving calibration.
+  gaze-over-stimulus plots. The validation score is an average; poor tracking at individual points
+  can still degrade reading measures. If additionally many more validations than calibrations are
+  present, this is a strong signal that the experimenter only achieved better validation score
+  without improving calibration.
 
-- **High data loss with good validation.** If the validation score is good but data loss is
-  high, the eye-tracker had either a blind spot, visible in the plots if gaze gets always lost in the same area,
-  or it jumped between different recognized reflections for example due to the participant wearing mascara, glasses
-  or contact lenses.
+- **High data loss with good validation.** If the validation score is good but data loss is high,
+  the eye-tracker had either a blind spot, visible in the plots if gaze gets always lost in the same
+  area, or it jumped between different recognized reflections for example due to the participant
+  wearing mascara, glasses or contact lenses.
 
-- **Good validation but low comprehension scores or visible skimming/skipping in plots.** If the validation score is good but comprehension
-  accuracy is below 50% or if the plots show only few fixation per page or only on the first part of the page
-  the participant may have been distracted, fatigued, or disengaged.
+- **Good validation but low comprehension scores or visible skimming/skipping in plots.** If the
+  validation score is good but comprehension accuracy is below 50% or if the plots show only few
+  fixation per page or only on the first part of the page the participant may have been distracted,
+  fatigued, or disengaged.
 
-- **Many recalibrations + persistent data loss.** Frequent recalibrations mid-session suggest
-  the experimenter tried to improve quality. If data loss and drift remain high despite this,
-  the root cause is more likely an eye-tracker setup problem (positioning, lighting,
-  participant alignment) rather than calibration.
+- **Many recalibrations + persistent data loss.** Frequent recalibrations mid-session suggest the
+  experimenter tried to improve quality. If data loss and drift remain high despite this, the root
+  cause is more likely an eye-tracker setup problem (positioning, lighting, participant alignment)
+  rather than calibration.
 
-- **Validation errors above 0.3 without recalibration.** When a moderate or bad validation is
-  not followed by a recalibration, the subsequent trial ran with poor calibration. The
-  experimenter should have recalibrated before starting that trial.
+- **Validation errors above 0.3 without recalibration.** When a moderate or bad validation is not
+  followed by a recalibration, the subsequent trial ran with poor calibration. The experimenter
+  should have recalibrated before starting that trial.
 
-- **Lost messages.** Missing ASC message patterns (start_recording, onset, offset,
-  stop_recording) usually indicate connection issues between the host PC and presentation PC.
-  Open tasks on the host PC or an active Wi-Fi connection can interfere. Has to be resolved before further data collection.
+- **Lost messages.** Missing ASC message patterns (start_recording, onset, offset, stop_recording)
+  usually indicate connection issues between the host PC and presentation PC. Open tasks on the host
+  PC or an active Wi-Fi connection can interfere. Has to be resolved before further data collection.
 
-- **Mid-trial recalibrations.** Calibrations during stimulus presentation (flagged in the
-  summary) interrupt the participant's reading and can affect comprehension performance. They
-  should be used sparingly and only when drift becomes visible.
+- **Mid-trial recalibrations.** Calibrations during stimulus presentation (flagged in the summary)
+  interrupt the participant's reading and can affect comprehension performance. They should be used
+  sparingly and only when drift becomes visible.
 
-- **Obligatory break under 5 minutes.** A shorter break reduces participant attention and
-  readiness for the second half of the experiment, which may impact both comprehension answers
-  and data quality in later trials.
+- **Obligatory break under 5 minutes.** A shorter break reduces participant attention and readiness
+  for the second half of the experiment, which may impact both comprehension answers and data
+  quality in later trials.
 
 - **Inconsistent tracked eye.** If validation tracked eyes show a mix of left and right, the
-  eye-tracker switched the tracked eye mid-session. This suggests either a calibration issue of the participant,
-  which was mitigated by changing the tracked eye or a mistake by the experimenter, has to be documented in any case in
-  the session notes.
+  eye-tracker switched the tracked eye mid-session. This suggests either a calibration issue of the
+  participant, which was mitigated by changing the tracked eye or a mistake by the experimenter, has
+  to be documented in any case in the session notes.

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -1461,7 +1461,8 @@ class MultipleyeDataCollection:
 
         trial_cols = ["trial", "stimulus", "page"]
         if data_loss_df is not None and blink_loss_df is not None:
-            return data_loss_df.join(blink_loss_df, on=trial_cols, how="full")
+            result = data_loss_df.join(blink_loss_df, on=trial_cols, how="full")
+            return result.drop([f"{c}_right" for c in trial_cols])
         if data_loss_df is not None:
             return data_loss_df
         return blink_loss_df

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -1461,8 +1461,7 @@ class MultipleyeDataCollection:
 
         trial_cols = ["trial", "stimulus", "page"]
         if data_loss_df is not None and blink_loss_df is not None:
-            result = data_loss_df.join(blink_loss_df, on=trial_cols, how="full")
-            return result.drop([f"{c}_right" for c in trial_cols])
+            return data_loss_df.join(blink_loss_df, on=trial_cols, how="left")
         if data_loss_df is not None:
             return data_loss_df
         return blink_loss_df

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import shutil
-
 import subprocess
 import warnings
 from functools import partial
@@ -17,31 +16,34 @@ import yaml
 from polars.exceptions import ComputeError
 from tqdm import tqdm
 
-from ..models.sid import Sid
-from ..models.dcn import Dcn
-from ..config import settings
-from ..utils.data_path_utils import _ci_resolve
-from ..utils.conversion import convert_to_time_str
-from ..utils.data_collection_utils import _report_to_file
-from ..utils.logging import get_logger
-from ..checks.et_quality_checks import (
-    check_comprehension_question_answers,
-    check_metadata,
-    report_to_file_metadata as report_meta,
-    check_validation_requirements,
-)
-from ..checks.formal_experiment_checks import (
-    check_all_screens_logfile,
-    sanity_check_gaze_frame,
-    check_messages,
-)
-from ..data_collection.session import Session
-from ..data_collection.stimulus import LabConfig, Stimulus
-from ..plotting.plot import plot_gaze, plot_main_sequence
-from ..utils.fix_questionnaire_data import remap_wrong_pq_values
 from preprocessing.scripts.prepare_language_folder import (
     extract_stimulus_version_number_from_asc,
 )
+
+from ..checks.et_quality_checks import (
+    check_comprehension_question_answers,
+    check_metadata,
+    check_validation_requirements,
+)
+from ..checks.et_quality_checks import (
+    report_to_file_metadata as report_meta,
+)
+from ..checks.formal_experiment_checks import (
+    check_all_screens_logfile,
+    check_messages,
+    sanity_check_gaze_frame,
+)
+from ..config import settings
+from ..data_collection.session import Session
+from ..data_collection.stimulus import LabConfig, Stimulus
+from ..models.dcn import Dcn
+from ..models.sid import Sid
+from ..plotting.plot import plot_gaze, plot_main_sequence
+from ..utils.conversion import convert_to_time_str
+from ..utils.data_collection_utils import _report_to_file
+from ..utils.data_path_utils import _ci_resolve
+from ..utils.fix_questionnaire_data import remap_wrong_pq_values
+from ..utils.logging import get_logger
 
 
 def eyelink(method):
@@ -612,6 +614,39 @@ class MultipleyeDataCollection:
                 separator="\t",
             )
 
+            _report_to_file("## Per-trial Data Loss", report_file_path)
+            per_trial_loss = self._compute_per_trial_loss_table(session_name)
+            if per_trial_loss is not None and not per_trial_loss.is_empty():
+                num_trials = per_trial_loss.height
+                mean_data_loss = (
+                    per_trial_loss["data_loss_ratio"].mean()
+                    if "data_loss_ratio" in per_trial_loss
+                    else None
+                )
+                mean_blink_loss = (
+                    per_trial_loss["blink_loss_ratio"].mean()
+                    if "blink_loss_ratio" in per_trial_loss
+                    else None
+                )
+                if mean_data_loss is not None:
+                    _report_to_file(
+                        f"- Mean per-trial data loss: {mean_data_loss:.3f} "
+                        f"(across {num_trials} trials)",
+                        report_file_path,
+                    )
+                if mean_blink_loss is not None:
+                    _report_to_file(
+                        f"- Mean per-trial blink loss: {mean_blink_loss:.3f}",
+                        report_file_path,
+                    )
+
+                per_trial_loss.write_csv(
+                    session_results / f"per_trial_data_loss_{session_name}.tsv",
+                    separator="\t",
+                )
+            else:
+                _report_to_file("- No per-trial metrics available.", report_file_path)
+
             legend = "\n---\n\n**Legend:** ✅ Pass | ❌ Fail | ⚠️ Warning\n"
             _report_to_file(legend, report_file_path)
 
@@ -905,7 +940,6 @@ class MultipleyeDataCollection:
                     trial_ids[trial_ids.index(trial)] = f"trial_{int(trial)}"
                 except TypeError:
                     trial_ids = trial_ids
-                    pass
 
         stimulus_names = completed_stimuli["stimulus_name"].to_list()
         stimuli_trial_mapping = {
@@ -1097,7 +1131,7 @@ class MultipleyeDataCollection:
         in_break = False
 
         with open(asc_file, encoding="utf-8") as f:
-            for line in f.readlines():
+            for line in f:
                 if match := settings.MESSAGE_REGEX.match(line):
                     messages.append(match.groupdict())
                     msg = match.groupdict()["message"]
@@ -1413,6 +1447,24 @@ class MultipleyeDataCollection:
 
         # write to file
         return fixation_durations_page_avg
+
+    def _compute_per_trial_loss_table(self, session_name: str):
+        data_loss_df = getattr(
+            self.sessions[session_name], "_per_trial_data_loss", None
+        )
+        blink_loss_df = getattr(
+            self.sessions[session_name], "_per_trial_blink_loss", None
+        )
+
+        if data_loss_df is None and blink_loss_df is None:
+            return None
+
+        trial_cols = ["trial", "stimulus", "page"]
+        if data_loss_df is not None and blink_loss_df is not None:
+            return data_loss_df.join(blink_loss_df, on=trial_cols, how="full")
+        if data_loss_df is not None:
+            return data_loss_df
+        return blink_loss_df
 
     def _load_psychometric_tests(self, session_identifier: str):
         # Match the eye-tracking session to a psychometric test folder

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -6,9 +6,9 @@ import re
 from pathlib import Path
 
 import polars as pl
-import yaml
-
 import pymovements as pm
+import yaml
+from pymovements import transforms
 from pymovements.events import Events
 
 from ..config import settings
@@ -89,7 +89,20 @@ def load_gaze_data(
     trial_cols = gaze.trial_columns or ["trial", "stimulus", "page"]
 
     if gaze.events is not None and not gaze.events.frame.is_empty():
-        blink_expr = gaze.measure_events_ratio("blink_eyelink", sampling_rate=sr)
+        # Use transforms.events2timeratio directly with trial_columns=None
+        # for session-level blink loss. gaze.measure_events_ratio() always
+        # passes self.trial_columns, which produces a per-row expression
+        # that crashes .item() on multi-sample DataFrames.
+        # TODO: switch back to gaze.measure_events_ratio(trial_columns=None)
+        # once https://github.com/pymovements/pymovements/issues/1673 ships.
+        blink_expr = transforms.events2timeratio(
+            events=gaze.events.frame,
+            samples=gaze.samples,
+            name="blink_eyelink",
+            time_column="time",
+            trial_columns=None,
+            sampling_rate=sr,
+        )
         gaze._measure_blink_loss_ratio = gaze.samples.select(blink_expr).item()
 
     # Clear parsed events to avoid save_raw_data crash.

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -105,6 +105,37 @@ def load_gaze_data(
         )
         gaze._measure_blink_loss_ratio = gaze.samples.select(blink_expr).item()
 
+        blink_events = gaze.events.frame.filter(pl.col("name").str.contains("blink"))
+        if not blink_events.is_empty():
+            per_trial_blink = blink_events.group_by(trial_cols).agg(
+                pl.col("duration").sum().alias("blink_duration_ms")
+            )
+            per_trial_sample_count = gaze.samples.group_by(trial_cols).agg(
+                pl.len().alias("sample_count")
+            )
+            gaze._per_trial_blink_loss = (
+                per_trial_blink.join(per_trial_sample_count, on=trial_cols, how="right")
+                .with_columns(
+                    (
+                        pl.col("blink_duration_ms").fill_null(0)
+                        / (pl.col("sample_count") * 1000.0 / sr)
+                    ).alias("blink_loss_ratio")
+                )
+                .with_columns(
+                    (pl.col("sample_count") * 1000.0 / sr).alias("trial_duration_ms")
+                )
+                .select(
+                    [
+                        *trial_cols,
+                        "blink_loss_ratio",
+                        "blink_duration_ms",
+                        "trial_duration_ms",
+                    ]
+                )
+            )
+        else:
+            gaze._per_trial_blink_loss = None
+
     # Clear parsed events to avoid save_raw_data crash.
     gaze.events = Events(
         data=pl.DataFrame(

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -1,17 +1,17 @@
+import contextlib
 import os
 from argparse import ArgumentParser
 
-from tqdm import tqdm
 import polars as pl
 import pymovements as pm
+from tqdm import tqdm
 
-from ..utils.logging import get_logger
 import preprocessing
 from preprocessing import settings
-
-from preprocessing.scripts.prepare_language_folder import prepare_language_folder
 from preprocessing.checks.quality_thresholds import write_quality_thresholds
-import contextlib
+from preprocessing.scripts.prepare_language_folder import prepare_language_folder
+
+from ..utils.logging import get_logger
 
 
 def run_preprocessing(config_path: str | None = None):
@@ -127,6 +127,11 @@ def run_preprocessing(config_path: str | None = None):
                 pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio")
             ).item()
 
+            # Compute per-trial data loss
+            gaze._per_trial_data_loss = gaze.samples.group_by(gaze.trial_columns).agg(
+                pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio")
+            )
+
             preprocessing.save_raw_data(sess.sid, gaze)
             preprocessing.save_session_metadata(sess.sid, gaze)
 
@@ -145,6 +150,8 @@ def run_preprocessing(config_path: str | None = None):
             "_measure_blink_loss_ratio",
             None,
         )
+        sess._per_trial_data_loss = getattr(gaze, "_per_trial_data_loss", None)
+        sess._per_trial_blink_loss = getattr(gaze, "_per_trial_blink_loss", None)
 
         # preprocess gaze data
         pbar.set_description(f"Preprocessing samples {sess.sid}:")

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -88,7 +88,8 @@ def run_preprocessing(config_path: str | None = None):
 
         # create or load raw data
         raw_data_folder = sess.sid.raw_data_dir
-        if raw_data_folder.exists() and not settings.OVERWRITE:
+        metadata_exists = (sess.sid.metadata_dir / "gaze_metadata.json").exists()
+        if raw_data_folder.exists() and not settings.OVERWRITE and metadata_exists:
             # check if the folder contains the expected number of files, if not, we will overwrite
             num_expected_files = len(sess.completed_stimuli_ids)
             num_files = len(list(raw_data_folder.glob("*.csv")))

--- a/tests/unit/preprocessing/data_collection/test_per_trial_loss.py
+++ b/tests/unit/preprocessing/data_collection/test_per_trial_loss.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+
+import polars as pl
+
+from preprocessing.data_collection.multipleye_data_collection import (
+    MultipleyeDataCollection,
+)
+from preprocessing.data_collection.session import Session
+
+
+def _make_session():
+    return Session(
+        participant_id=1,
+        session_identifier="001_EN_UK_1_ET1",
+        is_pilot=False,
+        session_folder_path=Path("/tmp"),
+        session_file_path=Path("/tmp/test.log"),
+        session_file_name="test.log",
+    )
+
+
+def _make_mdc(session):
+    mdc = MultipleyeDataCollection.__new__(MultipleyeDataCollection)
+    mdc.sessions = {"001_EN_UK_1_ET1": session}
+    return mdc
+
+
+TRIAL_COLS = ["trial", "stimulus", "page"]
+
+
+def test_compute_per_trial_loss_table_both_available():
+    session = _make_session()
+    session._per_trial_data_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_2"],
+            "stimulus": ["Enc_WikiMoon_1", "Lit_MagicMountain_6"],
+            "page": ["page_1", "page_1"],
+            "data_loss_ratio": [0.05, 0.12],
+        }
+    )
+    session._per_trial_blink_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_2"],
+            "stimulus": ["Enc_WikiMoon_1", "Lit_MagicMountain_6"],
+            "page": ["page_1", "page_1"],
+            "blink_loss_ratio": [0.02, 0.03],
+            "blink_duration_ms": [100.0, 150.0],
+            "trial_duration_ms": [5000.0, 5000.0],
+        }
+    )
+
+    mdc = _make_mdc(session)
+    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+
+    assert result is not None
+    assert result.height == 2
+    assert "data_loss_ratio" in result.columns
+    assert "blink_loss_ratio" in result.columns
+    assert result["data_loss_ratio"].to_list() == [0.05, 0.12]
+    assert result["blink_loss_ratio"].to_list() == [0.02, 0.03]
+
+
+def test_compute_per_trial_loss_table_data_loss_only():
+    session = _make_session()
+    session._per_trial_data_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1"],
+            "stimulus": ["Enc_WikiMoon_1"],
+            "page": ["page_1"],
+            "data_loss_ratio": [0.05],
+        }
+    )
+    session._per_trial_blink_loss = None
+
+    mdc = _make_mdc(session)
+    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+
+    assert result is not None
+    assert result.height == 1
+    assert "data_loss_ratio" in result.columns
+    assert "blink_loss_ratio" not in result.columns
+
+
+def test_compute_per_trial_loss_table_blink_loss_only():
+    session = _make_session()
+    session._per_trial_data_loss = None
+    session._per_trial_blink_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1"],
+            "stimulus": ["Enc_WikiMoon_1"],
+            "page": ["page_1"],
+            "blink_loss_ratio": [0.02],
+            "blink_duration_ms": [100.0],
+            "trial_duration_ms": [5000.0],
+        }
+    )
+
+    mdc = _make_mdc(session)
+    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+
+    assert result is not None
+    assert result.height == 1
+    assert "data_loss_ratio" not in result.columns
+    assert "blink_loss_ratio" in result.columns
+
+
+def test_compute_per_trial_loss_table_none_available():
+    session = _make_session()
+    session._per_trial_data_loss = None
+    session._per_trial_blink_loss = None
+
+    mdc = _make_mdc(session)
+    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+
+    assert result is None
+
+
+def test_compute_per_trial_loss_table_handles_missing_trials():
+    session = _make_session()
+    session._per_trial_data_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_2"],
+            "stimulus": ["Enc_WikiMoon_1", "Lit_MagicMountain_6"],
+            "page": ["page_1", "page_2"],
+            "data_loss_ratio": [0.05, 0.12],
+        }
+    )
+    session._per_trial_blink_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1"],
+            "stimulus": ["Enc_WikiMoon_1"],
+            "page": ["page_1"],
+            "blink_loss_ratio": [0.02],
+            "blink_duration_ms": [100.0],
+            "trial_duration_ms": [5000.0],
+        }
+    )
+
+    mdc = _make_mdc(session)
+    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+
+    assert result is not None
+    assert result.height == 2
+    assert result["data_loss_ratio"].to_list() == [0.05, 0.12]
+    # trial_2 has no blink data, should be null
+    blink_ratios = result["blink_loss_ratio"].to_list()
+    assert blink_ratios[0] == 0.02
+    assert blink_ratios[1] is None

--- a/tests/unit/preprocessing/io/test_load.py
+++ b/tests/unit/preprocessing/io/test_load.py
@@ -1,8 +1,9 @@
 import polars as pl
 import pytest
-from preprocessing.io.load import load_gaze_data
-from preprocessing.data_collection.stimulus import LabConfig
+
 from preprocessing.config import settings
+from preprocessing.data_collection.stimulus import LabConfig
+from preprocessing.io.load import load_gaze_data
 from preprocessing.models.sid import Sid
 
 
@@ -147,3 +148,50 @@ def test_load_gaze_data_with_patterns(synthetic_asc, lab_config):
     assert not gaze.messages["content"].str.contains("page_1").any()
     # But question start should be here
     assert gaze.messages["content"].str.contains("question_6111").any()
+
+
+def test_blink_loss_ratio_is_scalar_with_trial_columns():
+    import pymovements as pm
+    from pymovements import transforms
+
+    samples = pl.DataFrame(
+        {
+            "time": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            "x": [0.0] * 6,
+            "y": [0.0] * 6,
+            "trial": ["trial_1"] * 6,
+            "stimulus": ["stim"] * 6,
+            "page": ["page_1"] * 6,
+        }
+    )
+    events = pm.Events(
+        pl.DataFrame(
+            {
+                "name": ["blink_eyelink", "blink_eyelink"],
+                "onset": [1.0, 4.0],
+                "offset": [2.0, 5.0],
+                "trial": ["trial_1", "trial_1"],
+                "stimulus": ["stim", "stim"],
+                "page": ["page_1", "page_1"],
+            }
+        ),
+        trial_columns=["trial", "stimulus", "page"],
+    )
+    gaze = pm.Gaze(
+        samples,
+        trial_columns=["trial", "stimulus", "page"],
+        pixel_columns=["x", "y"],
+    )
+    gaze.events = events
+
+    sr = 1000.0
+    expr = transforms.events2timeratio(
+        events=gaze.events.frame,
+        samples=gaze.samples,
+        name="blink_eyelink",
+        trial_columns=None,
+        sampling_rate=sr,
+    )
+    result = gaze.samples.select(expr)
+
+    assert result.height == 1


### PR DESCRIPTION
This PR adds per-trial `data_loss_ratio` and `blink_loss_ratio` to the sanity check report, plus the pipeline fixes needed to make them work.

### Changes
New per-trial metrics:

- `load_gaze_data` computes per-trial blink loss before clearing events
- `run_preprocessing` computes per-trial data loss from gaze samples grouped by trial
Sanity check writes `per_trial_data_loss_{sid}.tsv` alongside the existing `fixation_statistics_per_page` TSV
A "Per-trial Data Loss" section in the markdown report shows the mean across all trials.

### Example output

In report:
```md
- Mean per-trial data loss: 0.005 (across 206 trials)
- Mean per-trial blink loss: 0.005
```

per_trial_data_loss_000_X_X_1_ET1.tsv:
```
trial      stimulus              page                       data_loss_ratio  blink_loss_ratio  blink_duration_ms  trial_duration_ms
trial_1    Lit_MagicMountain_6   subject_difficulty_screen   0.0              0.0                                 5154.0
trial_4    PopSci_Caveman_12     page_5                      0.0              0.0                                16478.0
trial_3    Lit_Solaris_8         page_3                      0.0              0.0                                28919.0
trial_5    Arg_PISACowsMilk_10   familiarity_rating_screen_2 0.1605           0.1604              1231            7674.0
```
Closes #141.