### PR TITLE
feat: restructure session overview YAML into topic groups

### DIFF
--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -1,12 +1,15 @@
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import polars as pl
 
-from ..data_collection.stimulus import Stimulus, LabConfig
+from ..config import settings
+from ..data_collection.stimulus import LabConfig, Stimulus
 from ..data_collection.trial import Trial
 from ..models import Sid
-from ..config import settings
+from ..utils.logging import get_logger
+
+logger = get_logger()
 
 
 @dataclass
@@ -52,6 +55,9 @@ class Session:
     calibrations: pl.DataFrame = field(default="unknown", init=False)
     validations: pl.DataFrame = field(default="unknown", init=False)
     avg_comprehension_score: float = field(default="unknown", init=False)
+    avg_comprehension_score_local: float = field(default="unknown", init=False)
+    avg_comprehension_score_global: float = field(default="unknown", init=False)
+    avg_comprehension_score_bridging: float = field(default="unknown", init=False)
     avg_calibration_error: float = field(default="unknown", init=False)
     num_calibrations: int = field(default="unknown", init=False)
     num_validations: int = field(default="unknown", init=False)
@@ -90,63 +96,212 @@ class Session:
     def sid(self) -> "Sid":
         return Sid(self.session_identifier)
 
-    def create_overview(self):
+    def create_overview(self) -> dict:
+        """
+        Create a topic-grouped overview of the session.
+
+        Returns
+        -------
+        dict
+            Overview with sections: Administrative, Technical_setup, Tracking,
+            Calibration_validation, Data_quality, Experiment_procedure,
+            Comprehension, and Data_formats.
+        """
         self._create_stats()
 
-        dict_repr = {
-            "participant_id": self.participant_id,
-            "session_identifier": self.session_identifier,
-            "is_pilot": self.is_pilot,
-            "question_order": self.question_order,
-            "stimulus_order_ids": self.stimulus_order_ids,
-            "was_session_interrupted": self.interrupted,
-            "lab_config": asdict(self.lab_config)
-            if isinstance(self.lab_config, LabConfig)
-            else self.lab_config,
-            "total_reading_time": self.total_reading_time,
-            "total_session_duration": self.total_session_duration,
-            "obligatory_break_made": self.obligatory_break_made,
-            "num_optional_breaks_made": self.num_optional_breaks_made,
-            "total_break_time": self.total_break_time,
-            "avg_comprehension_score": self.avg_comprehension_score,
-            "avg_calibration_error": self.avg_calibration_error,
-            "num_calibrations": self.num_calibrations,
-            "num_validations": self.num_validations,
-            "avg_validation_error": self.avg_validation_error,
-            "total_data_loss_ratio": getattr(
-                self,
-                "_measure_total_data_loss_ratio",
-                None,
-            ),
-            "blink_loss_ratio": getattr(
-                self,
-                "_measure_blink_loss_ratio",
-                None,
-            ),
-            "Mount_configuration": self.pm_gaze_metadata["mount_configuration"],
-            "Pupil_data_type": self.pm_gaze_metadata["pupil_data_type"],
-            "tracked_eye": self.tracked_eye,
-            "tracked_eye_consistent": self.tracked_eye_consistent,
-            "num_good_validations": self.num_good_validations,
-            "num_moderate_validations": self.num_moderate_validations,
-            "num_bad_validations": self.num_bad_validations,
-            "num_completed_trials": len(self.stimulus_order_ids)
-            if isinstance(self.stimulus_order_ids, list)
-            else None,
-            "Raw_data": self.raw_data,
-            "Fixations": self.fixations,
-            "Saccades": self.saccades,
-            "Reading_measures": self.reading_measures,
-            "Answers": self.answers,
+        return {
+            "Administrative": {
+                "participant_id": self.participant_id,
+                "session_identifier": self.session_identifier,
+                "is_pilot": self.is_pilot,
+                "year_of_data_collection": self._get_metadata("year", "unknown"),
+                "month_of_data_collection": self._get_metadata("month", "unknown"),
+            },
+            "Technical_setup": self._technical_setup(),
+            "Tracking": {
+                "tracked_eye": self.tracked_eye,
+                "tracked_eye_consistent": self.tracked_eye_consistent,
+            },
+            "Calibration_validation": {
+                "num_calibrations": self.num_calibrations,
+                "num_validations": self.num_validations,
+                "avg_calibration_error": self.avg_calibration_error,
+                "avg_validation_error": self.avg_validation_error,
+                "num_good_validations": self.num_good_validations,
+                "num_moderate_validations": self.num_moderate_validations,
+                "num_bad_validations": self.num_bad_validations,
+            },
+            "Data_quality": {
+                "total_data_loss_ratio": getattr(
+                    self,
+                    "_measure_total_data_loss_ratio",
+                    None,
+                ),
+                "blink_loss_ratio": getattr(
+                    self,
+                    "_measure_blink_loss_ratio",
+                    None,
+                ),
+            },
+            "Experiment_procedure": {
+                "question_order": self.question_order,
+                "stimulus_order_ids": self.stimulus_order_ids,
+                "num_completed_trials": len(self.stimulus_order_ids)
+                if isinstance(self.stimulus_order_ids, list)
+                else None,
+                "was_session_interrupted": self.interrupted,
+                "obligatory_break_made": self.obligatory_break_made,
+                "num_optional_breaks_made": self.num_optional_breaks_made,
+                "total_break_time": self.total_break_time,
+                "total_reading_time": self.total_reading_time,
+                "total_session_duration": self.total_session_duration,
+            },
+            "Comprehension": {
+                "avg_comprehension_score": self.avg_comprehension_score,
+                "avg_comprehension_score_local": self.avg_comprehension_score_local,
+                "avg_comprehension_score_global": self.avg_comprehension_score_global,
+                "avg_comprehension_score_bridging": self.avg_comprehension_score_bridging,
+            },
+            "Data_formats": {
+                "raw_data": self.raw_data,
+                "fixations": self.fixations,
+                "saccades": self.saccades,
+                "reading_measures": self.reading_measures,
+                "answers": self.answers,
+            },
         }
 
-        return dict_repr
+    def _get_metadata(self, key: str, default: str = "unknown") -> str:
+        """Return a value from pm_gaze_metadata without raising on missing keys."""
+        if isinstance(self.pm_gaze_metadata, dict):
+            return self.pm_gaze_metadata.get(key, default)
+        return default
+
+    def _technical_setup(self) -> dict:
+        """Assemble the technical setup section from lab config and gaze metadata."""
+        cfg = self.lab_config if isinstance(self.lab_config, LabConfig) else None
+        mount = self._get_metadata("mount_configuration", {})
+        if not isinstance(mount, dict):
+            mount = {}
+
+        def _resolve(attr: str, fallback: object = None) -> object:
+            if cfg is not None:
+                return getattr(cfg, attr, fallback)
+            return fallback
+
+        def _pair(tup: object) -> tuple[object, object]:
+            if isinstance(tup, (tuple, list)) and len(tup) == 2:
+                return tup[0], tup[1]
+            return None, None
+
+        screen_res_w, screen_res_h = _pair(_resolve("screen_resolution"))
+        screen_size_w, screen_size_h = _pair(_resolve("screen_size_cm"))
+        image_res_w, image_res_h = _pair(_resolve("image_resolution"))
+        image_size_w, image_size_h = _pair(_resolve("image_size_cm"))
+
+        return {
+            "Eye_tracker_name": _resolve("name_eye_tracker", None),
+            "Sampling_frequency_hz": _resolve("sampling_frequency_hz", None),
+            "Mount_type": mount.get("mount_type"),
+            "Head_stabilization": mount.get("head_stabilization"),
+            "Eyes_recorded": mount.get("eyes_recorded"),
+            "Pupil_data_type": self._get_metadata("pupil_data_type"),
+            "Screen_resolution_width_px": screen_res_w,
+            "Screen_resolution_height_px": screen_res_h,
+            "Screen_size_width_cm": screen_size_w,
+            "Screen_size_height_cm": screen_size_h,
+            "Screen_distance_cm": _resolve("screen_distance_cm", None),
+            "Image_resolution_width_px": image_res_w,
+            "Image_resolution_height_px": image_res_h,
+            "Image_size_width_cm": image_size_w,
+            "Image_size_height_cm": image_size_h,
+        }
+
+    def _compute_comprehension_scores(self) -> None:
+        """Load the session answers CSV and compute mean comprehension scores.
+
+        Scores are computed over experiment trials only (practice trials are
+        excluded). Type-specific scores use the condition_number column where
+        1=local, 2=bridging, 3=global.
+        """
+        default = "unknown"
+        self.avg_comprehension_score = default
+        self.avg_comprehension_score_local = default
+        self.avg_comprehension_score_global = default
+        self.avg_comprehension_score_bridging = default
+
+        answers_csv = self.sid.answers_dir / f"{self.sid}_answers.csv"
+        if not answers_csv.exists():
+            return
+
+        try:
+            answers = pl.read_csv(answers_csv)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"Could not read answers CSV {answers_csv}: {exc}")
+            return
+
+        if answers.is_empty() or "is_correct" not in answers.columns:
+            return
+
+        experiment = answers.filter(~pl.col("trial").str.starts_with("PRACTICE_"))
+        if experiment.is_empty():
+            return
+
+        correct = experiment["is_correct"].to_list()
+        if correct:
+            self.avg_comprehension_score = round(
+                sum(1 for c in correct if c) / len(correct), 3
+            )
+
+        type_map = {1: "local", 2: "bridging", 3: "global"}
+        if "condition_number" in experiment.columns:
+            for condition, name in type_map.items():
+                subset = experiment.filter(pl.col("condition_number") == condition)[
+                    "is_correct"
+                ].to_list()
+                if subset:
+                    setattr(
+                        self,
+                        f"avg_comprehension_score_{name}",
+                        round(sum(1 for c in subset if c) / len(subset), 3),
+                    )
+
+    def _compute_session_duration(self) -> float | None:
+        """Return session duration in seconds from message timestamps, if available."""
+        if not isinstance(self.messages, pl.DataFrame) or self.messages.is_empty():
+            return None
+        if "time" not in self.messages.columns:
+            return None
+        min_t = self.messages["time"].min()
+        max_t = self.messages["time"].max()
+        if min_t is None or max_t is None:
+            return None
+        return round((float(max_t) - float(min_t)) / 1000, 3)
 
     def _create_stats(self):
         self.num_calibrations = len(self.calibrations)
         self.num_validations = len(self.validations)
 
         self.tracked_eye = self.pm_gaze_metadata.get("tracked_eye", "unknown")
