### PR TITLE
chore: pin ruff to 0.16.3 and normalise lint across the repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: nbstripout
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.16.3
     hooks:
       # Run the formatter.
       - id: ruff-format

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,12 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 # from sphinx.search import languages
 
 project = "MultiplEYE Preprocessing pEYEpline"
-copyright = f"2024–{datetime.now().year}, Deborah N. Jakobi et al"
+copyright = f"2024–{datetime.now(tz=UTC).year}, Deborah N. Jakobi et al"
 author = "Deborah N. Jakobi et al."
 release = "2026.08.12"
 

--- a/preprocessing/__init__.py
+++ b/preprocessing/__init__.py
@@ -28,11 +28,11 @@ setup_logging(
     file_level=settings.FILE_LOG_LEVEL,
 )
 
-from .api import *  # noqa: F403, E402 # Brings all functions from API into the top-level preprocessing namespace
+from .api import *  # Brings all functions from API into the top-level preprocessing namespace
 
 # Functionality made available with absolute imports
-from .api import __all__ as _api_all  # noqa: E402
-from .data_collection import __all__ as _data_collection_all  # noqa: E402
-from .utils import __all__ as _utils_all  # noqa: E402
+from .api import __all__ as _api_all
+from .data_collection import __all__ as _data_collection_all
+from .utils import __all__ as _utils_all
 
 __all__ = list(set(_api_all + _data_collection_all + _utils_all)) + ["settings"]

--- a/preprocessing/answers/collect.py
+++ b/preprocessing/answers/collect.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 
 import polars as pl
 
-from .parser import parse_question_order, construct_question_id
-from .io import write_answers
 from ..data_collection.stimulus import Stimulus
 from ..utils.logging import get_logger
+from .io import write_answers
+from .parser import construct_question_id, parse_question_order
 
 
 def _normalize_trial_key(k) -> int | str:
