### PR TITLE
feat: enhance DCN overview YAML with hierarchical structure

### DIFF
--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import subprocess
 import warnings
+from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
 
@@ -43,7 +44,7 @@ from ..utils.conversion import convert_to_time_str
 from ..utils.data_collection_utils import _report_to_file
 from ..utils.data_path_utils import _ci_resolve
 from ..utils.fix_questionnaire_data import remap_wrong_pq_values
-from ..utils.logging import get_logger
+from ..utils.logging import get_logger, get_pipeline_info
 
 
 def eyelink(method):
@@ -180,7 +181,19 @@ class MultipleyeDataCollection:
         if not self.overview:
             self.overview = self.create_dataset_overview()
 
-        return "\n".join(f"{k}\t{v}" for k, v in self.overview.items())
+        lines = []
+        for section_name, section in self.overview.items():
+            if isinstance(section, dict):
+                lines.append(f"[{section_name}]")
+                for k, v in section.items():
+                    lines.append(f"  {k}: {v}")
+            elif isinstance(section, list):
+                lines.append(f"[{section_name}]")
+                for item in section:
+                    lines.append(f"  - {item}")
+            else:
+                lines.append(f"{section_name}: {section}")
+        return "\n".join(lines)
 
     # TODO: check these chatgpt functions :D
     def __iter__(self):
@@ -675,16 +688,98 @@ class MultipleyeDataCollection:
             [session for session in self.sessions if self.sessions[session].is_pilot]
         )
 
-        # TODO: add more, check metadata scheme, add stats like num read pages, total reading time etc.
+        metadata_form = self._load_metadata_form()
+        metadata_form_exists = bool(metadata_form)
+
+        dataset_description = (
+            f"{self.country}, {self.city} (lab {self.lab_number}). "
+            f"{self.language} corpus. "
+            f"Data collected from {metadata_form.get('Start_date_of_data_collection', 'unknown')} "
+            f"to {metadata_form.get('End_date_of_data_collection', 'unknown')}."
+        )
+
         overview = {
-            "Title": self.data_collection_name,
-            "Dataset_type": self.type,
-            "Number_of_sessions": num_sessions,
-            "Number_of_pilots": num_pilots,
-            "Tested_language": self.language,
-            "Country": self.country,
-            "Year": self.year,
-            "Number of eye-tracking (ET) sessions per participant": self.num_sessions,
+            "Administrative": {
+                "Title": self.data_collection_name,
+                "Dataset_type": self.type,
+                "Dataset_description": dataset_description,
+                "Number_of_sessions": num_sessions,
+                "Number_of_pilots": num_pilots,
+                "Number of eye-tracking (ET) sessions per participant": (
+                    self.num_sessions
+                ),
+                "City": self.city,
+                "Lab_number": self.lab_number,
+                "Country": self.country,
+                "Tested_language": self.language,
+                "Year": self.year,
+            },
+            "Language_details": {
+                "Metadata_form_exists": metadata_form_exists,
+                "Language_script": metadata_form.get("Script"),
+                "Language_family": metadata_form.get("Language_family"),
+                "Start_date_of_data_collection": metadata_form.get(
+                    "Start_date_of_data_collection"
+                ),
+                "End_date_of_data_collection": metadata_form.get(
+                    "End_date_of_data_collection"
+                ),
+            },
+            "Data_availability": {
+                "Raw_data_available": True,
+                "Fixations_available": True,
+                "Saccades_available": True,
+                "Reading_measures_available": True,
+            },
+            "Psychometric_tests": {
+                "Tests_available": getattr(
+                    self.lab_configuration, "psychometric_tests", None
+                ),
+            },
+            "Technical_setup": {
+                "Eye_tracker_name": getattr(
+                    self.lab_configuration, "name_eye_tracker", None
+                ),
+                "Sampling_frequency_hz": getattr(
+                    self.lab_configuration, "sampling_frequency_hz", None
+                ),
+                "Monitor_name": metadata_form.get("Monitor_name"),
+                "Screen_resolution_width_px": (
+                    self.lab_configuration.screen_resolution[0]
+                    if getattr(self.lab_configuration, "screen_resolution", None)
+                    else None
+                ),
+                "Screen_resolution_height_px": (
+                    self.lab_configuration.screen_resolution[1]
+                    if getattr(self.lab_configuration, "screen_resolution", None)
+                    else None
+                ),
+            },
+            "Processing": {
+                "Preprocessing_date": datetime.now(tz=UTC).strftime("%Y-%m-%d"),
+                "Pipeline_version": self._get_pipeline_version(),
+                "Number_of_stimulus_versions": len(
+                    self.stim_order_versions["version_number"].unique()
+                )
+                if hasattr(self, "stim_order_versions")
+                and len(self.stim_order_versions) > 0
+                else 0,
+                # Flags from metadata_form.json
+                "Required_pq_fixing": metadata_form.get("Required_pq_fixing"),
+                "Psychotests_restructuring": metadata_form.get(
+                    "Psychotests_restructuring"
+                ),
+                "Custom_units_of_analysis": metadata_form.get(
+                    "Custom_units_of_analysis"
+                ),
+                "Answer_option_shuffling_bug": metadata_form.get(
+                    "Answer_option_shuffling_bug"
+                ),
+            },
+            "Data_quality": {
+                "Attrition_rate": self._compute_attrition_rate(),
+                **self._compute_dcn_averages(),
+            },
         }
 
         # Add warnings to overview