+
+        # Mean calibration and validation error (accuracy_avg column), if present.
+        if (
+            isinstance(self.validations, pl.DataFrame)
+            and not self.validations.is_empty()
+            and "accuracy_avg" in self.validations.columns
+        ):
+            vals = self.validations["accuracy_avg"].drop_nulls().to_list()
+            if vals:
+                self.avg_validation_error = round(sum(vals) / len(vals), 3)
+
+        if (
+            isinstance(self.calibrations, pl.DataFrame)
+            and not self.calibrations.is_empty()
+            and "accuracy_avg" in self.calibrations.columns
+        ):
+            vals = self.calibrations["accuracy_avg"].drop_nulls().to_list()
+            if vals:
+                self.avg_calibration_error = round(sum(vals) / len(vals), 3)
 
         if not isinstance(self.validations, str) and not self.validations.is_empty():
             scores = self.validations["accuracy_avg"].to_list()
@@ -169,3 +324,37 @@ class Session:
                 e for e in eyes if e and e[0].lower() != self.tracked_eye.lower()
             ]
             self.tracked_eye_consistent = len(non_standard) == 0
+
+        self._compute_comprehension_scores()
+
+        duration = self._compute_session_duration()
+        if duration is not None:
+            self.total_session_duration = duration
+
+        if self.total_reading_time == "unknown":
+            reading = self._compute_total_reading_time()
+            if reading is not None:
+                self.total_reading_time = reading
+
+    def _compute_total_reading_time(self) -> float | None:
+        """Return total reading time in seconds from stimulus start/end timestamps.
+
+        The timestamps are stored on the session when reading times are
+        documented (sanity checks). Falls back to None when unavailable.
+        """
+        if (
+            not isinstance(self.stimulus_start_end_ts, list)
+            or not self.stimulus_start_end_ts
+        ):
+            return None
+        total_ms = 0.0
+        for entry in self.stimulus_start_end_ts:
+            try:
+                start = float(entry["start_ts"])
+                stop = float(entry["stop_ts"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            total_ms += stop - start
+        if total_ms <= 0:
+            return None
+        return round(total_ms / 1000, 3)

--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TypeVar
 
 import polars as pl
 
@@ -10,6 +11,8 @@ from ..models import Sid
 from ..utils.logging import get_logger
 
 logger = get_logger()
+
+T = TypeVar("T")
 
 
 @dataclass
@@ -24,43 +27,49 @@ class Session:
     session_folder_path: Path
     session_file_path: Path
     session_file_name: str
-    asc_path: Path = field(default="unknown", init=False)
+    asc_path: Path | str = field(default="unknown", init=False)
 
     # stimuli
     # TODO: move stimuli, completed stimuli, stimuli trial mapping to one thing
-    stimuli: list[Stimulus] = field(default="unknown", init=False)
-    randomization_version: int = field(default="unknown", init=False)
+    stimuli: list[Stimulus] | str = field(default="unknown", init=False)
+    randomization_version: int | str = field(default="unknown", init=False)
     stimulus_folder_name: str = field(default="unknown", init=False)
-    completed_stimuli_ids: list[int] = field(default="unknown", init=False)
-    completed_stimuli_names: list[str] = field(default="unknown", init=False)
-    question_order: dict[str, list[str]] = field(default="unknown", init=False)
-    stimulus_order_ids: list[int] = field(default="unknown", init=False)
-    messages: list[dict[str, str]] = field(default="unknown", init=False)
-    uncategorized_messages: list[dict[str, str]] = field(default="unknown", init=False)
-    stimuli_trial_mapping: dict[str, str] = field(default="unknown", init=False)
-    stimulus_start_end_ts: dict[str, list[str]] = field(default="unknown", init=False)
+    completed_stimuli_ids: list[int] | str = field(default="unknown", init=False)
+    completed_stimuli_names: list[str] | str = field(default="unknown", init=False)
+    question_order: dict[str, list[str]] | str = field(default="unknown", init=False)
+    stimulus_order_ids: list[int] | str = field(default="unknown", init=False)
+    messages: pl.DataFrame | list[dict[str, str]] | str = field(
+        default="unknown", init=False
+    )
+    uncategorized_messages: list[dict[str, str]] | str = field(
+        default="unknown", init=False
+    )
+    stimuli_trial_mapping: dict[str, str] | str = field(default="unknown", init=False)
+    stimulus_start_end_ts: list[dict[str, str | float]] | str = field(
+        default="unknown", init=False
+    )
 
     logfile: str = field(default="unknown", init=False)
-    interrupted: bool = field(default="unknown", init=False)
-    lab_config: LabConfig = field(default="unknown", init=False)
+    interrupted: bool | str = field(default="unknown", init=False)
+    lab_config: LabConfig | str = field(default="unknown", init=False)
 
     # stats
     total_reading_time: float | str = field(default="unknown", init=False)
     total_session_duration: float | str = field(default="unknown", init=False)
-    obligatory_break_made: bool = field(default="unknown", init=False)
-    num_optional_breaks_made: int = field(default="unknown", init=False)
+    obligatory_break_made: bool | str = field(default="unknown", init=False)
+    num_optional_breaks_made: int | str = field(default="unknown", init=False)
     total_break_time: float | str = field(default="unknown", init=False)
 
     # calibrations & validations
-    calibrations: pl.DataFrame = field(default="unknown", init=False)
-    validations: pl.DataFrame = field(default="unknown", init=False)
+    calibrations: pl.DataFrame | str = field(default="unknown", init=False)
+    validations: pl.DataFrame | str = field(default="unknown", init=False)
     avg_comprehension_score: float | str = field(default="unknown", init=False)
     avg_comprehension_score_local: float | str = field(default="unknown", init=False)
     avg_comprehension_score_global: float | str = field(default="unknown", init=False)
     avg_comprehension_score_bridging: float | str = field(default="unknown", init=False)
     avg_calibration_error: float | str = field(default="unknown", init=False)
-    num_calibrations: int = field(default="unknown", init=False)
-    num_validations: int = field(default="unknown", init=False)
+    num_calibrations: int | str = field(default="unknown", init=False)
+    num_validations: int | str = field(default="unknown", init=False)
     avg_validation_error: float | str = field(default="unknown", init=False)
 
     # eye tracking metadata
@@ -74,11 +83,11 @@ class Session:
     num_completed_trials: int = field(default=0, init=False)
 
     # sanity report
-    sanity_report_path: Path = field(default="unknown", init=False)
+    sanity_report_path: Path | str = field(default="unknown", init=False)
 
     # preprocessing pm
-    pm_gaze_path: Path = field(default="unknown", init=False)
-    pm_gaze_metadata: dict = field(default="unknown", init=False)
+    pm_gaze_path: Path | str = field(default="unknown", init=False)
+    pm_gaze_metadata: dict | str = field(default="unknown", init=False)
 
     # psychometric tests
     psychometric_tests_session: str = field(default="unknown", init=False)
@@ -173,7 +182,7 @@ class Session:
             },
         }
 