@@ -395,7 +395,7 @@ def collect_session_answers(
             num = int(str(trial_id).split("_")[-1])
             return f"1_{num:03d}"
         except (ValueError, IndexError):
-            return f"2_{str(trial_id)}"
+            return f"2_{trial_id!s}"
 
     long_df = long_df.with_columns(
         pl.col("trial")

--- a/preprocessing/answers/experiment_log_parser.py
+++ b/preprocessing/answers/experiment_log_parser.py
@@ -1,9 +1,10 @@
 import warnings
+
 import polars as pl
 
 
 def parse_answers_from_logfile(
-    logfile: pl.DataFrame, stimuli_trial_mapping: dict[str, str] = None
+    logfile: pl.DataFrame, stimuli_trial_mapping: dict[str, str] | None = None
 ) -> pl.DataFrame:
     """Parse comprehension question answers from experiment logfile.
 

--- a/preprocessing/answers/msg_parser.py
+++ b/preprocessing/answers/msg_parser.py
@@ -1,5 +1,6 @@
-import polars as pl
 import re
+
+import polars as pl
 
 
 def _result_schema() -> dict:

--- a/preprocessing/api.py
+++ b/preprocessing/api.py
@@ -1,53 +1,52 @@
 """pEYEpline: API for the MultiplEYE preprocessing pipeline"""
 
-from .metrics.calculate import calculate_reading_measures
-from .signals.preprocess import preprocess_gaze
-from .events.properties import compute_event_properties
+from .answers.collect import collect_session_answers
+from .answers.experiment_log_parser import parse_answers_from_logfile
+from .answers.msg_parser import parse_answers_from_messages
+from .checks.preflight import run_preflight_check
 from .events.detect import detect_fixations, detect_saccades
-from .mapping.aoi import map_fixations_to_aois
-from .io.save import (
-    save_raw_data,
-    save_events_data,
-    save_scanpaths,
-    save_session_metadata,
-    save_reading_measures,
-)
+from .events.properties import compute_event_properties
 from .io.load import (
     load_gaze_data,
-    load_trial_level_raw_data,
-    load_trial_level_events_data,
     load_reading_measures,
+    load_trial_level_events_data,
+    load_trial_level_raw_data,
 )
-from .answers.msg_parser import parse_answers_from_messages
-from .answers.experiment_log_parser import parse_answers_from_logfile
-from .answers.collect import collect_session_answers
-from .checks.preflight import run_preflight_check
-
+from .io.save import (
+    save_events_data,
+    save_raw_data,
+    save_reading_measures,
+    save_scanpaths,
+    save_session_metadata,
+)
+from .mapping.aoi import map_fixations_to_aois
+from .metrics.calculate import calculate_reading_measures
+from .psychometric_tests.preprocess_psychometric_tests import preprocess_all_sessions
 from .scripts.prepare_language_folder import prepare_language_folder
 from .scripts.restructure_psycho_tests import fix_psycho_tests_structure
-from .psychometric_tests.preprocess_psychometric_tests import preprocess_all_sessions
+from .signals.preprocess import preprocess_gaze
 
 __all__ = [
-    "prepare_language_folder",
-    "fix_psycho_tests_structure",
-    "preprocess_all_sessions",
-    "preprocess_gaze",
-    "compute_event_properties",  # needed in API? - not directly used in the preprocessing pipeline
     "calculate_reading_measures",
+    "collect_session_answers",
+    "compute_event_properties",  # needed in API? - not directly used in the preprocessing pipeline
     "detect_fixations",
     "detect_saccades",
+    "fix_psycho_tests_structure",
+    "load_gaze_data",
+    "load_reading_measures",
+    "load_trial_level_events_data",
+    "load_trial_level_raw_data",
     "map_fixations_to_aois",
-    "save_raw_data",
+    "parse_answers_from_logfile",
+    "parse_answers_from_messages",
+    "prepare_language_folder",
+    "preprocess_all_sessions",
+    "preprocess_gaze",
+    "run_preflight_check",
     "save_events_data",
+    "save_raw_data",
+    "save_reading_measures",
     "save_scanpaths",
     "save_session_metadata",
-    "save_reading_measures",
-    "load_gaze_data",
-    "load_trial_level_raw_data",
-    "load_trial_level_events_data",
-    "load_reading_measures",
-    "parse_answers_from_messages",
-    "parse_answers_from_logfile",
-    "collect_session_answers",
-    "run_preflight_check",
 ]

--- a/preprocessing/checks/et_quality_checks.py
+++ b/preprocessing/checks/et_quality_checks.py
@@ -1,6 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TextIO
-from collections.abc import Callable
 
 import polars as pl
 
@@ -48,7 +48,9 @@ def report_to_file_metadata(
 
 
 def check_comprehension_question_answers(
-    logfile: pl.DataFrame, stimuli: Stimulus | list[Stimulus], report_file: Path = None
+    logfile: pl.DataFrame,
+    stimuli: Stimulus | list[Stimulus],
+    report_file: Path | None = None,
 ):
     """compute the number of correct answers for each participant
     params: logfile as polars

--- a/preprocessing/checks/formal_experiment_checks.py
+++ b/preprocessing/checks/formal_experiment_checks.py
@@ -46,7 +46,9 @@ RATING_SCREENS = [
 
 
 def check_all_screens_logfile(
-    logfile: pl.DataFrame, stimuli: Stimulus | list[Stimulus], report_file: Path = None
+    logfile: pl.DataFrame,
+    stimuli: Stimulus | list[Stimulus],
+    report_file: Path | None = None,
 ):
     """
     checking if all screens, where ET data is tracked are present in the log file
@@ -203,7 +205,7 @@ def check_messages(
 
         try:
             last_msg_index = messages_only.index(f"start_recording{pattern}_page_1")
-        except ValueError as e:
+        except ValueError:
             # if the session has been restarted, there might be a mismatch between trial numbers and stimulus ids
             if restarted:
                 while updated_trial <= 12:
@@ -214,9 +216,9 @@ def check_messages(
                         last_msg_index = messages_only.index(pattern)
                         break
                 else:
-                    raise e
+                    raise
             else:
-                raise e
+                raise
 
         last_msg_timestamp = messages[last_msg_index].get("timestamp")
 

--- a/preprocessing/checks/quality_thresholds.py
+++ b/preprocessing/checks/quality_thresholds.py
@@ -1,5 +1,6 @@
-import yaml
 from pathlib import Path
+
+import yaml
 
 from ..config import settings
 

--- a/preprocessing/data_collection/__init__.py
+++ b/preprocessing/data_collection/__init__.py
@@ -1,9 +1,9 @@
 """Data collection submodule of the preprocessing module."""
 
-from .multipleye_data_collection import MultipleyeDataCollection
 from .merid_data_collection import MeridDataCollection
+from .multipleye_data_collection import MultipleyeDataCollection
 
 __all__ = [
-    "MultipleyeDataCollection",
     "MeridDataCollection",
+    "MultipleyeDataCollection",
 ]

--- a/preprocessing/data_collection/merid_data_collection.py
+++ b/preprocessing/data_collection/merid_data_collection.py
@@ -1,10 +1,11 @@
 import warnings
 
-from ..data_collection.multipleye_data_collection import MultipleyeDataCollection
-from ..models.sid import Sid
 from preprocessing.scripts.prepare_language_folder import (
     extract_stimulus_version_number_from_asc,
 )
+
+from ..data_collection.multipleye_data_collection import MultipleyeDataCollection
+from ..models.sid import Sid
 
 
 class MeridDataCollection(MultipleyeDataCollection):
@@ -112,4 +113,3 @@ class MeridDataCollection(MultipleyeDataCollection):
         warnings.warn(
             "Not yet implemented: loading psychometric tests for MeRID data collection."
         )
-        pass

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -338,7 +338,7 @@ class MultipleyeDataCollection:
             if missing_included:
                 self.logger.warning(
                     f"The following sessions were specified in 'include_sessions' but "
-                    f"were not found in the data folder: {sorted(list(missing_included))}"
+                    f"were not found in the data folder: {sorted(missing_included)}"
                 )
 
         if self.excluded_sessions:
@@ -346,7 +346,7 @@ class MultipleyeDataCollection:
             if missing_excluded:
                 self.logger.warning(
                     f"The following sessions were specified in 'exclude_sessions' but "
-                    f"were not found in the data folder: {sorted(list(missing_excluded))}"
+                    f"were not found in the data folder: {sorted(missing_excluded)}"
                 )
 
     @eyelink
@@ -389,6 +389,7 @@ class MultipleyeDataCollection:
                 ["edf2asc", "-y", edf_path],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                check=False,
             )
 
             local_asc_path = edf_path.with_suffix(".asc")
@@ -1212,7 +1213,7 @@ class MultipleyeDataCollection:
                 try:
                     trial_ids[trial_ids.index(trial)] = f"trial_{int(trial)}"
                 except TypeError:
-                    trial_ids = trial_ids
+                    pass  # trial id already in the target format, leave as-is
 
         stimulus_names = completed_stimuli["stimulus_name"].to_list()
         stimuli_trial_mapping = {
@@ -1759,7 +1760,7 @@ class MultipleyeDataCollection:
         )
 
     def _check_stimuli_gaze_frame(self, gaze, stimuli, session_identifier):
-        """ """
+        """Check the gaze data for all stimuli screens of a session."""
         logging.debug(
             f"Checking asc file all screens for {session_identifier} all screens."
         )
@@ -1944,7 +1945,7 @@ if __name__ == "__main__":
     settings.setup_logging()
     data_collection_folder = "MultiplEYE_ET_EE_Tartu_1_2025"
 
-    this_repo = Path().resolve().parent
+    this_repo = Path.cwd().parent
 
     data_folder_path = this_repo / "data" / data_collection_folder
 

--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -247,7 +247,7 @@ class Session:
 
         try:
             answers = pl.read_csv(answers_csv)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(f"Could not read answers CSV {answers_csv}: {exc}")
             return
 

--- a/preprocessing/data_collection/stimulus.py
+++ b/preprocessing/data_collection/stimulus.py
@@ -11,8 +11,8 @@ import pymovements as pm
 from pymovements.stimulus import TextStimulus
 
 from ..config import settings
-from ..utils.data_path_utils import _ci_resolve
 from ..mapping.aoi import enlarge_aois
+from ..utils.data_path_utils import _ci_resolve
 from ..utils.logging import get_logger
 
 logger = get_logger()
@@ -359,7 +359,7 @@ class LabConfig:
 
         psychometric_tests = json_config.get("Psychometric_tests", {})
         if not isinstance(psychometric_tests, dict):
-            raise ValueError(
+            raise TypeError(
                 f"'Psychometric_tests' in lab configuration JSON must be an object (dict), "
                 f"got {type(psychometric_tests).__name__}. "
                 f"Check file: {json_config_path}"

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -20,7 +20,7 @@ def load_gaze_data(
     asc_file: Path,
     lab_config: LabConfig,
     sid: Sid,
-    trial_cols: list[str] = None,
+    trial_cols: list[str] | None = None,
     messages: bool | list[str] = False,
 ) -> pm.Gaze:
     """Load sample gaze data from an ASC file.

--- a/preprocessing/io/save.py
+++ b/preprocessing/io/save.py
@@ -1,12 +1,12 @@
 """Functions for saving data."""
 
+import contextlib
 import json
 
 import polars as pl
-
 import pymovements as pm
+
 from ..models.sid import Sid
-import contextlib
 
 
 def save_raw_data(sid: Sid, data: pm.Gaze) -> None:
@@ -33,7 +33,7 @@ def save_raw_data(sid: Sid, data: pm.Gaze) -> None:
         df = trial.samples
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]
-        name = f"{str(sid)}_{trial}_{stimulus}_raw_data.csv"
+        name = f"{sid!s}_{trial}_{stimulus}_raw_data.csv"
         df = df["time", "pixel_x", "pixel_y", "pupil", "page"]
         df.write_csv(directory / name)
 
@@ -81,7 +81,7 @@ def save_events_data(
     events = data_copy.events.frame.filter(pl.col("name") == event_type)
 
     for group in events.partition_by(split_column):
-        name = f"{str(sid)}"
+        name = f"{sid!s}"
         for col in name_columns:
             if col not in group.columns:
                 raise ValueError(f"Column {col} not found in events data.")
@@ -127,7 +127,7 @@ def save_scanpaths(sid: Sid, data: pm.Gaze) -> None:
             continue
         trial = df["trial"][0]
         stimulus = df["stimulus"][0]
-        name = f"{str(sid)}_{trial}_{stimulus}_scanpath.csv"
+        name = f"{sid!s}_{trial}_{stimulus}_scanpath.csv"
 
         df = df[
             "onset",
@@ -170,7 +170,7 @@ def save_reading_measures(sid: Sid, data: pl.DataFrame) -> None:
     for trial in trials:
         trial_id = trial["trial"][0]
         stimulus = trial["stimulus"][0]
-        name = f"{str(sid)}_{trial_id}_{stimulus}_reading_measures.csv"
+        name = f"{sid!s}_{trial_id}_{stimulus}_reading_measures.csv"
         trial = trial.drop("stimulus", "trial")
         trial.write_csv(directory / name)
 

--- a/preprocessing/mapping/aoi.py
+++ b/preprocessing/mapping/aoi.py
@@ -1,7 +1,6 @@
 """Mapping of fixations to AOIs."""
 
 import polars as pl
-
 import pymovements as pm
 
 

--- a/preprocessing/metrics/calculate.py
+++ b/preprocessing/metrics/calculate.py
@@ -1,12 +1,12 @@
-import pymovements as pm
 import polars as pl
+import pymovements as pm
 
 from preprocessing.data_collection.stimulus import Stimulus
 from preprocessing.metrics.reading.fixations import annotate_fixations
 from preprocessing.metrics.reading.reading_measures import build_word_level_table
 from preprocessing.metrics.reading.words import (
-    mark_skipped_tokens,
     all_tokens_from_aois,
+    mark_skipped_tokens,
 )
 
 

--- a/preprocessing/metrics/reading/words.py
+++ b/preprocessing/metrics/reading/words.py
@@ -5,7 +5,7 @@ from ...config import settings
 
 def all_tokens_from_aois(
     aois: pl.DataFrame,
-    trial: str = None,
+    trial: str | None = None,
 ) -> pl.DataFrame:
     """
     Returns every AOI token on the page:

--- a/preprocessing/models/__init__.py
+++ b/preprocessing/models/__init__.py
@@ -1,4 +1,4 @@
-from .sid import Sid
 from .dcn import Dcn
+from .sid import Sid
 
-__all__ = ["Sid", "Dcn"]
+__all__ = ["Dcn", "Sid"]

--- a/preprocessing/models/dcn.py
+++ b/preprocessing/models/dcn.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
 import re
+from dataclasses import dataclass, field
 
 __all__ = ["Dcn"]
 

--- a/preprocessing/models/sid.py
+++ b/preprocessing/models/sid.py
@@ -1,6 +1,6 @@
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
-import re
 
 __all__ = ["Sid"]
 

--- a/preprocessing/plotting/plot.py
+++ b/preprocessing/plotting/plot.py
@@ -1,8 +1,8 @@
 import math
 from pathlib import Path
 
-import PIL
 import matplotlib.pyplot as plt
+import PIL
 import polars as pl
 import pymovements as pm
 from matplotlib.patches import Circle

--- a/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
+++ b/preprocessing/psychometric_tests/preprocess_psychometric_tests.py
@@ -20,8 +20,8 @@ import warnings
 from math import nan
 from pathlib import Path
 
-from pandas import read_csv, DataFrame
 import pandas as pd
+from pandas import DataFrame, read_csv
 
 from ..config import settings
 from ..models.sid import Sid
@@ -181,7 +181,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["LWMC_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"[{session.name}] LWMC test skipped: {str(err)}",
+                    f"[{session.name}] LWMC test skipped: {err!s}",
                     category=UserWarning,
                 )
 
@@ -197,7 +197,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["RAN_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"[{session.name}] RAN test skipped: {str(err)}",
+                    f"[{session.name}] RAN test skipped: {err!s}",
                     category=UserWarning,
                 )
 
@@ -226,7 +226,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["Stroop_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"[{session.name}] Stroop test skipped: {str(err)}",
+                    f"[{session.name}] Stroop test skipped: {err!s}",
                     category=UserWarning,
                 )
             try:
@@ -253,7 +253,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["Flanker_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"[{session.name}] Flanker test skipped: {str(err)}",
+                    f"[{session.name}] Flanker test skipped: {err!s}",
                     category=UserWarning,
                 )
 
@@ -277,7 +277,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["WikiVocab_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"[{session.name}] WikiVocab test skipped: {str(err)}",
+                    f"[{session.name}] WikiVocab test skipped: {err!s}",
                     category=UserWarning,
                 )
 
@@ -300,7 +300,7 @@ def preprocess_all_sessions(test_session_folder: Path | None = None) -> Path:
                 overview_row["PLAB_Done"] = 1
             except ValueError as err:
                 warnings.warn(
-                    f"[{session.name}] PLAB test skipped: {str(err)}",
+                    f"[{session.name}] PLAB test skipped: {err!s}",
                     category=UserWarning,
                 )
 
@@ -1275,9 +1275,9 @@ def preprocess_plab(plab_dir: Path) -> dict:
     df_set1 = df[df["question_id"].isin([1, 2, 3, 4])]
     df_set2 = df[df["question_id"].isin(range(5, 16))]
 
-    rt_set1, acc_set1, num_set1 = (nan, nan, 0)
+    rt_set1, acc_set1, _num_set1 = (nan, nan, 0)
     if not df_set1.empty:
-        rt_set1, acc_set1, num_set1 = _reaction_time_accuracy(
+        rt_set1, acc_set1, _num_set1 = _reaction_time_accuracy(
             df_set1,
             reaction_time_col="rt",
             correctness_col="correctness",
@@ -1285,9 +1285,9 @@ def preprocess_plab(plab_dir: Path) -> dict:
             max_rt=float("inf"),
         )
 
-    rt_set2, acc_set2, num_set2 = (nan, nan, 0)
+    rt_set2, acc_set2, _num_set2 = (nan, nan, 0)
     if not df_set2.empty:
-        rt_set2, acc_set2, num_set2 = _reaction_time_accuracy(
+        rt_set2, acc_set2, _num_set2 = _reaction_time_accuracy(
             df_set2,
             reaction_time_col="rt",
             correctness_col="correctness",

--- a/preprocessing/scripts/prepare_language_folder.py
+++ b/preprocessing/scripts/prepare_language_folder.py
@@ -1,21 +1,21 @@
 import argparse
+import os
 import re
 import shutil
-import os
 import tarfile
 from pathlib import Path
 
 import pandas as pd
 
 from ..models.dcn import Dcn
+from ..scripts.restructure_psycho_tests import fix_psycho_tests_structure
 from ..utils.data_path_utils import check_data_collection_exists
 from ..utils.file_utils import _copytree, _to_win_long_path
-from ..utils.logging import get_logger
-from ..scripts.restructure_psycho_tests import fix_psycho_tests_structure
 from ..utils.fix_multipleye_aoi_files import (
     remap_space_to_following_word,
     repair_word_labels,
 )
+from ..utils.logging import get_logger
 
 logger = get_logger()
 
@@ -80,9 +80,11 @@ def prepare_language_folder(data_collection_name: str | None = None):
                         only_in_dst = dst_names - src_names
                         if only_in_src or only_in_dst:
                             msg_parts = [
-                                f"Folder '{folder.name}' exists in both "
-                                f"'core_sessions' and 'eye-tracking-sessions' "
-                                f"with different contents."
+                                (
+                                    f"Folder '{folder.name}' exists in both "
+                                    f"'core_sessions' and 'eye-tracking-sessions' "
+                                    f"with different contents."
+                                )
                             ]
                             if only_in_src:
                                 msg_parts.append(

--- a/preprocessing/scripts/psychometric_tests.py
+++ b/preprocessing/scripts/psychometric_tests.py
@@ -1,11 +1,11 @@
 """Main script for the psychmetric test processing."""
 
 import argparse
-from ..utils.logging import get_logger
 from pathlib import Path
 
 from .. import settings
 from ..psychometric_tests.preprocess_psychometric_tests import preprocess_all_sessions
+from ..utils.logging import get_logger
 
 
 def process_all_psychometric_test_sessions():

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -1,17 +1,17 @@
+import contextlib
 import os
 from argparse import ArgumentParser
 
-from tqdm import tqdm
 import polars as pl
 import pymovements as pm
+from tqdm import tqdm
 
-from ..utils.logging import get_logger
 import preprocessing
 from preprocessing import settings
-
-from preprocessing.scripts.prepare_language_folder import prepare_language_folder
 from preprocessing.checks.quality_thresholds import write_quality_thresholds
-import contextlib
+from preprocessing.scripts.prepare_language_folder import prepare_language_folder
+
+from ..utils.logging import get_logger
 
 
 def run_preprocessing(config_path: str | None = None):

--- a/preprocessing/scripts/sync_version.py
+++ b/preprocessing/scripts/sync_version.py
@@ -1,6 +1,6 @@
-import sys
-import re
 import argparse
+import re
+import sys
 from pathlib import Path
 
 # Paths to files and the regex to find the version string in each

--- a/preprocessing/utils/__init__.py
+++ b/preprocessing/utils/__init__.py
@@ -1,19 +1,19 @@
 """Utilities submodule of the preprocessing module."""
 
+from .data_collection_utils import _report_to_file
 from .data_path_utils import (
     check_data_collection_exists,
     validate_psychometric_data,
 )
-from .data_collection_utils import _report_to_file
 from .file_utils import _copytree, _to_win_long_path
 from .logging import get_logger, setup_logging
 
 __all__ = [
-    "check_data_collection_exists",
-    "validate_psychometric_data",
-    "_report_to_file",
     "_copytree",
+    "_report_to_file",
     "_to_win_long_path",
+    "check_data_collection_exists",
     "get_logger",
     "setup_logging",
+    "validate_psychometric_data",
 ]

--- a/preprocessing/utils/add_custom_uoa_to_aois.py
+++ b/preprocessing/utils/add_custom_uoa_to_aois.py
@@ -14,8 +14,9 @@ from pathlib import Path
 
 import pandas as pd
 
-from ..models.dcn import Dcn
 from preprocessing import config
+
+from ..models.dcn import Dcn
 
 
 def rename_aoi_header(data_collection_name: str) -> None:

--- a/preprocessing/utils/conversion.py
+++ b/preprocessing/utils/conversion.py
@@ -1,7 +1,7 @@
 """Conversion utilities."""
 
 
-def convert_to_time_str(duration_ms: float | int) -> str:
+def convert_to_time_str(duration_ms: float) -> str:
     """Convert a duration in milliseconds to a string in the format HH:MM:SS.
 
     Parameters
@@ -20,7 +20,7 @@ def convert_to_time_str(duration_ms: float | int) -> str:
         If duration_ms is >= 86,400,000 (24 hours or more), negative, or not a number.
     """
     if not isinstance(duration_ms, (int, float)):
-        raise ValueError(f"Duration must be a number: {duration_ms}")
+        raise ValueError(f"Duration must be a number: {duration_ms}")  # noqa: TRY004
     if duration_ms < 0:
         raise ValueError(f"Duration cannot be negative: {duration_ms}")
     if duration_ms >= 86400000:

--- a/preprocessing/utils/data_collection_utils.py
+++ b/preprocessing/utils/data_collection_utils.py
@@ -15,5 +15,5 @@ def _report_to_file(message: str, report_file: Path) -> None:
         The path to the file where the message will be appended.
     """
     assert isinstance(report_file, Path)
-    with open(report_file, "a", encoding="utf-8") as report_file:
-        report_file.write(f"{message}\n")
+    with open(report_file, "a", encoding="utf-8") as f:
+        f.write(f"{message}\n")

--- a/preprocessing/utils/data_path_utils.py
+++ b/preprocessing/utils/data_path_utils.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import yaml
 
-from ..models.sid import Sid
 from preprocessing.config import settings
+
+from ..models.sid import Sid
 
 
 def _ci_exists(path: Path) -> bool:

--- a/preprocessing/utils/file_utils.py
+++ b/preprocessing/utils/file_utils.py
@@ -24,6 +24,6 @@ def _copytree(src: Path, dst: Path, **kwargs) -> None:
 
 
 __all__ = [
-    "_to_win_long_path",
     "_copytree",
+    "_to_win_long_path",
 ]

--- a/preprocessing/utils/fix_multipleye_aoi_files.py
+++ b/preprocessing/utils/fix_multipleye_aoi_files.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-import polars as pl
 import pandas as pd
+import polars as pl
 
 from ..utils.logging import get_logger
 

--- a/preprocessing/utils/logging.py
+++ b/preprocessing/utils/logging.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from ..config import settings
 import logging
 import re
 import subprocess
@@ -8,6 +7,8 @@ from importlib import metadata
 from pathlib import Path
 
 import pymovements as pm
+
+from ..config import settings
 
 # Package-level logger
 logger = logging.getLogger("preprocessing")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,30 @@ review = [
 [tool.setuptools.packages.find]
 include = ["preprocessing", "review_app"]
 
+[tool.ruff]
+# Notebooks are templates/notes, not shipped code; ruff 0.16 lints them by default.
+exclude = ["*.ipynb"]
+
+[tool.ruff.lint]
+# Rules deliberately not enforced. These are the 0.16 default rules that
+# conflict with established codebase patterns; kept as explicit ignores so
+# the effective lint set is reproducible across dev and CI.
+ignore = [
+    "ASYNC220",  # subprocess in async routes (FastAPI pattern, blocking is intentional)
+    "ASYNC230",  # open() in async routes (FastAPI pattern, blocking is intentional)
+    "BLE001",  # blind except: pipeline deliberately catches broadly and logs
+    "LOG015",  # root logger calls: codebase uses the logging module directly
+    "RUF012",  # mutable class attribute defaults (dataclass-like pattern)
+    "S112",  # try-except-continue: psychometric tests deliberately skip and continue
+    "SIM113",  # index-based loop is intentional (index used into stimuli_order)
+]
+
 [dependency-groups]
 dev = [{ include-group = "lint" }, { include-group = "docs" }]
 lint = [
     "pre-commit>=4.5.1",
     "pytest>=7.0.0",
-    "ruff>=0.13.0",
+    "ruff==0.16.3",
 ]
 docs = [
     "myst-nb>=1.3.0",

--- a/review_app/config.py
+++ b/review_app/config.py
@@ -6,9 +6,8 @@ environment variable. Folder name constants mirror those in
 avoid triggering the settings auto-load mechanism.
 """
 
-from pathlib import Path
 import os
-
+from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 

--- a/review_app/main.py
+++ b/review_app/main.py
@@ -1,18 +1,21 @@
 """FastAPI app, route registration, and startup."""
 
-from pathlib import Path
 import urllib.request
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from .config import PREPROCESSED_DATA_DIR
-from .routes.home import router as home_router
 from .routes.collection import (
-    router as collection_router,
     page_router as collection_page_router,
 )
-from .routes.session import router as session_router, api_router as session_api_router
+from .routes.collection import (
+    router as collection_router,
+)
+from .routes.home import router as home_router
+from .routes.session import api_router as session_api_router
+from .routes.session import router as session_router
 from .routes.swipe import router as swipe_router
 
 _HTMX_URL = "https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"
@@ -62,9 +65,10 @@ def _startup() -> None:
     import asyncio
 
     def _run_preflight_for_all_dcns() -> None:
+        from preprocessing.models import Dcn
+
         from .config import RAW_DATA_DIR
         from .services.preflight import run_pipeline_preflight
-        from preprocessing.models import Dcn
 
         if not RAW_DATA_DIR.exists():
             return

--- a/review_app/models.py
+++ b/review_app/models.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-
 ReviewStatus = Literal["unreviewed", "accepted", "flagged", "excluded"]
 CheckStatus = Literal["pass", "warn", "fail"]
 

--- a/review_app/routes/collection.py
+++ b/review_app/routes/collection.py
@@ -73,7 +73,7 @@ async def dcn_psychometric(dcn_name: str) -> JSONResponse:
     with open(path) as f:
         reader = csv.DictReader(f)
         for row in reader:
-            rows.append(row)
+            rows.append(dict(row))
     return JSONResponse(rows)
 
 

--- a/review_app/routes/home.py
+++ b/review_app/routes/home.py
@@ -6,10 +6,9 @@ import signal
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
-from ..templating import render
 from ..config import PREPROCESSED_DATA_DIR
 from ..services.dcn import list_dcns
-
+from ..templating import render
 
 router = APIRouter()
 

--- a/review_app/routes/session.py
+++ b/review_app/routes/session.py
@@ -1,19 +1,19 @@
 """Session-level routes — detail page, review save."""
 
 from pathlib import Path
+
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
-from ..templating import render
-from ..services.session_data import read_overview, build_session_detail
-from ..services.thresholds import load_thresholds
 from ..services.review import load_review, save_review
+from ..services.session_data import build_session_detail, read_overview
 from ..services.swipe import (
-    load_plot_judgments_dict,
-    load_plot_comments_dict,
     list_plot_data,
+    load_plot_comments_dict,
+    load_plot_judgments_dict,
 )
-
+from ..services.thresholds import load_thresholds
+from ..templating import render
 
 router = APIRouter()
 
@@ -70,9 +70,9 @@ async def session_content_partial(
     from ..config import session_overview_path
     from ..services.dcn import list_sessions
     from ..services.swipe import (
-        load_plot_judgments_dict,
-        load_plot_comments_dict,
         list_plot_data,
+        load_plot_comments_dict,
+        load_plot_judgments_dict,
     )
 
     sessions = list_sessions(dcn)

--- a/review_app/routes/swipe.py
+++ b/review_app/routes/swipe.py
@@ -5,15 +5,21 @@ import asyncio
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
-from ..templating import render
 from ..services.dcn import get_dcn
+from ..services.swipe import (
+    remove_plot_judgment as _remove_plot_judgment_sync,
+)
+from ..services.swipe import (
+    save_plot_comment as _save_plot_comment_sync,
+)
+from ..services.swipe import (
+    save_plot_judgment as _save_plot_judgment_sync,
+)
 from ..services.swipe import (
     swipe_data,
     swipe_stats,
-    save_plot_judgment as _save_plot_judgment_sync,
-    remove_plot_judgment as _remove_plot_judgment_sync,
-    save_plot_comment as _save_plot_comment_sync,
 )
+from ..templating import render
 
 router = APIRouter()
 

--- a/review_app/services/preflight.py
+++ b/review_app/services/preflight.py
@@ -8,7 +8,7 @@ loads instantly — the user clicks "Re-run" to refresh.
 
 import io
 from contextlib import redirect_stderr
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import yaml
 
@@ -136,4 +136,4 @@ def _do_run(dcn_name: str) -> dict:
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(UTC).isoformat(timespec="seconds")

--- a/review_app/services/review.py
+++ b/review_app/services/review.py
@@ -4,14 +4,14 @@ Uses atomic write (tempfile -> os.replace) to prevent file corruption.
 Reviews are stored keyed by SID in ``review_data/<DCN>/reviews.yaml``.
 """
 
-import yaml
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from ..models import ReviewAnnotation
+import yaml
+
 from ..config import reviews_file_path
-
+from ..models import ReviewAnnotation
 
 REVIEW_STATUSES = {"unreviewed", "accepted", "flagged", "excluded"}
 
@@ -88,7 +88,7 @@ def save_review(
             f"Invalid issue type: {type_of_issue}. Must be one of {list(ISSUE_TYPES.keys())}"
         )
 
-    reviewed_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    reviewed_at = datetime.now(UTC).isoformat(timespec="seconds")
 
     annotation = ReviewAnnotation(
         status=status,

--- a/review_app/services/thresholds.py
+++ b/review_app/services/thresholds.py
@@ -1,7 +1,8 @@
 """Load quality thresholds YAML and compare values."""
 
-import yaml
 from typing import Any
+
+import yaml
 
 from ..models import CheckStatus
 

--- a/tests/test_data_collection.py
+++ b/tests/test_data_collection.py
@@ -1,12 +1,11 @@
 import unittest
-from unittest import TestCase
-from unittest.mock import patch, MagicMock
 from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from preprocessing.data_collection import MultipleyeDataCollection
-
 
 # the tests were written with github copilot, so they are not complete yet, and I don't know if they are correct, nor do I understand them fully
 

--- a/tests/test_multipleye_data_collection.py
+++ b/tests/test_multipleye_data_collection.py
@@ -1,9 +1,10 @@
-from unittest import TestCase
-import pytest
 from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from preprocessing.data_collection import MultipleyeDataCollection
-from unittest.mock import patch, MagicMock
 
 
 @pytest.mark.skip(reason="Not complete")
@@ -14,7 +15,7 @@ class TestMultipleyeDataCollection(TestCase):
         # For example, you could create a temporary directory or file
         # self.test_dir = tempfile.TemporaryDirectory()
 
-        self.this_repo = Path().resolve().parent
+        self.this_repo = Path.cwd().parent
 
         self.data_collection_folder = "MultiplEYE_toy_X_x_1_1"
         self.data_folder_path = self.this_repo / "tests" / self.data_collection_folder

--- a/tests/unit/data_collection/test_edf2asc_conversion.py
+++ b/tests/unit/data_collection/test_edf2asc_conversion.py
@@ -1,6 +1,7 @@
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from preprocessing.data_collection import MultipleyeDataCollection
 from preprocessing.data_collection.session import Session

--- a/tests/unit/preprocessing/answers/test_collect.py
+++ b/tests/unit/preprocessing/answers/test_collect.py
@@ -4,7 +4,7 @@ import polars as pl
 import pytest
 
 from preprocessing.answers.collect import collect_session_answers
-from preprocessing.data_collection.stimulus import Stimulus, ComprehensionQuestion
+from preprocessing.data_collection.stimulus import ComprehensionQuestion, Stimulus
 
 
 @pytest.fixture

--- a/tests/unit/preprocessing/answers/test_collect_integration.py
+++ b/tests/unit/preprocessing/answers/test_collect_integration.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 import polars as pl
 import pytest
-from pathlib import Path
+
 from preprocessing.answers.collect import collect_session_answers
 from preprocessing.answers.msg_parser import parse_answers_from_messages
-from preprocessing.data_collection.stimulus import Stimulus, ComprehensionQuestion
+from preprocessing.data_collection.stimulus import ComprehensionQuestion, Stimulus
 
 
 @pytest.fixture

--- a/tests/unit/preprocessing/answers/test_experiment_log_parser.py
+++ b/tests/unit/preprocessing/answers/test_experiment_log_parser.py
@@ -1,5 +1,6 @@
 import polars as pl
 import pytest
+
 from preprocessing.answers.experiment_log_parser import parse_answers_from_logfile
 
 

--- a/tests/unit/preprocessing/answers/test_msg_parser.py
+++ b/tests/unit/preprocessing/answers/test_msg_parser.py
@@ -1,5 +1,6 @@
 import polars as pl
 import pytest
+
 from preprocessing.answers.msg_parser import parse_answers_from_messages
 
 

--- a/tests/unit/preprocessing/answers/test_parser.py
+++ b/tests/unit/preprocessing/answers/test_parser.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 
 from preprocessing.answers.parser import (
-    parse_question_order,
     construct_question_id,
+    parse_question_order,
 )
 
 
@@ -12,8 +12,10 @@ from preprocessing.answers.parser import (
     "csv_text,expected_trials,expected_first_row",
     [
         (
-            """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
-            """6,12,11,21,22,32,31\n""",
+            (
+                """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
+                """6,12,11,21,22,32,31\n"""
+            ),
             [1],
             {
                 "question_order_version": 6,
@@ -26,9 +28,11 @@ from preprocessing.answers.parser import (
             },
         ),
         (
-            """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
-            """4,12,11,22,21,31,32\n"""
-            """2,12,11,21,22,31,32\n""",
+            (
+                """question_order_version,local_question_1,local_question_2,bridging_question_1,bridging_question_2,global_question_1,global_question_2\n"""
+                """4,12,11,22,21,31,32\n"""
+                """2,12,11,21,22,31,32\n"""
+            ),
             [1, 2],
             {
                 "question_order_version": 4,

--- a/tests/unit/preprocessing/checks/test_preflight.py
+++ b/tests/unit/preprocessing/checks/test_preflight.py
@@ -10,8 +10,8 @@ import yaml
 
 from preprocessing.checks.preflight import (
     PreflightError,
-    run_preflight_check,
     _check_psychometric_tests,
+    run_preflight_check,
 )
 from preprocessing.config import settings
 
@@ -722,7 +722,8 @@ def _make_task_first(
     tests = tests if tests is not None else ["PLAB", "RAN"]
     config_dir = base / f"participant_configs_{lang}_{country}_{lab}"
     config_dir.mkdir(parents=True)
-    yaml.safe_dump({"dummy": True}, open(config_dir / "001_EN_UK_1_S1.yaml", "w"))
+    with open(config_dir / "001_EN_UK_1_S1.yaml", "w") as f:
+        yaml.safe_dump({"dummy": True}, f)
 
     data_dir = base / f"psychometric_test_{lang}_{country}_{lab}"
     for t in tests:
@@ -868,7 +869,7 @@ def test_pt_check_data_issues(
 
 def test_pt_check_flag_disabled(pt_env, monkeypatch):
     """No warnings when RUN_PSYCHOMETRIC_TESTS is False."""
-    dc, pt_dir = pt_env
+    dc, _pt_dir = pt_env
     monkeypatch.setattr(settings, "RUN_PSYCHOMETRIC_TESTS", False)
     pt_warnings: list[str] = []
     _check_psychometric_tests(dc, pt_warnings)

--- a/tests/unit/preprocessing/checks/test_quality_thresholds.py
+++ b/tests/unit/preprocessing/checks/test_quality_thresholds.py
@@ -1,5 +1,6 @@
-import yaml
 from pathlib import Path
+
+import yaml
 
 from preprocessing.checks.quality_thresholds import write_quality_thresholds
 

--- a/tests/unit/preprocessing/data_collection/test_reading_times.py
+++ b/tests/unit/preprocessing/data_collection/test_reading_times.py
@@ -1,8 +1,9 @@
-import polars as pl
 import os
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock
+
+import polars as pl
 
 from preprocessing.data_collection.multipleye_data_collection import (
     MultipleyeDataCollection,
@@ -164,7 +165,7 @@ class TestCategorizeAscMessages:
             ],
         )
 
-        rt_df, breaks, screens, uncat, initial_ts = (
+        rt_df, _breaks, _screens, _uncat, initial_ts = (
             MultipleyeDataCollection._categorize_asc_messages(dc, "test_session")
         )
 

--- a/tests/unit/preprocessing/data_collection/test_session_lists.py
+++ b/tests/unit/preprocessing/data_collection/test_session_lists.py
@@ -1,5 +1,6 @@
-import pytest
 import pandas as pd
+import pytest
+
 from preprocessing.data_collection.multipleye_data_collection import (
     MultipleyeDataCollection,
 )

--- a/tests/unit/preprocessing/io/test_output_structure.py
+++ b/tests/unit/preprocessing/io/test_output_structure.py
@@ -1,19 +1,20 @@
-import pytest
 import polars as pl
 import pymovements as pm
+import pytest
+
+from preprocessing.config import settings
+from preprocessing.io.load import (
+    load_reading_measures,
+    load_trial_level_events_data,
+    load_trial_level_raw_data,
+)
 from preprocessing.io.save import (
-    save_raw_data,
     save_events_data,
-    save_scanpaths,
+    save_raw_data,
     save_reading_measures,
+    save_scanpaths,
     save_session_metadata,
 )
-from preprocessing.io.load import (
-    load_trial_level_raw_data,
-    load_trial_level_events_data,
-    load_reading_measures,
-)
-from preprocessing.config import settings
 from preprocessing.models.sid import Sid
 
 SID_STRINGS = ["001_EN_UK_1_S1", "017_DA_DK_1_ET1_start_after_trial_3"]
@@ -81,9 +82,7 @@ def test_save_load_raw_data_structure(tmp_path, dummy_gaze, sid_str):
     sid = Sid(sid_str)
     save_raw_data(sid, dummy_gaze)
     assert sid.raw_data_dir.exists()
-    assert (
-        sid.raw_data_dir / f"{str(sid)}_trial_1_Enc_WikiMoon_1_raw_data.csv"
-    ).exists()
+    assert (sid.raw_data_dir / f"{sid!s}_trial_1_Enc_WikiMoon_1_raw_data.csv").exists()
 
     loaded_gaze = load_trial_level_raw_data(
         sid, trial_columns=["trial", "stimulus", "page"]
@@ -105,7 +104,7 @@ def test_save_load_events_structure(tmp_path, dummy_gaze, event_type, sid_str):
     )
     expected_dir = sid.fixations_dir if event_type == "fixation" else sid.saccades_dir
     assert expected_dir.exists()
-    assert (expected_dir / f"{str(sid)}_Enc_WikiMoon_1_{event_type}.csv").exists()
+    assert (expected_dir / f"{sid!s}_Enc_WikiMoon_1_{event_type}.csv").exists()
 
     loaded_gaze = load_trial_level_events_data(dummy_gaze, sid, event_type)
     assert len(loaded_gaze.events.frame.filter(pl.col("name") == event_type)) >= 1
@@ -116,9 +115,7 @@ def test_save_scanpaths_structure(tmp_path, dummy_gaze, sid_str):
     sid = Sid(sid_str)
     save_scanpaths(sid, dummy_gaze)
     assert sid.scanpaths_dir.exists()
-    assert (
-        sid.scanpaths_dir / f"{str(sid)}_trial_1_Enc_WikiMoon_1_scanpath.csv"
-    ).exists()
+    assert (sid.scanpaths_dir / f"{sid!s}_trial_1_Enc_WikiMoon_1_scanpath.csv").exists()
 
 
 @pytest.mark.parametrize("sid_str", SID_STRINGS)
@@ -131,7 +128,7 @@ def test_save_load_reading_measures_structure(tmp_path, sid_str):
     assert sid.reading_measures_dir.exists()
     assert (
         sid.reading_measures_dir
-        / f"{str(sid)}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
+        / f"{sid!s}_trial_1_Enc_WikiMoon_1_reading_measures.csv"
     ).exists()
 
     loaded_rm = load_reading_measures(sid)

--- a/tests/unit/preprocessing/models/test_dcn.py
+++ b/tests/unit/preprocessing/models/test_dcn.py
@@ -1,4 +1,5 @@
 import pytest
+
 from preprocessing.models.dcn import Dcn
 
 

--- a/tests/unit/preprocessing/models/test_sid.py
+++ b/tests/unit/preprocessing/models/test_sid.py
@@ -1,6 +1,7 @@
 import pytest
-from preprocessing.models.sid import Sid
+
 from preprocessing.config import settings
+from preprocessing.models.sid import Sid
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/preprocessing/plotting/test_plot_gaze_fallback.py
+++ b/tests/unit/preprocessing/plotting/test_plot_gaze_fallback.py
@@ -1,11 +1,13 @@
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from preprocessing.plotting.plot import plot_gaze
+
+import pytest
+
+from preprocessing.config import settings
 from preprocessing.data_collection.stimulus import (
     Stimulus,
 )
-from preprocessing.config import settings
+from preprocessing.plotting.plot import plot_gaze
 
 
 @pytest.fixture

--- a/tests/unit/preprocessing/psychometric_tests/test_merged_overview.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_merged_overview.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from preprocessing.psychometric_tests.preprocess_psychometric_tests import (
     create_merged_psychometric_overview,
 )

--- a/tests/unit/preprocessing/psychometric_tests/test_non_compliant_sid.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_non_compliant_sid.py
@@ -1,9 +1,10 @@
 import pandas as pd
-from preprocessing.psychometric_tests.preprocess_psychometric_tests import (
-    preprocess_all_sessions,
-    create_merged_psychometric_overview,
-)
+
 from preprocessing.config import settings
+from preprocessing.psychometric_tests.preprocess_psychometric_tests import (
+    create_merged_psychometric_overview,
+    preprocess_all_sessions,
+)
 
 
 def test_non_compliant_sid_in_preprocess(tmp_path, monkeypatch):

--- a/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
+++ b/tests/unit/preprocessing/psychometric_tests/test_preprocess_psychometric_tests.py
@@ -9,14 +9,14 @@ from numpy import float64
 
 from preprocessing.config import settings
 from preprocessing.psychometric_tests.preprocess_psychometric_tests import (
-    _reaction_time_accuracy,
     _find_one_filetype_with_columns,
-    preprocess_stroop,
+    _reaction_time_accuracy,
     preprocess_flanker,
+    preprocess_lwmc,
     preprocess_plab,
     preprocess_ran,
+    preprocess_stroop,
     preprocess_wikivocab,
-    preprocess_lwmc,
 )
 
 
@@ -767,16 +767,7 @@ def _make_wmc_csv(folder: Path, make_text_file):
         "ss_key_resp_recall.corr,ss_key_resp_recall.rt,"
         "ss_key_resp_sentence.corr\n"
     )
-    body = "".join(
-        [
-            # Trial 1
-            "False,1,1,100,1,10,1,0,5,1\n",
-            "False,,0,200,,,1,1,15,0\n",
-            # Trial 2
-            "False,2,1,300,0,30,0,1,25,1\n",
-            "False,,1,400,,,1,0,35,0\n",
-        ]
-    )
+    body = "False,1,1,100,1,10,1,0,5,1\nFalse,,0,200,,,1,1,15,0\nFalse,2,1,300,0,30,0,1,25,1\nFalse,,1,400,,,1,0,35,0\n"
     make_text_file(folder / "wmc.csv", header=header, body=body)
 
 

--- a/tests/unit/preprocessing/reading-measures_tests/conftest.py
+++ b/tests/unit/preprocessing/reading-measures_tests/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import polars as pl
+import pytest
 
 from preprocessing.metrics.reading.fixations import annotate_fixations
 from preprocessing.metrics.reading.reading_measures import build_word_level_table

--- a/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
+++ b/tests/unit/preprocessing/scripts/test_prepare_language_folder.py
@@ -1,11 +1,12 @@
-import pytest
 import pandas as pd
-from preprocessing.scripts.prepare_language_folder import prepare_language_folder
+import pytest
+
 from preprocessing import settings
-from preprocessing.models.dcn import Dcn
 from preprocessing.data_collection.multipleye_data_collection import (
     MultipleyeDataCollection,
 )
+from preprocessing.models.dcn import Dcn
+from preprocessing.scripts.prepare_language_folder import prepare_language_folder
 
 
 @pytest.fixture
@@ -222,7 +223,7 @@ def test_prepare_language_folder_optional_aoi_images(
     tmp_path, data_collection_name, aoi_dir = mock_data_collection_factory(
         data_collection_name
     )
-    suffix, lang = setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
+    suffix, _lang = setup_stimulus_assets(tmp_path, data_collection_name, aoi_dir)
 
     # Create AOI stimuli images folder
     stimuli_dir = aoi_dir.parent

--- a/tests/unit/preprocessing/test_config.py
+++ b/tests/unit/preprocessing/test_config.py
@@ -1,6 +1,6 @@
+import logging
 from pathlib import Path
 
-import logging
 import pytest
 import yaml
 
@@ -156,9 +156,9 @@ def test_settings_validation_cases(settings_obj):
 
 def test_prepare_language_folder_none_error():
     """Test that prepare_language_folder raises a ValueError when name is None and no config."""
-    from preprocessing.scripts.prepare_language_folder import prepare_language_folder
-    from preprocessing.config import Settings
     import preprocessing
+    from preprocessing.config import Settings
+    from preprocessing.scripts.prepare_language_folder import prepare_language_folder
 
     # Use a fresh settings object without a config file
     s = Settings()
@@ -210,7 +210,7 @@ def test_settings_precedence_env_var(tmp_path, monkeypatch):
 
 def test_settings_copies_template_silently(tmp_path, monkeypatch, caplog):
     """Test that missing config copies template silently during load."""
-    from preprocessing.config import Settings, TEMPLATE_RELATIVE_PATH
+    from preprocessing.config import TEMPLATE_RELATIVE_PATH, Settings
 
     template_path = Settings()._repo_root / TEMPLATE_RELATIVE_PATH
     template_contents = template_path.read_text(encoding="utf-8")

--- a/tests/unit/preprocessing/utils/test_file_utils.py
+++ b/tests/unit/preprocessing/utils/test_file_utils.py
@@ -131,11 +131,11 @@ class TestCopytree:
         src = source_dir
         dst = tmp_path / "dest"
 
-        with patch("os.name", "nt" if is_windows else "posix"):
-            with patch(
-                "preprocessing.utils.file_utils.shutil.copytree"
-            ) as mock_copytree:
-                _copytree(src, dst, dirs_exist_ok=True)
+        with (
+            patch("os.name", "nt" if is_windows else "posix"),
+            patch("preprocessing.utils.file_utils.shutil.copytree") as mock_copytree,
+        ):
+            _copytree(src, dst, dirs_exist_ok=True)
 
         call_args, call_kwargs = mock_copytree.call_args
         src_arg, dst_arg = call_args[0], call_args[1]

--- a/tests/unit/preprocessing/utils/test_validate_psychometric_data.py
+++ b/tests/unit/preprocessing/utils/test_validate_psychometric_data.py
@@ -1,6 +1,8 @@
 import logging
+
 import pytest
 import yaml
+
 from preprocessing.utils.data_path_utils import validate_psychometric_data
 
 

--- a/tests/unit/review_app/test_review.py
+++ b/tests/unit/review_app/test_review.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import yaml
 
 from review_app.services.review import (
-    save_review,
-    load_review,
-    REVIEW_STATUSES,
     ISSUE_TYPES,
+    REVIEW_STATUSES,
+    load_review,
+    save_review,
 )
 
 

--- a/tests/unit/review_app/test_session_data.py
+++ b/tests/unit/review_app/test_session_data.py
@@ -1,12 +1,13 @@
 """Tests for session data service."""
 
-from review_app.services.session_data import (
-    read_overview,
-    compute_checks,
-    _is_checkable,
-    CHECK_REGISTRY,
-)
 from pathlib import Path
+
+from review_app.services.session_data import (
+    CHECK_REGISTRY,
+    _is_checkable,
+    compute_checks,
+    read_overview,
+)
 
 
 def test_read_overview_missing(tmp_path: Path) -> None:

--- a/tests/unit/review_app/test_swipe.py
+++ b/tests/unit/review_app/test_swipe.py
@@ -1,8 +1,9 @@
 """Tests for swipe service — per-plot judgment read/write."""
 
+from pathlib import Path
+
 import pytest
 import yaml
-from pathlib import Path
 
 
 def test_load_judgments_missing(monkeypatch):
@@ -15,7 +16,7 @@ def test_load_judgments_missing(monkeypatch):
 def test_save_and_load_plot_judgment(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_judgment, load_judgments
+    from review_app.services.swipe import load_judgments, save_plot_judgment
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
     data = load_judgments("dcn1")
@@ -26,7 +27,7 @@ def test_save_and_load_plot_judgment(tmp_path, monkeypatch):
 def test_save_multiple_plots(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_judgment, load_judgments
+    from review_app.services.swipe import load_judgments, save_plot_judgment
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
     save_plot_judgment("dcn1", "sid1", "plot_b", "flag")
@@ -39,9 +40,9 @@ def test_remove_plot_judgment(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
     from review_app.services.swipe import (
-        save_plot_judgment,
-        remove_plot_judgment,
         load_judgments,
+        remove_plot_judgment,
+        save_plot_judgment,
     )
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
@@ -57,9 +58,9 @@ def test_remove_last_plot_removes_session(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
     from review_app.services.swipe import (
-        save_plot_judgment,
-        remove_plot_judgment,
         load_judgments,
+        remove_plot_judgment,
+        save_plot_judgment,
     )
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
@@ -72,7 +73,7 @@ def test_remove_last_plot_removes_session(tmp_path, monkeypatch):
 def test_save_plot_comment(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_comment, load_judgments
+    from review_app.services.swipe import load_judgments, save_plot_comment
 
     save_plot_comment("dcn1", "sid1", "plot_a", "Looks good")
     data = load_judgments("dcn1")
@@ -83,7 +84,7 @@ def test_save_plot_comment(tmp_path, monkeypatch):
 def test_save_empty_comment_removes_it(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_comment, load_judgments
+    from review_app.services.swipe import load_judgments, save_plot_comment
 
     save_plot_comment("dcn1", "sid1", "plot_a", "Some note")
     save_plot_comment("dcn1", "sid1", "plot_a", "")
@@ -95,8 +96,9 @@ def test_save_empty_comment_removes_it(tmp_path, monkeypatch):
 def test_invalid_judgment_raises(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_judgment
     import pytest
+
+    from review_app.services.swipe import save_plot_judgment
 
     with pytest.raises(ValueError, match="Invalid judgment"):
         save_plot_judgment("dcn1", "sid1", "plot_a", "bogus")
@@ -105,7 +107,7 @@ def test_invalid_judgment_raises(tmp_path, monkeypatch):
 def test_yaml_format(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_judgment, save_plot_comment
+    from review_app.services.swipe import save_plot_comment, save_plot_judgment
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
     save_plot_judgment("dcn1", "sid1", "plot_b", "flag")
@@ -129,8 +131,8 @@ def test_load_session_judgment(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
     from review_app.services.swipe import (
-        save_plot_judgment,
         load_session_judgment,
+        save_plot_judgment,
     )
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
@@ -142,8 +144,8 @@ def test_load_session_judgment_mixed(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
     from review_app.services.swipe import (
-        save_plot_judgment,
         load_session_judgment,
+        save_plot_judgment,
     )
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "keep")
@@ -163,8 +165,8 @@ def test_load_plot_judgments_dict(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
     from review_app.services.swipe import (
-        save_plot_judgment,
         load_plot_judgments_dict,
+        save_plot_judgment,
     )
 
     save_plot_judgment("dcn1", "sid1", "plot_a", "flag")
@@ -175,7 +177,7 @@ def test_load_plot_judgments_dict(tmp_path, monkeypatch):
 def test_load_plot_comments_dict(tmp_path, monkeypatch):
     monkeypatch.setattr("review_app.config.REVIEW_DATA_DIR", tmp_path)
 
-    from review_app.services.swipe import save_plot_comment, load_plot_comments_dict
+    from review_app.services.swipe import load_plot_comments_dict, save_plot_comment
 
     save_plot_comment("dcn1", "sid1", "plot_a", "Comment text")
     result = load_plot_comments_dict("dcn1", "sid1")

--- a/tests/unit/review_app/test_thresholds.py
+++ b/tests/unit/review_app/test_thresholds.py
@@ -1,7 +1,8 @@
 """Tests for threshold comparison logic."""
 
 import pytest
-from review_app.services.thresholds import compare, check_value
+
+from review_app.services.thresholds import check_value, compare
 
 
 class TestCompare:
@@ -52,16 +53,16 @@ class TestCheckValue:
         """Within 10% of [min, max] boundary should warn."""
         thresholds = {"num_completed_trials": [6, 12]}
         # 5.4 is within 10% of 6 (margin = 0.6)
-        spec54, status54 = check_value("num_completed_trials", 5.4, thresholds)
+        _spec54, status54 = check_value("num_completed_trials", 5.4, thresholds)
         assert status54 == "warn"
 
     def test_range_as_minimum_threshold(self) -> None:
         """num_completed_trials uses [6, 12] as a 'minimum' threshold:
         4 should fail, 6 should pass, 12 should pass."""
         thresholds = {"num_completed_trials": [6, 12]}
-        spec4, status4 = check_value("num_completed_trials", 4, thresholds)
+        _spec4, status4 = check_value("num_completed_trials", 4, thresholds)
         assert status4 == "fail"
-        spec6, status6 = check_value("num_completed_trials", 6, thresholds)
+        _spec6, status6 = check_value("num_completed_trials", 6, thresholds)
         assert status6 == "pass"
-        spec12, status12 = check_value("num_completed_trials", 12, thresholds)
+        _spec12, status12 = check_value("num_completed_trials", 12, thresholds)
         assert status12 == "pass"

--- a/tests/unit/utils/test_data_path_utils.py
+++ b/tests/unit/utils/test_data_path_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 import pytest
 
 from preprocessing.utils.data_path_utils import check_data_collection_exists

--- a/tests/unit/utils/test_edf2asc_logging.py
+++ b/tests/unit/utils/test_edf2asc_logging.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from preprocessing.utils.logging import get_edf2asc_version
 
 

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -5,11 +5,11 @@ from unittest.mock import patch
 
 import pytest
 
+from preprocessing.config import settings
 from preprocessing.data_collection.multipleye_data_collection import (
     MultipleyeDataCollection,
 )
-from preprocessing.config import settings
-from preprocessing.utils.logging import setup_logging, clear_log_file
+from preprocessing.utils.logging import clear_log_file, setup_logging
 
 
 @pytest.fixture

--- a/tests/unit/utils/test_logging_levels.py
+++ b/tests/unit/utils/test_logging_levels.py
@@ -1,5 +1,6 @@
 import logging
 from unittest.mock import patch
+
 import preprocessing.utils.logging as logging_utils
 
 


### PR DESCRIPTION
the dev environment resolved `ruff>=0.13.0` -> 0.16.2, while pre-commit CI pinned `ruff-pre-commit v0.14.10`. Ruff 0.16.0 was a major release expanding the default rule set to 3x rules, so the two versions could disagree. The pre-commit workflow does run `--all-files`, so pinning one version is exactly what makes it enforce formatting repo-wide.

- Pinned `ruff==0.16.3` in `pyproject.toml` dev deps + `ruff-pre-commit rev v0.16.3`
- Added `[tool.ruff]` config: notebooks excluded (templates, not shipped code)
- Applied `ruff check --fix` + `ruff format` across `preprocessing/`, `review_app/`, `tests/`, `docs/`
- Fixed found bugs the new rules caught: empty docstring, self-assignment no-op, missing `check=` on subprocess, unused noqa