@@ -692,9 +787,211 @@ class MultipleyeDataCollection:
             overview["Warnings"] = list(set(logging._captured_warnings))
 
         with open(overview_path, "w", encoding="utf8") as f:
-            yaml.dump(overview, f)
+            yaml.dump(overview, f, sort_keys=False)
 
         return overview
+
+    @staticmethod
+    def _get_pipeline_version() -> str | None:
+        """
+        Return the installed pipeline version, or None if it cannot be determined.
+
+        Returns
+        -------
+        str | None
+            Version string from package metadata, or None on failure.
+        """
+        try:
+            version, _ = get_pipeline_info()
+            return version
+        except (ImportError, KeyError, subprocess.SubprocessError):
+            return None
+
+    def _load_metadata_form(self) -> dict:
+        """
+        Load the final metadata form JSON for this data collection, if present.
+
+        Returns
+        -------
+        dict
+            Parsed metadata form contents, or an empty dict if the file is missing.
+        """
+        lang = self.language.lower() if self.language else ""
+        country = self.country.lower() if self.country else ""
+        city = self.city.capitalize() if self.city else ""
+        labnum = self.lab_number
+        year = self.year
+
+        metadata_path = (
+            self.stimulus_dir.parent
+            / "documentation"
+            / f"MultiplEYE_{lang}_{country}_{city}_{labnum}_{year}_metadata_form.json"
+        )
+        if metadata_path.exists():
+            with open(metadata_path, encoding="utf-8") as f:
+                return json.load(f)
+        return {}
+
+    def _compute_attrition_rate(self) -> float | None:
+        """
+        Compute the session attrition rate across non-pilot sessions.
+
+        Attrition is the fraction of non-pilot sessions that crashed, rounded to
+        two decimal places.
+
+        Returns
+        -------
+        float | None
+            Crashed session ratio, or None if there are no non-pilot sessions.
+        """
+        non_pilot_sessions = [s for s in self.sessions.values() if not s.is_pilot]
+        total_sessions = len(non_pilot_sessions)
+        if total_sessions == 0:
+            return None
+        crashed = (
+            len(self.crashed_session_ids) if hasattr(self, "crashed_session_ids") else 0
+        )
+        return round(crashed / total_sessions, 2)
+
+    def _compute_dcn_averages(self) -> dict[str, float | None]:
+        """
+        Compute simple means across non-pilot sessions for the data quality fields.
+
+        Averages are unweighted means across sessions (not time-weighted). Session
+        fields that are not numeric (e.g. the string default "unknown") are skipped,
+        so a field is None when no session has a computed value for it.
+
+        Returns
+        -------
+        dict[str, float | None]
+            Mapping of metric name to mean value, or None if no data is available.
+        """
+        non_pilot_sessions = [s for s in self.sessions.values() if not s.is_pilot]
+        if not non_pilot_sessions:
+            return {
+                "mean_calibration_error": None,
+                "mean_validation_error": None,
+                "mean_data_loss_ratio": None,
+                "mean_blink_ratio": None,
+                "mean_total_reading_time_ms": None,
+                "mean_total_session_duration_s": None,
+                "mean_wpm": None,
+                "mean_comprehension_score": None,
+            }
+
+        calib_errors = [
+            s.avg_calibration_error
+            for s in non_pilot_sessions
+            if isinstance(s.avg_calibration_error, (int, float))
+        ]
+        val_errors = [
+            s.avg_validation_error
+            for s in non_pilot_sessions
+            if isinstance(s.avg_validation_error, (int, float))
+        ]
+        data_loss = [
+            getattr(s, "_measure_total_data_loss_ratio", None)
+            for s in non_pilot_sessions
+        ]
+        data_loss = [v for v in data_loss if isinstance(v, (int, float))]
+        blink_loss = [
+            getattr(s, "_measure_blink_loss_ratio", None) for s in non_pilot_sessions
+        ]
+        blink_loss = [v for v in blink_loss if isinstance(v, (int, float))]
+        reading_times = [
+            s.total_reading_time
+            for s in non_pilot_sessions
+            if isinstance(s.total_reading_time, (int, float))
+        ]
+        session_durations = [
+            s.total_session_duration
+            for s in non_pilot_sessions
+            if isinstance(s.total_session_duration, (int, float))
+        ]
+        comp_scores = [
+            s.avg_comprehension_score
+            for s in non_pilot_sessions
+            if isinstance(s.avg_comprehension_score, (int, float))
+        ]
+
+        # WPM: total words / total_minutes
+        # Word count computed from stimulus page texts
+        mean_wpm = None
+        if reading_times:
+            total_reading_s = sum(reading_times) / 1000  # ms to seconds
+            if total_reading_s > 0:
+                mean_wpm = self._compute_dcn_wpm(non_pilot_sessions, total_reading_s)
+
+        return {
+            "mean_calibration_error": (
+                round(sum(calib_errors) / len(calib_errors), 2)
+                if calib_errors
+                else None
+            ),
+            "mean_validation_error": (
+                round(sum(val_errors) / len(val_errors), 2) if val_errors else None
+            ),
+            "mean_data_loss_ratio": (
+                round(sum(data_loss) / len(data_loss), 2) if data_loss else None
+            ),
+            "mean_blink_ratio": (
+                round(sum(blink_loss) / len(blink_loss), 2) if blink_loss else None
+            ),
+            "mean_total_reading_time_ms": (
+                round(sum(reading_times) / len(reading_times), 2)
+                if reading_times
+                else None
+            ),
+            "mean_total_session_duration_s": (
+                round(sum(session_durations) / len(session_durations), 2)
+                if session_durations
+                else None
+            ),
+            "mean_wpm": round(mean_wpm, 1) if mean_wpm else None,
+            "mean_comprehension_score": (
+                round(sum(comp_scores) / len(comp_scores), 2) if comp_scores else None
+            ),
+        }
+
+    def _compute_dcn_wpm(
+        self,
+        non_pilot_sessions: list,
+        total_reading_seconds: float,
+    ) -> float | None:
+        """
+        Compute words per minute across non-pilot sessions.
+
+        Word count is derived from the stimulus page texts; total words divided by
+        total reading time in minutes.
+
+        Parameters
+        ----------
+        non_pilot_sessions : list
+            Non-pilot Session objects to aggregate.
+        total_reading_seconds : float
+            Total reading time across those sessions, in seconds.
+
+        Returns
+        -------
+        float | None
+            Words per minute, or None if no words or no reading time is available.
+        """
+        total_words = 0
+        for session in non_pilot_sessions:
+            if not isinstance(session.stimuli, list):
+                continue
+            for stim in session.stimuli:
+                if not hasattr(stim, "pages"):
+                    continue
+                for page in stim.pages:
+                    if hasattr(page, "text") and page.text:
+                        total_words += len(page.text.split())
+        if total_words == 0:
+            return None
+        total_minutes = total_reading_seconds / 60
+        if total_minutes <= 0:
+            return None
+        return total_words / total_minutes
 
     def create_session_overview(self, session_idf: str, path: str | Path = "") -> dict:
         sess = self.sessions[session_idf]

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -712,7 +712,6 @@ class MultipleyeDataCollection:
                 "Lab_number": self.lab_number,
                 "Country": self.country,
                 "Tested_language": self.language,