-    def _get_metadata(self, key: str, default: str = "unknown") -> str:
+    def _get_metadata(self, key: str, default: T = "unknown") -> str | T:
         """Return a value from pm_gaze_metadata without raising on missing keys."""
         if isinstance(self.pm_gaze_metadata, dict):
             return self.pm_gaze_metadata.get(key, default)
@@ -278,11 +287,12 @@ class Session:
             return None
         if "time" not in self.messages.columns:
             return None
-        min_t = self.messages["time"].min()
-        max_t = self.messages["time"].max()
-        if min_t is None or max_t is None:
+        times = self.messages["time"].cast(pl.Float64).drop_nulls().to_list()
+        if not times:
             return None
-        return round((float(max_t) - float(min_t)) / 1000, 3)
+        min_t = min(times)
+        max_t = max(times)
+        return round((max_t - min_t) / 1000, 3)
 
     def _create_stats(self):
         self.num_calibrations = len(self.calibrations)

--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -45,23 +45,23 @@ class Session:
     lab_config: LabConfig = field(default="unknown", init=False)
 
     # stats
-    total_reading_time: float = field(default="unknown", init=False)
-    total_session_duration: float = field(default="unknown", init=False)
+    total_reading_time: float | str = field(default="unknown", init=False)
+    total_session_duration: float | str = field(default="unknown", init=False)
     obligatory_break_made: bool = field(default="unknown", init=False)
     num_optional_breaks_made: int = field(default="unknown", init=False)
-    total_break_time: float = field(default="unknown", init=False)
+    total_break_time: float | str = field(default="unknown", init=False)
 
     # calibrations & validations
     calibrations: pl.DataFrame = field(default="unknown", init=False)
     validations: pl.DataFrame = field(default="unknown", init=False)
-    avg_comprehension_score: float = field(default="unknown", init=False)
-    avg_comprehension_score_local: float = field(default="unknown", init=False)
-    avg_comprehension_score_global: float = field(default="unknown", init=False)
-    avg_comprehension_score_bridging: float = field(default="unknown", init=False)
-    avg_calibration_error: float = field(default="unknown", init=False)
+    avg_comprehension_score: float | str = field(default="unknown", init=False)
+    avg_comprehension_score_local: float | str = field(default="unknown", init=False)
+    avg_comprehension_score_global: float | str = field(default="unknown", init=False)
+    avg_comprehension_score_bridging: float | str = field(default="unknown", init=False)
+    avg_calibration_error: float | str = field(default="unknown", init=False)
     num_calibrations: int = field(default="unknown", init=False)
     num_validations: int = field(default="unknown", init=False)
-    avg_validation_error: float = field(default="unknown", init=False)
+    avg_validation_error: float | str = field(default="unknown", init=False)
 
     # eye tracking metadata
     tracked_eye: str = field(default="unknown", init=False)
@@ -84,11 +84,13 @@ class Session:
     psychometric_tests_session: str = field(default="unknown", init=False)
 
     # data formats
-    raw_data: bool = field(default=False, init=False)
-    fixations: bool = field(default=False, init=False)
-    saccades: bool = field(default=False, init=False)
-    reading_measures: bool = field(default=False, init=False)
-    answers: bool = field(default=False, init=False)
+    # True by default: our pipeline produces all formats. Other pipelines may
+    # set these to False when a format is not generated.
+    raw_data: bool = field(default=True, init=False)
+    fixations: bool = field(default=True, init=False)
+    saccades: bool = field(default=True, init=False)
+    reading_measures: bool = field(default=True, init=False)
+    answers: bool = field(default=True, init=False)
 
     trials = list[Trial]
 
@@ -247,7 +249,7 @@ class Session:
         if experiment.is_empty():
             return
 
-        correct = experiment["is_correct"].to_list()
+        correct = [c for c in experiment["is_correct"].to_list() if c is not None]
         if correct:
             self.avg_comprehension_score = round(
                 sum(1 for c in correct if c) / len(correct), 3
@@ -256,9 +258,13 @@ class Session:
         type_map = {1: "local", 2: "bridging", 3: "global"}
         if "condition_number" in experiment.columns:
             for condition, name in type_map.items():
-                subset = experiment.filter(pl.col("condition_number") == condition)[
-                    "is_correct"
-                ].to_list()
+                subset = [
+                    c
+                    for c in experiment.filter(pl.col("condition_number") == condition)[
+                        "is_correct"
+                    ].to_list()
+                    if c is not None
+                ]
                 if subset:
                     setattr(
                         self,
@@ -282,7 +288,7 @@ class Session:
         self.num_calibrations = len(self.calibrations)
         self.num_validations = len(self.validations)
 
-        self.tracked_eye = self.pm_gaze_metadata.get("tracked_eye", "unknown")
+        self.tracked_eye = self._get_metadata("tracked_eye", "unknown")
 
         # Mean calibration and validation error (accuracy_avg column), if present.
         if (
@@ -303,9 +309,13 @@ class Session:
             if vals:
                 self.avg_calibration_error = round(sum(vals) / len(vals), 3)
 
-        if not isinstance(self.validations, str) and not self.validations.is_empty():
-            scores = self.validations["accuracy_avg"].to_list()
-            eyes = self.validations["eye"].to_list()
+        if (
+            not isinstance(self.validations, str)
+            and not self.validations.is_empty()
+            and {"accuracy_avg", "eye"}.issubset(self.validations.columns)
+        ):
+            scores = self.validations["accuracy_avg"].drop_nulls().to_list()
+            eyes = self.validations["eye"].drop_nulls().to_list()
             self.num_good_validations = sum(
                 1 for s in scores if s < settings.SINGLE_VALIDATION_GOOD_MAX
             )

--- a/review_app/routes/collection.py
+++ b/review_app/routes/collection.py
@@ -1,12 +1,11 @@
 """DCN-level routes — overview, session list, flags, stats, psychometric."""
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import JSONResponse, HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
-from ..templating import render
-from ..services.dcn import get_dcn, list_sessions
 from ..models import FlagSummary
-
+from ..services.dcn import get_dcn, list_sessions
+from ..templating import render
 
 router = APIRouter(prefix="/api/dcn")
 
@@ -62,8 +61,9 @@ async def dcn_flags(dcn_name: str) -> JSONResponse:
 @router.get("/{dcn_name}/psychometric")
 async def dcn_psychometric(dcn_name: str) -> JSONResponse:
     """Return per-session psychometric scores."""
-    from ..config import psychometric_path
     import csv
+
+    from ..config import psychometric_path
 
     path = psychometric_path(dcn_name)
     if not path.exists():
@@ -84,8 +84,8 @@ async def dcn_stats(dcn_name: str) -> JSONResponse:
     if not sessions:
         return JSONResponse({})
 
-    from ..services.session_data import read_overview
     from ..config import session_overview_path
+    from ..services.session_data import get_field, read_overview
 
     values: dict[str, list[float | int | bool | str]] = {}
     for s in sessions:
@@ -101,7 +101,7 @@ async def dcn_stats(dcn_name: str) -> JSONResponse:
             "num_validations",
             "total_session_duration",
         ):
-            val = ov.get(key)
+            val = get_field(ov, key)
             if val is not None and isinstance(val, (int, float)):
                 values.setdefault(key, []).append(val)
 
@@ -127,6 +127,7 @@ async def open_dcn_folder(dcn_name: str, which: str):
     """Open a DCN's data folder in the OS file manager (Finder on macOS)."""
     import subprocess
     import sys
+
     from ..config import PREPROCESSED_DATA_DIR, RAW_DATA_DIR
 
     if which == "input":

--- a/review_app/services/dcn.py
+++ b/review_app/services/dcn.py
@@ -6,9 +6,9 @@ from preprocessing.models import Dcn
 
 from ..config import PREPROCESSED_DATA_DIR, RAW_DATA_DIR
 from ..models import DcnSummary, SessionSummary
-from .review import load_review
-from .session_data import read_overview, compute_checks
 from .preflight import run_pipeline_preflight
+from .review import load_review
+from .session_data import compute_checks, read_overview
 
 
 def _discover_dcn_names() -> set[str]:
@@ -123,13 +123,14 @@ def list_sessions(dcn_name: str) -> list[SessionSummary]:
 
 def _build_session_summary(dcn_name: str, sid: str) -> SessionSummary | None:
     from ..config import metadata_path, quality_thresholds_path
+    from .session_data import get_field
 
     overview = read_overview(metadata_path(dcn_name, sid) / f"{sid}_overview.yaml")
     if overview is None:
         return None
 
-    pid = overview.get("participant_id", 0)
-    is_pilot = overview.get("is_pilot", False)
+    pid = get_field(overview, "participant_id") or 0
+    is_pilot = get_field(overview, "is_pilot") or False
 
     thresholds = None
     t_path = quality_thresholds_path(dcn_name)
@@ -143,7 +144,7 @@ def _build_session_summary(dcn_name: str, sid: str) -> SessionSummary | None:
 
     review = load_review(dcn_name, sid)
     comment_preview = review.comment.split("\n")[0][:80] if review.comment else ""
-    num_completed_trials = overview.get("num_completed_trials")
+    num_completed_trials = get_field(overview, "num_completed_trials")
 
     return SessionSummary(
         sid=sid,

--- a/review_app/services/session_data.py
+++ b/review_app/services/session_data.py
@@ -1,11 +1,11 @@
 """Read session overview YAML and compute check results with threshold comparison."""
 
-import yaml
 from pathlib import Path
 
-from ..models import CheckResult, SessionDetail, ReviewAnnotation
-from .thresholds import check_value
+import yaml
 
+from ..models import CheckResult, ReviewAnnotation, SessionDetail
+from .thresholds import check_value
 
 # Mapping from overview YAML field names to check metadata.
 # Ordered by category for display grouping.
@@ -17,11 +17,63 @@ CHECK_REGISTRY: list[dict] = [
         "label": "Tracked eye consistent",
         "category": "Hardware",
     },
-    {"field": "Mount_configuration", "label": "Mount type", "category": "Hardware"},
+    {"field": "Eye_tracker_name", "label": "Eye tracker", "category": "Hardware"},
+    {
+        "field": "Sampling_frequency_hz",
+        "label": "Sampling frequency (Hz)",
+        "category": "Hardware",
+    },
+    {"field": "Mount_type", "label": "Mount type", "category": "Hardware"},
+    {
+        "field": "Head_stabilization",
+        "label": "Head stabilization",
+        "category": "Hardware",
+    },
+    {"field": "Eyes_recorded", "label": "Eyes recorded", "category": "Hardware"},
     {"field": "Pupil_data_type", "label": "Pupil data type", "category": "Hardware"},
     {
-        "field": "expected_sampling_rate_hz",
-        "label": "Sampling rate (Hz)",
+        "field": "Screen_resolution_width_px",
+        "label": "Screen resolution width (px)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Screen_resolution_height_px",
+        "label": "Screen resolution height (px)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Screen_size_width_cm",
+        "label": "Screen size width (cm)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Screen_size_height_cm",
+        "label": "Screen size height (cm)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Screen_distance_cm",
+        "label": "Screen distance (cm)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Image_resolution_width_px",
+        "label": "Image resolution width (px)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Image_resolution_height_px",
+        "label": "Image resolution height (px)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Image_size_width_cm",
+        "label": "Image size width (cm)",
+        "category": "Hardware",
+    },
+    {
+        "field": "Image_size_height_cm",
+        "label": "Image size height (cm)",
         "category": "Hardware",
     },
     # Calibration & validation
@@ -124,16 +176,31 @@ CHECK_REGISTRY: list[dict] = [
         "label": "Avg comprehension score",
         "category": "Comprehension",
     },
-    # Data presence
-    {"field": "Raw_data", "label": "Raw data present", "category": "Data Files"},
-    {"field": "Fixations", "label": "Fixations present", "category": "Data Files"},
-    {"field": "Saccades", "label": "Saccades present", "category": "Data Files"},
     {
-        "field": "Reading_measures",
+        "field": "avg_comprehension_score_local",
+        "label": "Avg local comprehension score",
+        "category": "Comprehension",
+    },
+    {
+        "field": "avg_comprehension_score_global",
+        "label": "Avg global comprehension score",
+        "category": "Comprehension",
+    },
+    {
+        "field": "avg_comprehension_score_bridging",
+        "label": "Avg bridging comprehension score",
+        "category": "Comprehension",
+    },
+    # Data presence
+    {"field": "raw_data", "label": "Raw data present", "category": "Data Files"},
+    {"field": "fixations", "label": "Fixations present", "category": "Data Files"},
+    {"field": "saccades", "label": "Saccades present", "category": "Data Files"},
+    {
+        "field": "reading_measures",
         "label": "Reading measures present",
         "category": "Data Files",
     },
-    {"field": "Answers", "label": "Answers present", "category": "Data Files"},
+    {"field": "answers", "label": "Answers present", "category": "Data Files"},
 ]
 
 
@@ -149,6 +216,25 @@ def read_overview(path: Path) -> dict | None:
         return yaml.load(f, Loader=yaml.FullLoader)
 
 
+def get_field(overview: dict, field: str) -> object | None:
+    """Resolve a field from a session overview, searching nested sections.
+
+    Session overviews are grouped into topic sections (e.g. ``Data_quality``).
+    This helper finds a field either at the top level (legacy flat overviews)
+    or inside any section dict.
+
+    :param overview: Dict from a session overview YAML.
+    :param field: Field name to look up.
+    :returns: The value, or None if not found.
+    """
+    if field in overview:
+        return overview[field]
+    for section in overview.values():
+        if isinstance(section, dict) and field in section:
+            return section[field]
+    return None
+
+
 def compute_checks(overview: dict, thresholds: dict | None) -> list[CheckResult]:
     """Compute CheckResult list from overview values and thresholds.
 
@@ -159,7 +245,7 @@ def compute_checks(overview: dict, thresholds: dict | None) -> list[CheckResult]
     checks: list[CheckResult] = []
     for entry in CHECK_REGISTRY:
         field = entry["field"]
-        value = overview.get(field, None)
+        value = get_field(overview, field)
         if value is None:
             continue
         if not _is_checkable(value):
@@ -224,8 +310,8 @@ def build_session_detail(
     :param sid: Session identifier.
     :returns: SessionDetail model.
     """
-    pid = overview.get("participant_id", 0)
-    is_pilot = overview.get("is_pilot", False)
+    pid = get_field(overview, "participant_id") or 0
+    is_pilot = get_field(overview, "is_pilot") or False
     checks = compute_checks(overview, thresholds)
 
     from ..config import sanity_checks_path

--- a/review_app/services/swipe.py
+++ b/review_app/services/swipe.py
@@ -1,16 +1,21 @@
 """Swipe mode — per-plot judgments stored in per-DCN swipe_judgments.yaml."""
 
-import yaml
 import os
 import tempfile
 
-from ..config import dcn_path, swipe_judgments_path
-from .dcn import list_sessions, get_dcn
-from .session_data import read_overview, compute_checks
-from .thresholds import load_thresholds
-from .review import load_review
-from ..config import sanity_checks_path, session_overview_path
 import pycountry
+import yaml
+
+from ..config import (
+    dcn_path,
+    sanity_checks_path,
+    session_overview_path,
+    swipe_judgments_path,
+)
+from .dcn import get_dcn, list_sessions
+from .review import load_review
+from .session_data import compute_checks, get_field, read_overview
+from .thresholds import load_thresholds
 
 VALID_JUDGMENTS = {"keep", "flag", "skip"}
 
@@ -266,8 +271,8 @@ def swipe_data(dcn_name: str) -> dict:
                 "is_pilot": s.is_pilot,
                 "language": language_name,
                 "country": country_name_str,
-                "num_calibrations": overview.get("num_calibrations", 0),
-                "num_validations": overview.get("num_validations", 0),
+                "num_calibrations": get_field(overview, "num_calibrations") or 0,
+                "num_validations": get_field(overview, "num_validations") or 0,
                 "n_flags": s.n_flags,
                 "n_fail_flags": s.n_fail_flags,
                 "n_warn_flags": s.n_warn_flags,

--- a/tests/unit/preprocessing/data_collection/test_session_overview.py
+++ b/tests/unit/preprocessing/data_collection/test_session_overview.py
@@ -47,20 +47,32 @@ def _seed_metadata(sess: Session) -> None:
     sess.lab_config = _mock_lab_config()
 
 
-def test_create_overview_includes_new_fields() -> None:
-    validations = pl.DataFrame(
+def _validations(accuracy: list[float | None] | None = None) -> pl.DataFrame:
+    accuracy = accuracy if accuracy is not None else [0.2, 0.35, 0.5]
+    return pl.DataFrame(
         {
-            "time": [100.0, 200.0, 300.0],
-            "accuracy_avg": [0.2, 0.35, 0.5],
-            "accuracy_max": [0.3, 0.4, 0.6],
-            "eye": ["right", "right", "right"],
+            "time": list(range(100, 100 + len(accuracy))),
+            "accuracy_avg": accuracy,
+            "accuracy_max": [0.3] * len(accuracy),
+            "eye": ["right"] * len(accuracy),
         }
     )
-    calibrations = pl.DataFrame({"time": [50.0, 150.0]})
+
+
+def _calibrations() -> pl.DataFrame:
+    return pl.DataFrame({"time": [50.0, 150.0]})
+
+
+def _sess_with_validation_data() -> Session:
     sess = _make_session()
-    sess.validations = validations
-    sess.calibrations = calibrations
     _seed_metadata(sess)
+    sess.validations = _validations()
+    sess.calibrations = _calibrations()
+    return sess
+
+
+def test_create_overview_includes_new_fields() -> None:
+    sess = _sess_with_validation_data()
 
     overview = sess.create_overview()
 
@@ -79,17 +91,7 @@ def test_create_overview_includes_new_fields() -> None:
 
 
 def test_create_overview_includes_measure_based_data_loss() -> None:
-    sess = _make_session()
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
-    _seed_metadata(sess)
+    sess = _sess_with_validation_data()
     sess._measure_total_data_loss_ratio = 0.015
     sess._measure_blink_loss_ratio = 0.008
 
@@ -101,18 +103,11 @@ def test_create_overview_includes_measure_based_data_loss() -> None:
 
 
 def test_tracked_eye_inconsistent_when_eye_changes() -> None:
-    validations = pl.DataFrame(
-        {
-            "time": [100.0, 200.0],
-            "accuracy_avg": [0.2, 0.2],
-            "accuracy_max": [0.3, 0.3],
-            "eye": ["right", "left"],
-        }
-    )
-    calibrations = pl.DataFrame({"time": [50.0]})
+    validations = _validations()
+    validations = validations.with_columns(pl.lit("left").alias("eye"))
     sess = _make_session()
     sess.validations = validations
-    sess.calibrations = calibrations
+    sess.calibrations = _calibrations()
     _seed_metadata(sess)
 
     overview = sess.create_overview()
@@ -123,17 +118,7 @@ def test_tracked_eye_inconsistent_when_eye_changes() -> None:
 
 
 def test_sections_are_present() -> None:
-    sess = _make_session()
-    _seed_metadata(sess)
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
+    sess = _sess_with_validation_data()
 
     overview = sess.create_overview()
 
@@ -150,17 +135,7 @@ def test_sections_are_present() -> None:
 
 
 def test_technical_setup_from_lab_config() -> None:
-    sess = _make_session()
-    _seed_metadata(sess)
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
+    sess = _sess_with_validation_data()
 
     overview = sess.create_overview()
     tech = overview["Technical_setup"]
@@ -181,14 +156,7 @@ def test_avg_validation_error_computed_from_validations() -> None:
     sess = _make_session()
     _seed_metadata(sess)
     sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0, 200.0, 300.0],
-            "accuracy_avg": [0.2, 0.3, 0.4],
-            "accuracy_max": [0.3, 0.4, 0.5],
-            "eye": ["right", "right", "right"],
-        }
-    )
+    sess.validations = _validations([0.2, 0.3, 0.4])
 
     overview = sess.create_overview()
     cal = overview["Calibration_validation"]