-                "Year": self.year,
             },
             "Language_details": {
                 "Metadata_form_exists": metadata_form_exists,

--- a/review_app/services/dcn.py
+++ b/review_app/services/dcn.py
@@ -6,9 +6,9 @@ from preprocessing.models import Dcn
 
 from ..config import PREPROCESSED_DATA_DIR, RAW_DATA_DIR
 from ..models import DcnSummary, SessionSummary
-from .review import load_review
-from .session_data import read_overview, compute_checks
 from .preflight import run_pipeline_preflight
+from .review import load_review
+from .session_data import compute_checks, read_overview
 
 
 def _discover_dcn_names() -> set[str]:
@@ -59,7 +59,7 @@ def _build_dcn_summary(dcn: Dcn) -> DcnSummary:
     if ov_path.exists():
         with open(ov_path) as f:
             dcn_overview = yaml.safe_load(f) or {}
-        dcn_type = dcn_overview.get("Dataset_type", "")
+        dcn_type = dcn_overview.get("Administrative", {}).get("Dataset_type", "")
 
     sessions = list_sessions(dcn_name) if is_processed else []
 

--- a/tests/unit/preprocessing/data_collection/test_dcn_overview.py
+++ b/tests/unit/preprocessing/data_collection/test_dcn_overview.py
@@ -149,7 +149,6 @@ class TestAdministrative:
         assert a["Dataset_type"] == "MultiplEYE"
         assert a["Tested_language"] == "EN"
         assert a["Country"] == "UK"
-        assert a["Year"] == 2025
         assert a["City"] == "London"
         assert a["Lab_number"] == 1
 

--- a/tests/unit/preprocessing/data_collection/test_dcn_overview.py
+++ b/tests/unit/preprocessing/data_collection/test_dcn_overview.py
@@ -1,0 +1,437 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+import yaml
+
+from preprocessing.data_collection.multipleye_data_collection import (
+    MultipleyeDataCollection,
+)
+from preprocessing.data_collection.session import Session
+
+
+def _mock_lab_config():
+    cfg = MagicMock()
+    cfg.screen_resolution = (1920, 1080)
+    cfg.screen_size_cm = (52.0, 32.0)
+    cfg.screen_distance_cm = 60.0
+    cfg.image_resolution = (1322, 980)
+    cfg.image_size_cm = (38.0, 28.3)
+    cfg.name_eye_tracker = "EyeLink 1000 Plus"
+    cfg.sampling_frequency_hz = 1000.0
+    cfg.psychometric_tests = ["TestA", "TestB"]
+    return cfg
+
+
+@pytest.fixture
+def dummy_dcn_dir(tmp_path: Path) -> Path:
+    """Create a dummy data collection folder structure with sessions."""
+    collection_name = "MultiplEYE_EN_UK_London_1_2025"
+    data_dir = tmp_path / collection_name
+    data_dir.mkdir()
+
+    et_sessions_dir = data_dir / "eye-tracking-sessions"
+    et_sessions_dir.mkdir()
+    (data_dir / "psychometric-tests").mkdir()
+    stimuli_dir = data_dir / f"stimuli_{collection_name}"
+    stimuli_dir.mkdir()
+    config_dir = stimuli_dir / "config"
+    config_dir.mkdir()
+
+    df = pd.DataFrame({"participant_id": [1, 2, 3], "version_number": [1, 1, 1]})
+    df.to_csv(config_dir / "stimulus_order_versions_EN_UK_1.csv", index=False)
+
+    for s_id in ["001_EN_UK_1_ET1", "002_EN_UK_1_ET1", "003_EN_UK_1_ET1"]:
+        s_path = et_sessions_dir / s_id
+        s_path.mkdir()
+        (s_path / "data.edf").touch()
+
+    return data_dir
+
+
+@pytest.fixture
+def mock_load_lab_config(monkeypatch):
+    """Mock load_lab_config to return a mock config."""
+
+    class MockLabConfig:
+        def __init__(self):
+            self.name_eye_tracker = "EyeLink 1000 Plus"
+            self.psychometric_tests = ["TestA", "TestB"]
+            self.screen_resolution = (1920, 1080)
+            self.sampling_frequency_hz = 1000.0
+            self.screen_size_cm = (52.0, 32.0)
+            self.screen_distance_cm = 60.0
+            self.image_resolution = (1322, 980)
+            self.image_size_cm = (38.0, 28.3)
+
+    monkeypatch.setattr(
+        MultipleyeDataCollection,
+        "load_lab_config",
+        lambda *args, **kwargs: MockLabConfig(),
+    )
+
+
+@pytest.fixture
+def mock_pipeline_version(monkeypatch):
+    monkeypatch.setattr(
+        MultipleyeDataCollection,
+        "_get_pipeline_version",
+        lambda self: "2026.08.11",
+    )
+
+
+def _create_dc(dummy_dcn_dir: Path, **kwargs) -> MultipleyeDataCollection:
+    """Factory to create a MultipleyeDataCollection with dummy data."""
+    return MultipleyeDataCollection.create_from_data_folder(dummy_dcn_dir, **kwargs)
+
+
+def _setup_session_with_data(
+    session: Session,
+    avg_calibration_error: float = 0.5,
+    avg_validation_error: float = 0.3,
+    total_data_loss: float = 0.02,
+    blink_loss: float = 0.01,
+    total_reading_time: float = 25000.0,
+    total_session_duration: float = 1800.0,
+    avg_comprehension: float = 0.8,
+    num_completed_trials: int = 10,
+) -> None:
+    session.avg_calibration_error = avg_calibration_error
+    session.avg_validation_error = avg_validation_error
+    session._measure_total_data_loss_ratio = total_data_loss
+    session._measure_blink_loss_ratio = blink_loss
+    session.total_reading_time = total_reading_time
+    session.total_session_duration = total_session_duration
+    session.avg_comprehension_score = avg_comprehension
+    session.num_completed_trials = num_completed_trials
+
+
+def _admin(overview: dict) -> dict:
+    return overview["Administrative"]
+
+
+def _lang(overview: dict) -> dict:
+    return overview["Language_details"]
+
+
+def _avail(overview: dict) -> dict:
+    return overview["Data_availability"]
+
+
+def _psych(overview: dict) -> dict:
+    return overview["Psychometric_tests"]
+
+
+def _tech(overview: dict) -> dict:
+    return overview["Technical_setup"]
+
+
+def _proc(overview: dict) -> dict:
+    return overview["Processing"]
+
+
+def _qual(overview: dict) -> dict:
+    return overview["Data_quality"]
+
+
+class TestAdministrative:
+    def test_legacy_fields_preserved(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        a = _admin(overview)
+
+        assert a["Title"] == "MultiplEYE_EN_UK_London_1_2025"
+        assert a["Dataset_type"] == "MultiplEYE"
+        assert a["Tested_language"] == "EN"
+        assert a["Country"] == "UK"
+        assert a["Year"] == 2025
+        assert a["City"] == "London"
+        assert a["Lab_number"] == 1
+
+    def test_dataset_description(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        a = _admin(overview)
+
+        assert "London" in a["Dataset_description"]
+        assert "EN" in a["Dataset_description"]
+
+    def test_session_counts(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        a = _admin(overview)
+
+        assert a["Number_of_sessions"] == 3
+        assert a["Number_of_pilots"] == 0
+        assert "Number of eye-tracking (ET) sessions per participant" in a
+
+
+class TestProcessing:
+    def test_processing_metadata(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        p = _proc(overview)
+
+        assert p["Pipeline_version"] == "2026.08.11"
+        assert p["Preprocessing_date"] == datetime.now(tz=UTC).strftime("%Y-%m-%d")
+
+
+class TestTechnicalSetup:
+    def test_technical_setup(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        t = _tech(overview)
+
+        assert t["Eye_tracker_name"] == "EyeLink 1000 Plus"
+        assert t["Sampling_frequency_hz"] == 1000.0
+        assert t["Screen_resolution_width_px"] == 1920
+        assert t["Screen_resolution_height_px"] == 1080
+
+    def test_psychometric_tests(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        p = _psych(overview)
+
+        assert p["Tests_available"] == ["TestA", "TestB"]
+
+
+class TestYAMLOutput:
+    def test_yaml_output_is_valid(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        dc.create_dataset_overview(path=dummy_dcn_dir)
+        yaml_path = dummy_dcn_dir / "MultiplEYE_EN_UK_London_1_2025_overview.yaml"
+        assert yaml_path.exists()
+
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+        assert data["Administrative"]["Title"] == "MultiplEYE_EN_UK_London_1_2025"
+
+    def test_sections_ordered(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+
+        keys = list(overview.keys())
+        assert keys[0] == "Administrative"
+        assert keys[1] == "Language_details"
+        assert keys[2] == "Data_availability"
+        assert keys[3] == "Psychometric_tests"
+        assert keys[4] == "Technical_setup"
+        assert keys[5] == "Processing"
+        assert keys[6] == "Data_quality"
+
+
+class TestDataAvailability:
+    def test_all_formats_hardcoded_true(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        a = _avail(overview)
+
+        assert a["Raw_data_available"] is True
+        assert a["Fixations_available"] is True
+        assert a["Saccades_available"] is True
+        assert a["Reading_measures_available"] is True
+
+
+class TestComputedAverages:
+    def test_none_with_unprocessed_sessions(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        q = _qual(overview)
+
+        assert q["mean_calibration_error"] is None
+        assert q["mean_validation_error"] is None
+        assert q["mean_data_loss_ratio"] is None
+        assert q["mean_blink_ratio"] is None
+        assert q["mean_total_reading_time_ms"] is None
+        assert q["mean_comprehension_score"] is None
+
+    def test_averages_with_multiple_sessions(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        _setup_session_with_data(
+            dc.sessions["001_EN_UK_1_ET1"],
+            avg_calibration_error=0.5,
+            avg_validation_error=0.3,
+            total_data_loss=0.02,
+            blink_loss=0.01,
+        )
+        _setup_session_with_data(
+            dc.sessions["002_EN_UK_1_ET1"],
+            avg_calibration_error=0.7,
+            avg_validation_error=0.4,
+            total_data_loss=0.03,
+            blink_loss=0.02,
+        )
+        _setup_session_with_data(
+            dc.sessions["003_EN_UK_1_ET1"],
+            avg_calibration_error=0.6,
+            avg_validation_error=0.5,
+            total_data_loss=0.01,
+            blink_loss=0.03,
+        )
+
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        q = _qual(overview)
+
+        assert q["mean_calibration_error"] == 0.6
+        assert q["mean_validation_error"] == 0.4
+        assert q["mean_data_loss_ratio"] == 0.02
+        assert q["mean_blink_ratio"] == 0.02
+
+
+class TestAttritionRate:
+    def test_attrition_rate(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        for s in dc.sessions.values():
+            _setup_session_with_data(s)
+        dc.crashed_session_ids = ["1"]
+
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+
+        assert _qual(overview)["Attrition_rate"] == pytest.approx(1.0 / 3.0, abs=0.01)
+
+    def test_attrition_rate_zero_with_no_crashes(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        for s in dc.sessions.values():
+            _setup_session_with_data(s)
+
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+
+        assert _qual(overview)["Attrition_rate"] == 0.0
+
+
+class TestMetadataForm:
+    def test_missing_metadata_form(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        ld = _lang(overview)
+
+        assert ld["Metadata_form_exists"] is False
+        assert ld["Language_script"] is None
+        assert ld["Language_family"] is None
+
+    def test_metadata_form_fields_loaded(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        collection_name = "MultiplEYE_EN_UK_London_1_2025"
+        stimuli_dir = dummy_dcn_dir / f"stimuli_{collection_name}"
+        doc_dir = stimuli_dir.parent / "documentation"
+        doc_dir.mkdir(parents=True, exist_ok=True)
+        metadata_path = doc_dir / "MultiplEYE_en_uk_London_1_2025_metadata_form.json"
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "Script": "Latin",
+                    "Language_family": "Indo-European",
+                    "Start_date_of_data_collection": "2025-01-15",
+                    "End_date_of_data_collection": "2025-03-20",
+                    "Required_pq_fixing": "yes",
+                    "Monitor_name": "Dell U2412M",
+                    "Custom_units_of_analysis": False,
+                },
+                f,
+            )
+
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        ld = _lang(overview)
+        t = _tech(overview)
+        p = _proc(overview)
+
+        assert ld["Metadata_form_exists"] is True
+        assert ld["Language_script"] == "Latin"
+        assert ld["Language_family"] == "Indo-European"
+        assert ld["Start_date_of_data_collection"] == "2025-01-15"
+        assert ld["End_date_of_data_collection"] == "2025-03-20"
+        assert t["Monitor_name"] == "Dell U2412M"
+        assert p["Required_pq_fixing"] == "yes"
+        assert "2025-01-15" in _admin(overview)["Dataset_description"]
+
+
+class TestWPM:
+    def test_wpm_none_when_no_stimuli(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        dc = _create_dc(dummy_dcn_dir)
+        s1 = dc.sessions["001_EN_UK_1_ET1"]
+        _setup_session_with_data(s1, total_reading_time=30000.0)
+        s1.stimuli = "unknown"
+
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        q = _qual(overview)
+
+        assert q["mean_total_reading_time_ms"] == 30000.0
+        assert q["mean_wpm"] is None
+
+    def test_wpm_computed_from_page_texts(
+        self, dummy_dcn_dir, mock_load_lab_config, mock_pipeline_version
+    ) -> None:
+        page = MagicMock()
+        page.text = "This is a test sentence with eight words here."
+        stim = MagicMock()
+        stim.pages = [page, page]
+
+        dc = _create_dc(dummy_dcn_dir)
+        s1 = dc.sessions["001_EN_UK_1_ET1"]
+        _setup_session_with_data(s1, total_reading_time=60000.0)
+        s1.stimuli = [stim]
+
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+
+        assert _qual(overview)["mean_wpm"] == pytest.approx(18.0, abs=0.5)
+
+
+class TestLabConfigAttributeSafety:
+    def test_missing_lab_config_attrs_handled(
+        self, dummy_dcn_dir, mock_pipeline_version, monkeypatch
+    ) -> None:
+        class SparseLabConfig:
+            def __init__(self):
+                self.name_eye_tracker = "EyeLink 1000 Plus"
+                self.psychometric_tests = None
+
+        monkeypatch.setattr(
+            MultipleyeDataCollection,
+            "load_lab_config",
+            lambda *args, **kwargs: SparseLabConfig(),
+        )
+        dc = _create_dc(dummy_dcn_dir)
+        overview = dc.create_dataset_overview(path=dummy_dcn_dir)
+        t = _tech(overview)
+        p = _psych(overview)
+
+        assert t["Eye_tracker_name"] is not None
+        assert t["Sampling_frequency_hz"] is None
+        assert t["Screen_resolution_width_px"] is None
+        assert t["Screen_resolution_height_px"] is None
+        assert p["Tests_available"] is None


### PR DESCRIPTION
## Summary
This PR restructures the data collection overview YAML into topic-grouped sections and adds new metadata fields. Builds on #210 for the data quality aggregates.

New structure:
- Administrative: Title, Dataset_type, Dataset_description, session/pilot counts, city, lab, country, tested language
- Language_details: metadata form existence flag, script, family, start/end collection dates
- Data_availability: hardcoded `true` flags for raw data, fixations, saccades, reading measures
- Psychometric_tests: configured tests from lab config
- Technical_setup: eye tracker, sampling frequency, monitor, screen resolution
- Processing: preprocessing date, pipeline version, stimulus version count, PQ/psychotest/custom-AOI/shuffling flags
- Data_quality: attrition rate + simple means across sessions (calibration/validation error, data loss, blink ratio, reading time, session duration, WPM, comprehension score)

## Changes
- `create_dataset_overview()`: new helpers `_load_metadata_form()`, `_compute_attrition_rate()`, `_compute_dcn_averages()`, `_compute_dcn_wpm()` (word counts from page texts), `_get_pipeline_version()`
- Removed `Data_collection_identifier` (duplicate of `Title`) and `Year` (redundant, flagged for deletion in #169)
- updates in review app connection
- add unit tests

This relates to #169, but will only close after:

## Follow-ups
1. `mean_pupil_loss`, `mean_missing_values_ratio`, `linguistic_annotations_available` (no data source / annotation team state unknown)
2. Comprehension-by-type: `mean_comprehension_score_local/global/bridging` (blocked on session-overview comprehension types, session overview #170)
3. dataset overview table (pub.cl.uzh.ch/projects/eyetracker/datasets.html): `mean_num_words_per_participant` and "all features listed here" (see comment on #169)

## Verification

tests pass

The output files looks like this now (just with one session included):

```yaml
Administrative:
  Title: MultiplEYE_DE_DE_[redacted]_1_2025
  Dataset_type: MultiplEYE
  Dataset_description: DE, [redacted] (lab 1). DE corpus. Data collected from unknown
    to unknown.
  Number_of_sessions: 1
  Number_of_pilots: 0
  Number of eye-tracking (ET) sessions per participant: 1
  City: [redacted]
  Lab_number: 1
  Country: DE
  Tested_language: DE
  Year: 2025
Language_details:
  Metadata_form_exists: false
  Language_script: null
  Language_family: null
  Start_date_of_data_collection: null
  End_date_of_data_collection: null
Data_availability:
  Raw_data_available: true
  Fixations_available: true
  Saccades_available: true
  Reading_measures_available: true
Psychometric_tests:
  Tests_available:
  - LWMC
  - PLAB
  - Flanker
  - Stroop
  - RAN
  - WikiVocab
Technical_setup:
  Eye_tracker_name: EyeLink 1000-Plus
  Sampling_frequency_hz: 1000
  Monitor_name: null
  Screen_resolution_width_px: 1920
  Screen_resolution_height_px: 1200
Processing:
  Preprocessing_date: '2026-08-12'
  Pipeline_version: 2026.8.11
  Number_of_stimulus_versions: 55
  Required_pq_fixing: null
  Psychotests_restructuring: null
  Custom_units_of_analysis: null
  Answer_option_shuffling_bug: null
Data_quality:
  Attrition_rate: 0.0
  mean_calibration_error: null
  mean_validation_error: null
  mean_data_loss_ratio: null
  mean_blink_ratio: null
  mean_total_reading_time_ms: null
  mean_total_session_duration_s: null
  mean_wpm: null
  mean_comprehension_score: null
```