@@ -199,17 +167,7 @@ def test_avg_validation_error_computed_from_validations() -> None:
 
 
 def test_comprehension_scores_read_from_answers_csv(tmp_path: Path) -> None:
-    sess = _make_session()
-    _seed_metadata(sess)
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
+    sess = _sess_with_validation_data()
 
     answers = pl.DataFrame(
         {
@@ -249,17 +207,7 @@ class _FakeSid:
 
 
 def test_session_duration_from_messages() -> None:
-    sess = _make_session()
-    _seed_metadata(sess)
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
+    sess = _sess_with_validation_data()
     sess.messages = pl.DataFrame(
         {"time": [1000.0, 2000.0, 60000.0], "content": ["a", "b", "c"]}
     )
@@ -271,17 +219,7 @@ def test_session_duration_from_messages() -> None:
 
 
 def test_reading_time_from_stimulus_start_end_ts() -> None:
-    sess = _make_session()
-    _seed_metadata(sess)
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
+    sess = _sess_with_validation_data()
     sess.stimulus_start_end_ts = [
         {"stimulus": "a", "trial": "trial_1", "start_ts": 1000.0, "stop_ts": 4000.0},
         {"stimulus": "b", "trial": "trial_2", "start_ts": 5000.0, "stop_ts": 7000.0},
@@ -294,24 +232,348 @@ def test_reading_time_from_stimulus_start_end_ts() -> None:
 
 
 def test_data_formats_section() -> None:
-    sess = _make_session()
-    _seed_metadata(sess)
-    sess.calibrations = pl.DataFrame({"time": [50.0]})
-    sess.validations = pl.DataFrame(
-        {
-            "time": [100.0],
-            "accuracy_avg": [0.2],
-            "accuracy_max": [0.3],
-            "eye": ["right"],
-        }
-    )
-    sess.raw_data = True
-    sess.reading_measures = True
+    sess = _sess_with_validation_data()
 
     overview = sess.create_overview()
     formats = overview["Data_formats"]
 
     assert formats["raw_data"] is True
-    assert formats["fixations"] is False
+    assert formats["fixations"] is True
+    assert formats["saccades"] is True
     assert formats["reading_measures"] is True
-    assert formats["answers"] is False
+    assert formats["answers"] is True
+
+
+def test_data_formats_can_be_disabled_for_other_pipelines() -> None:
+    sess = _sess_with_validation_data()
+    sess.fixations = False
+    sess.saccades = False
+
+    overview = sess.create_overview()
+    formats = overview["Data_formats"]
+
+    assert formats["fixations"] is False
+    assert formats["saccades"] is False
+    assert formats["raw_data"] is True
+
+
+# --- Branch coverage: unprocessed / edge-case sessions ---
+
+
+def test_unprocessed_session_defaults() -> None:
+    """A session with no data populated should not crash and report defaults."""
+    sess = _make_session()
+
+    overview = sess.create_overview()
+
+    assert overview["Tracking"]["tracked_eye"] == "unknown"
+    assert overview["Technical_setup"]["Eye_tracker_name"] is None
+    assert overview["Calibration_validation"]["avg_validation_error"] == "unknown"
+    assert overview["Calibration_validation"]["num_calibrations"] == 7
+    assert overview["Comprehension"]["avg_comprehension_score"] == "unknown"
+    assert overview["Experiment_procedure"]["total_session_duration"] == "unknown"
+    assert overview["Experiment_procedure"]["total_reading_time"] == "unknown"
+
+
+def test_metadata_not_a_dict() -> None:
+    sess = _make_session()
+    sess.pm_gaze_metadata = "unknown"
+
+    overview = sess.create_overview()
+
+    assert overview["Administrative"]["year_of_data_collection"] == "unknown"
+    assert overview["Technical_setup"]["Mount_type"] is None
+
+
+def test_mount_configuration_not_a_dict() -> None:
+    sess = _make_session()
+    sess.pm_gaze_metadata = {
+        "tracked_eye": "R",
+        "mount_configuration": "unknown",
+        "pupil_data_type": "AREA",
+    }
+
+    overview = sess.create_overview()
+    tech = overview["Technical_setup"]
+
+    assert tech["Mount_type"] is None
+    assert tech["Eyes_recorded"] is None
+
+
+def test_technical_setup_without_lab_config() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.lab_config = "unknown"
+
+    overview = sess.create_overview()
+    tech = overview["Technical_setup"]
+
+    assert tech["Eye_tracker_name"] is None
+    assert tech["Sampling_frequency_hz"] is None
+    assert tech["Screen_resolution_width_px"] is None
+
+
+def test_validations_without_accuracy_column() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = _calibrations()
+    sess.validations = pl.DataFrame({"time": [100.0, 200.0]})
+
+    overview = sess.create_overview()
+    cal = overview["Calibration_validation"]
+
+    assert cal["avg_validation_error"] == "unknown"
+    assert cal["num_validations"] == 2
+
+
+def test_validations_with_null_accuracy() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = _calibrations()
+    sess.validations = _validations([None, None])
+
+    overview = sess.create_overview()
+    cal = overview["Calibration_validation"]
+
+    assert cal["avg_validation_error"] == "unknown"
+
+
+def test_calibrations_with_accuracy_column() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.validations = _validations()
+    sess.calibrations = pl.DataFrame(
+        {
+            "time": [50.0, 150.0],
+            "num_points": [9, 9],
+            "eye": ["right", "right"],
+            "tracking_mode": ["CR", "CR"],
+            "accuracy_avg": [0.1, 0.3],
+        }
+    )
+
+    overview = sess.create_overview()
+    cal = overview["Calibration_validation"]
+
+    assert cal["avg_calibration_error"] == 0.2
+
+
+def test_calibrations_with_null_accuracy() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.validations = _validations()
+    sess.calibrations = pl.DataFrame(
+        {
+            "time": [50.0, 150.0],
+            "num_points": [9, 9],
+            "eye": ["right", "right"],
+            "tracking_mode": ["CR", "CR"],
+            "accuracy_avg": [None, None],
+        }
+    )
+
+    overview = sess.create_overview()
+    cal = overview["Calibration_validation"]
+
+    assert cal["avg_calibration_error"] == "unknown"
+
+
+def test_answers_csv_unreadable(tmp_path: Path, monkeypatch) -> None:
+    sess = _sess_with_validation_data()
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    (answers_dir / "001_EN_UK_1_ET1_answers.csv").write_text("garbage")
+
+    def _raise(*args, **kwargs):
+        from polars.exceptions import ComputeError
+
+        raise ComputeError("cannot parse")
+
+    monkeypatch.setattr("preprocessing.data_collection.session.pl.read_csv", _raise)
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == "unknown"
+
+
+def test_answers_csv_all_null_is_correct(tmp_path: Path) -> None:
+    sess = _sess_with_validation_data()
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    answers = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_2"],
+            "condition_number": [1, 2],
+            "is_correct": [None, None],
+        }
+    )
+    answers.write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == "unknown"
+    assert comp["avg_comprehension_score_local"] == "unknown"
+
+
+def test_answers_csv_without_one_condition(tmp_path: Path) -> None:
+    sess = _sess_with_validation_data()
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    answers = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_2"],
+            "condition_number": [1, 1],
+            "is_correct": [True, False],
+        }
+    )
+    answers.write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == 0.5
+    assert comp["avg_comprehension_score_local"] == 0.5
+    assert comp["avg_comprehension_score_bridging"] == "unknown"
+    assert comp["avg_comprehension_score_global"] == "unknown"
+
+
+def test_answers_csv_missing_is_correct(tmp_path: Path) -> None:
+    sess = _sess_with_validation_data()
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    answers = pl.DataFrame({"trial": ["trial_1"], "condition_number": [1]})
+    answers.write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == "unknown"
+
+
+def test_answers_csv_practice_only(tmp_path: Path) -> None:
+    sess = _sess_with_validation_data()
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    answers = pl.DataFrame(
+        {
+            "trial": ["PRACTICE_trial_1"],
+            "condition_number": [1],
+            "is_correct": [True],
+        }
+    )
+    answers.write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == "unknown"
+
+
+def test_answers_csv_without_condition_number(tmp_path: Path) -> None:
+    sess = _sess_with_validation_data()
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    answers = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_2"],
+            "is_correct": [True, False],
+        }
+    )
+    answers.write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == 0.5
+    assert comp["avg_comprehension_score_local"] == "unknown"
+
+
+def test_session_duration_without_time_column() -> None:
+    sess = _sess_with_validation_data()
+    sess.messages = pl.DataFrame({"content": ["a", "b"]})
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_session_duration"] == "unknown"
+
+
+def test_session_duration_with_null_timestamps() -> None:
+    sess = _sess_with_validation_data()
+    sess.messages = pl.DataFrame({"time": [None, None], "content": ["a", "b"]})
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_session_duration"] == "unknown"
+
+
+def test_reading_time_malformed_entries() -> None:
+    sess = _sess_with_validation_data()
+    sess.stimulus_start_end_ts = [
+        {"stimulus": "a", "trial": "trial_1", "start_ts": 1000.0, "stop_ts": 4000.0},
+        {"stimulus": "b", "trial": "trial_2"},
+        "garbage",
+    ]
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_reading_time"] == 3.0
+
+
+def test_reading_time_non_positive_total() -> None:
+    sess = _sess_with_validation_data()
+    sess.stimulus_start_end_ts = [
+        {"stimulus": "a", "trial": "trial_1", "start_ts": 4000.0, "stop_ts": 1000.0},
+    ]
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_reading_time"] == "unknown"
+
+
+def test_reading_time_already_set() -> None:
+    sess = _sess_with_validation_data()
+    sess.total_reading_time = 42.0
+    sess.stimulus_start_end_ts = [
+        {"stimulus": "a", "trial": "trial_1", "start_ts": 1000.0, "stop_ts": 4000.0},
+    ]
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_reading_time"] == 42.0

--- a/tests/unit/preprocessing/data_collection/test_session_overview.py
+++ b/tests/unit/preprocessing/data_collection/test_session_overview.py
@@ -1,8 +1,10 @@
-import polars as pl
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import polars as pl
 
 from preprocessing.data_collection.session import Session
+from preprocessing.data_collection.stimulus import LabConfig
 
 
 def _make_session(overrides: dict | None = None) -> Session:
@@ -18,17 +20,31 @@ def _make_session(overrides: dict | None = None) -> Session:
     return Session(**fields)
 
 
-def _mock_lab_config():
-    cfg = MagicMock()
-    cfg.screen_resolution = (1920, 1080)
-    cfg.screen_size_cm = (52.0, 32.0)
-    cfg.screen_distance_cm = 60.0
-    cfg.image_resolution = (1322, 980)
-    cfg.image_size_cm = (38.0, 28.3)
-    cfg.name_eye_tracker = "test"
-    cfg.sampling_frequency_hz = 1000.0
-    cfg.psychometric_tests = []
-    return cfg
+def _mock_lab_config() -> LabConfig:
+    return LabConfig(
+        screen_resolution=(1920, 1080),
+        screen_size_cm=(52.0, 32.0),
+        screen_distance_cm=60.0,
+        image_resolution=(1322, 980),
+        image_size_cm=(38.0, 28.3),
+        name_eye_tracker="test",
+        sampling_frequency_hz=1000.0,
+        psychometric_tests=[],
+    )
+
+
+def _seed_metadata(sess: Session) -> None:
+    sess.pm_gaze_metadata = {
+        "tracked_eye": "R",
+        "data_loss_ratio": 0.02,
+        "mount_configuration": {
+            "mount_type": "Desktop",
+            "head_stabilization": "stabilized",
+            "eyes_recorded": "binocular / monocular",
+        },
+        "pupil_data_type": "AREA",
+    }
+    sess.lab_config = _mock_lab_config()
 
 
 def test_create_overview_includes_new_fields() -> None:
@@ -44,25 +60,22 @@ def test_create_overview_includes_new_fields() -> None:
     sess = _make_session()
     sess.validations = validations
     sess.calibrations = calibrations
-    sess.pm_gaze_metadata = {
-        "tracked_eye": "R",
-        "data_loss_ratio": 0.02,
-        "mount_configuration": {"mount_type": "Desktop"},
-        "pupil_data_type": "AREA",
-    }
-    sess.lab_config = _mock_lab_config()
+    _seed_metadata(sess)
 
     overview = sess.create_overview()
 
-    assert overview["tracked_eye"] == "R"
-    assert overview["tracked_eye_consistent"] is True
-    assert overview["num_good_validations"] == 1
-    assert overview["num_moderate_validations"] == 1
-    assert overview["num_bad_validations"] == 1
-    assert "total_data_loss_ratio" in overview
-    assert overview["total_data_loss_ratio"] is None
-    assert "blink_loss_ratio" in overview
-    assert overview["blink_loss_ratio"] is None
+    tracking = overview["Tracking"]
+    assert tracking["tracked_eye"] == "R"
+    assert tracking["tracked_eye_consistent"] is True
+    cal = overview["Calibration_validation"]
+    assert cal["num_good_validations"] == 1
+    assert cal["num_moderate_validations"] == 1
+    assert cal["num_bad_validations"] == 1
+    dq = overview["Data_quality"]
+    assert "total_data_loss_ratio" in dq
+    assert dq["total_data_loss_ratio"] is None
+    assert "blink_loss_ratio" in dq
+    assert dq["blink_loss_ratio"] is None
 
 
 def test_create_overview_includes_measure_based_data_loss() -> None:
@@ -76,21 +89,15 @@ def test_create_overview_includes_measure_based_data_loss() -> None:
             "eye": ["right"],
         }
     )
-    sess.pm_gaze_metadata = {
-        "tracked_eye": "R",
-        "data_loss_ratio": 0.02,
-        "mount_configuration": {"mount_type": "Desktop"},
-        "pupil_data_type": "AREA",
-    }
-    sess.lab_config = _mock_lab_config()
+    _seed_metadata(sess)
     sess._measure_total_data_loss_ratio = 0.015
     sess._measure_blink_loss_ratio = 0.008
 
     overview = sess.create_overview()
 
-    assert overview["total_data_loss_ratio"] == 0.015
-    assert overview["blink_loss_ratio"] == 0.008
-    assert "data_loss_ratio" not in overview
+    dq = overview["Data_quality"]
+    assert dq["total_data_loss_ratio"] == 0.015
+    assert dq["blink_loss_ratio"] == 0.008
 
 
 def test_tracked_eye_inconsistent_when_eye_changes() -> None:
@@ -106,15 +113,205 @@ def test_tracked_eye_inconsistent_when_eye_changes() -> None:
     sess = _make_session()
     sess.validations = validations
     sess.calibrations = calibrations
-    sess.pm_gaze_metadata = {
-        "tracked_eye": "R",
-        "data_loss_ratio": 0.01,
-        "mount_configuration": {"mount_type": "Desktop"},
-        "pupil_data_type": "AREA",
-    }
-    sess.lab_config = _mock_lab_config()
+    _seed_metadata(sess)
 
     overview = sess.create_overview()
 
-    assert overview["tracked_eye"] == "R"
-    assert overview["tracked_eye_consistent"] is False
+    tracking = overview["Tracking"]
+    assert tracking["tracked_eye"] == "R"
+    assert tracking["tracked_eye_consistent"] is False
+
+
+def test_sections_are_present() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0],
+            "accuracy_avg": [0.2],
+            "accuracy_max": [0.3],
+            "eye": ["right"],
+        }
+    )
+
+    overview = sess.create_overview()
+
+    assert list(overview.keys()) == [
+        "Administrative",
+        "Technical_setup",
+        "Tracking",
+        "Calibration_validation",
+        "Data_quality",
+        "Experiment_procedure",
+        "Comprehension",
+        "Data_formats",
+    ]
+
+
+def test_technical_setup_from_lab_config() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0],
+            "accuracy_avg": [0.2],
+            "accuracy_max": [0.3],
+            "eye": ["right"],
+        }
+    )
+
+    overview = sess.create_overview()
+    tech = overview["Technical_setup"]
+
+    assert tech["Eye_tracker_name"] == "test"
+    assert tech["Sampling_frequency_hz"] == 1000.0
+    assert tech["Mount_type"] == "Desktop"
+    assert tech["Head_stabilization"] == "stabilized"
+    assert tech["Eyes_recorded"] == "binocular / monocular"
+    assert tech["Pupil_data_type"] == "AREA"
+    assert tech["Screen_resolution_width_px"] == 1920
+    assert tech["Screen_resolution_height_px"] == 1080
+    assert tech["Screen_distance_cm"] == 60.0
+    assert tech["Image_size_width_cm"] == 38.0
+
+
+def test_avg_validation_error_computed_from_validations() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0, 200.0, 300.0],
+            "accuracy_avg": [0.2, 0.3, 0.4],
+            "accuracy_max": [0.3, 0.4, 0.5],
+            "eye": ["right", "right", "right"],
+        }
+    )
+
+    overview = sess.create_overview()
+    cal = overview["Calibration_validation"]
+
+    assert cal["avg_validation_error"] == 0.3
+    assert cal["num_calibrations"] == 1
+    assert cal["num_validations"] == 3
+
+
+def test_comprehension_scores_read_from_answers_csv(tmp_path: Path) -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0],
+            "accuracy_avg": [0.2],
+            "accuracy_max": [0.3],
+            "eye": ["right"],
+        }
+    )
+
+    answers = pl.DataFrame(
+        {
+            "trial": ["trial_1"] * 6,
+            "condition_number": [1, 1, 2, 2, 3, 3],
+            "is_correct": [True, False, True, True, False, True],
+        }
+    )
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    answers.write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        overview = sess.create_overview()
+        comp = overview["Comprehension"]
+
+    assert comp["avg_comprehension_score"] == 0.667
+    assert comp["avg_comprehension_score_local"] == 0.5
+    assert comp["avg_comprehension_score_bridging"] == 1.0
+    assert comp["avg_comprehension_score_global"] == 0.5
+
+
+class _FakeSid:
+    def __init__(self, answers_dir: Path):
+        self._answers_dir = answers_dir
+
+    @property
+    def answers_dir(self) -> Path:
+        return self._answers_dir
+
+    def __str__(self) -> str:
+        return "001_EN_UK_1_ET1"
+
+
+def test_session_duration_from_messages() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0],
+            "accuracy_avg": [0.2],
+            "accuracy_max": [0.3],
+            "eye": ["right"],
+        }
+    )
+    sess.messages = pl.DataFrame(
+        {"time": [1000.0, 2000.0, 60000.0], "content": ["a", "b", "c"]}
+    )
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_session_duration"] == 59.0
+
+
+def test_reading_time_from_stimulus_start_end_ts() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0],
+            "accuracy_avg": [0.2],
+            "accuracy_max": [0.3],
+            "eye": ["right"],
+        }
+    )
+    sess.stimulus_start_end_ts = [
+        {"stimulus": "a", "trial": "trial_1", "start_ts": 1000.0, "stop_ts": 4000.0},
+        {"stimulus": "b", "trial": "trial_2", "start_ts": 5000.0, "stop_ts": 7000.0},
+    ]
+
+    overview = sess.create_overview()
+    proc = overview["Experiment_procedure"]
+
+    assert proc["total_reading_time"] == 5.0
+
+
+def test_data_formats_section() -> None:
+    sess = _make_session()
+    _seed_metadata(sess)
+    sess.calibrations = pl.DataFrame({"time": [50.0]})
+    sess.validations = pl.DataFrame(
+        {
+            "time": [100.0],
+            "accuracy_avg": [0.2],
+            "accuracy_max": [0.3],
+            "eye": ["right"],
+        }
+    )
+    sess.raw_data = True
+    sess.reading_measures = True
+
+    overview = sess.create_overview()
+    formats = overview["Data_formats"]
+
+    assert formats["raw_data"] is True
+    assert formats["fixations"] is False
+    assert formats["reading_measures"] is True
+    assert formats["answers"] is False


### PR DESCRIPTION
## Summary
Restructures `Session.create_overview()` into hierarchical topic sections that mirror the DCN overview level.

## Changes
- `create_overview()` now returns 8 sections: `Administrative`, `Technical_setup`, `Tracking`, `Calibration_validation`, `Data_quality`, `Experiment_procedure`, `Comprehension`, `Data_formats`
- New computed values:
- `avg_validation_error`: mean of `validations["accuracy_avg"]`
- `avg_comprehension_score` + `avg_comprehension_score_local/global/bridging`: from answers CSV, experiment trials only, split by `condition_number` (1=local, 2=bridging, 3=global)
  https://github.com/MultiplEYE-COST/multipleye-preprocessing/blob/8f7a1ba406a69270bf937fc08831265a8b988802/preprocessing/data_collection/session.py#L220-L267
- `total_session_duration`: from message timestamps `(max-min)/1000` s
  https://github.com/MultiplEYE-COST/multipleye-preprocessing/blob/8f7a1ba406a69270bf937fc08831265a8b988802/preprocessing/data_collection/session.py#L269-L279
- `total_reading_time`: from `stimulus_start_end_ts` sum, s
  https://github.com/MultiplEYE-COST/multipleye-preprocessing/blob/8f7a1ba406a69270bf937fc08831265a8b988802/preprocessing/data_collection/session.py#L339-L360
- New `Technical_setup` fields from `lab_config` + `pm_gaze_metadata` (eye tracker, sampling freq, mount type/head stabilization/eyes recorded, pupil data type, screen/image resolutions and sizes, screen distance)

The `review_app/` also has these fields now:

## Verification
- tests pass. 20 session-overview + review_app session-data tests

## Notes / follow-ups
- `avg_calibration_error` stays `"unknown"`. The calibrations DataFrame has no `accuracy_avg` column (only validations do) To be added?
- Deferred: `final_validation_score`, `eyelink_filters`, per-trial time breakdowns, `stimulus_order_ids_with_names`, `total_question_time_ms`/`total_rating_time_ms`, participant info, and the `trials` list

Example:
```
Administrative:
  is_pilot: false
  month_of_data_collection: Feb
  participant_id: 23
  session_identifier: [redacted]_DE_DE_1_ET1
  year_of_data_collection: 2026
Calibration_validation:
  avg_calibration_error: unknown
  avg_validation_error: 0.242
  num_bad_validations: 0
  num_calibrations: 14
  num_good_validations: 11
  num_moderate_validations: 4
  num_validations: 15
Comprehension:
  avg_comprehension_score: 0.6
  avg_comprehension_score_bridging: 0.55
  avg_comprehension_score_global: 0.65
  avg_comprehension_score_local: 0.6
Data_formats:
  answers: true
  fixations: true
  raw_data: true
  reading_measures: true
  saccades: true
Data_quality:
  blink_loss_ratio: 0.011735523109635292
  total_data_loss_ratio: 0.36533091556820546
Experiment_procedure:
  num_completed_trials: 12
  num_optional_breaks_made: unknown
  obligatory_break_made: unknown
  question_order: unknown
  stimulus_order_ids:
  - 13
  - 7
  - 3
  - 4
  - 11
  - 1
  - 2
  - 8
  - 9
  - 10
  - 6
  - 12
  total_break_time: unknown
  total_reading_time: 3049.917
  total_session_duration: 6376.694
  was_session_interrupted: unknown
Technical_setup:
  Eye_tracker_name: EyeLink 1000-Plus
  Eyes_recorded: binocular / monocular
  Head_stabilization: stabilized
  Image_resolution_height_px: 1015
  Image_resolution_width_px: 1353
  Image_size_height_cm: 28
  Image_size_width_cm: 37
  Mount_type: Desktop
  Pupil_data_type: AREA
  Sampling_frequency_hz: 1000
  Screen_distance_cm: 60
  Screen_resolution_height_px: 1200
  Screen_resolution_width_px: 1920
  Screen_size_height_cm: 33.1
  Screen_size_width_cm: 52.5
Tracking:
  tracked_eye: L
  tracked_eye_consistent: true
```