### PR TITLE
feat: add Trial data class and per-trial list in session overview

### DIFF
--- a/preprocessing/data_collection/session.py
+++ b/preprocessing/data_collection/session.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TypeVar
 
@@ -101,7 +101,8 @@ class Session:
     reading_measures: bool = field(default=True, init=False)
     answers: bool = field(default=True, init=False)
 
-    trials = list[Trial]
+    # per-trial metrics
+    trials: list[Trial] | str = field(default="unknown", init=False)
 
     @property
     def sid(self) -> "Sid":
@@ -167,6 +168,11 @@ class Session:
                 "total_reading_time": self.total_reading_time,
                 "total_session_duration": self.total_session_duration,
             },
+            "Trials": (
+                [asdict(t) for t in self.trials]
+                if isinstance(self.trials, list)
+                else self.trials
+            ),
             "Comprehension": {
                 "avg_comprehension_score": self.avg_comprehension_score,
                 "avg_comprehension_score_local": self.avg_comprehension_score_local,
@@ -347,6 +353,8 @@ class Session:
 
         self._compute_comprehension_scores()
 
+        self.trials = self._compute_trials()
+
         duration = self._compute_session_duration()
         if duration is not None:
             self.total_session_duration = duration
@@ -378,3 +386,80 @@ class Session:
         if total_ms <= 0:
             return None
         return round(total_ms / 1000, 3)
+
+    def _reading_time_by_trial(self) -> dict[str, float]:
+        """Return total reading time in ms per trial from stimulus timestamps."""
+        by_trial: dict[str, float] = {}
+        if not isinstance(self.stimulus_start_end_ts, list):
+            return by_trial
+        for entry in self.stimulus_start_end_ts:
+            try:
+                start = float(entry["start_ts"])
+                stop = float(entry["stop_ts"])
+                trial = str(entry["trial"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            by_trial[trial] = by_trial.get(trial, 0.0) + (stop - start)
+        return by_trial
+
+    def _compute_trials(self) -> list[Trial] | str:
+        """Assemble per-trial metrics from the answers CSV and reading times.
+
+        Returns
+        -------
+        list[Trial] | str
+            Per-trial metrics, or "unknown" when the answers CSV is missing.
+        """
+        answers_csv = self.sid.answers_dir / f"{self.sid}_answers.csv"
+        if not answers_csv.exists():
+            return "unknown"
+
+        try:
+            answers = pl.read_csv(answers_csv)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"Could not read answers CSV {answers_csv}: {exc}")
+            return "unknown"
+
+        required = {"trial", "stimulus", "stimulus_id", "is_correct"}
+        if answers.is_empty() or not required.issubset(answers.columns):
+            return "unknown"
+
+        reading_by_trial = self._reading_time_by_trial()
+
+        trials: list[Trial] = []
+        for trial_id, group in answers.group_by("trial", maintain_order=True):
+            trial_id = trial_id[0] if isinstance(trial_id, tuple) else trial_id
+            correct = [c for c in group["is_correct"].to_list() if c is not None]
+            if not correct:
+                score = 0.0
+            else:
+                score = round(sum(1 for c in correct if c) / len(correct), 3)
+
+            question_time = 0.0
+            if "confirmation_rt_ms" in group.columns:
+                q_times = [
+                    float(t) for t in group["confirmation_rt_ms"].drop_nulls().to_list()
+                ]
+                question_time = round(sum(q_times), 3) if q_times else 0.0
+
+            first = group.row(0, named=True)
+            try:
+                trial_number = int(str(trial_id).rsplit("_", 1)[-1])
+            except ValueError:
+                trial_number = 0
+
+            trials.append(
+                Trial(
+                    trial_number=trial_number,
+                    stimulus_id=int(first["stimulus_id"]),
+                    stimulus_name=str(first["stimulus"]),
+                    is_practice=str(trial_id).startswith("PRACTICE_"),
+                    num_questions=group.height,
+                    comprehension_score=score,
+                    comprehension_question_time_ms=question_time,
+                    reading_time_ms=round(reading_by_trial.get(str(trial_id), 0.0), 3),
+                )
+            )
+
+        trials.sort(key=lambda t: (t.is_practice, t.trial_number))
+        return trials

--- a/preprocessing/data_collection/trial.py
+++ b/preprocessing/data_collection/trial.py
@@ -3,19 +3,37 @@ from dataclasses import dataclass
 
 @dataclass
 class Trial:
-    participant_id: int
-    session_id: int
-    stimulus_id: str
-    stimulus_version: int
+    """Per-trial metrics assembled from the session answers and reading times.
+
+    A trial corresponds to one stimulus presentation (including practice
+    trials). The comprehension fields are derived from the session answers
+    CSV; ``reading_time_ms`` from the documented per-stimulus reading span.
+
+    Fields
+    ------
+    trial_number : int
+        Trial number within the session (1-based).
+    stimulus_id : int
+        Numeric stimulus identifier.
+    stimulus_name : str
+        Stimulus name (e.g. ``Lit_MagicMountain``).
+    is_practice : bool
+        True for practice trials.
+    num_questions : int
+        Number of comprehension questions answered for this trial.
+    comprehension_score : float
+        Proportion of correct comprehension answers for this trial.
+    comprehension_question_time_ms : float
+        Total time spent on comprehension questions, in milliseconds.
+    reading_time_ms : float
+        Total reading time for the trial's pages, in milliseconds.
+    """
+
     trial_number: int
-    reading_time: float
-    avg_comprehension_score: float
-    question_order: list[str]
-    total_trial_duration: float
-    comprehension_scores = list[int]
-    familiarity_rating_1: int
-    familiarity_rating_2: int
-    difficulty_rating: int
-    validation_before_start: bool
-    calibration_before_start: bool
-    validation_before_start_score: float
+    stimulus_id: int
+    stimulus_name: str
+    is_practice: bool
+    num_questions: int
+    comprehension_score: float
+    comprehension_question_time_ms: float
+    reading_time_ms: float

--- a/tests/unit/preprocessing/data_collection/test_session_overview.py
+++ b/tests/unit/preprocessing/data_collection/test_session_overview.py
@@ -1,7 +1,9 @@
+import contextlib
 from pathlib import Path
 from unittest.mock import patch
 
 import polars as pl
+import pytest
 
 from preprocessing.data_collection.session import Session
 from preprocessing.data_collection.stimulus import LabConfig
@@ -129,6 +131,7 @@ def test_sections_are_present() -> None:
         "Calibration_validation",
         "Data_quality",
         "Experiment_procedure",
+        "Trials",
         "Comprehension",
         "Data_formats",
     ]
@@ -577,3 +580,170 @@ def test_reading_time_already_set() -> None:
     proc = overview["Experiment_procedure"]
 
     assert proc["total_reading_time"] == 42.0
+
+
+# --- Trial building ---
+
+
+def _write_answers(
+    tmp_path: Path,
+    rows: list[dict],
+) -> Path:
+    """Write an answers CSV and return the comp_answers dir for the fake sid."""
+    answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+    answers_dir.mkdir(parents=True)
+    pl.DataFrame(rows).write_csv(answers_dir / "001_EN_UK_1_ET1_answers.csv")
+    return answers_dir
+
+
+def _trial_sess(answers_dir: Path) -> Session:
+    sess = _sess_with_validation_data()
+    sess.stimulus_start_end_ts = [
+        {
+            "stimulus": "Lit_MagicMountain",
+            "trial": "trial_1",
+            "start_ts": 1000.0,
+            "stop_ts": 4000.0,
+        },
+        {
+            "stimulus": "Lit_Alchemist",
+            "trial": "trial_2",
+            "start_ts": 5000.0,
+            "stop_ts": 8000.0,
+        },
+        {
+            "stimulus": "Enc_WikiMoon",
+            "trial": "PRACTICE_trial_1",
+            "start_ts": 100.0,
+            "stop_ts": 500.0,
+        },
+    ]
+    return sess
+
+
+_ANSWERS_ROWS = [
+    {
+        "trial": "trial_1",
+        "stimulus": "Lit_MagicMountain",
+        "stimulus_id": 3,
+        "is_correct": True,
+        "confirmation_rt_ms": 1000.0,
+    },
+    {
+        "trial": "trial_1",
+        "stimulus": "Lit_MagicMountain",
+        "stimulus_id": 3,
+        "is_correct": False,
+        "confirmation_rt_ms": 2000.0,
+    },
+    {
+        "trial": "trial_2",
+        "stimulus": "Lit_Alchemist",
+        "stimulus_id": 4,
+        "is_correct": True,
+        "confirmation_rt_ms": 1500.0,
+    },
+    {
+        "trial": "PRACTICE_trial_1",
+        "stimulus": "Enc_WikiMoon",
+        "stimulus_id": 13,
+        "is_correct": True,
+        "confirmation_rt_ms": 500.0,
+    },
+]
+
+
+@pytest.mark.parametrize(
+    (
+        "trial_number",
+        "is_practice",
+        "stimulus_name",
+        "num_questions",
+        "comprehension_score",
+        "question_time_ms",
+        "reading_time_ms",
+    ),
+    [
+        (1, False, "Lit_MagicMountain", 2, 0.5, 3000.0, 3000.0),
+        (2, False, "Lit_Alchemist", 1, 1.0, 1500.0, 3000.0),
+        (1, True, "Enc_WikiMoon", 1, 1.0, 500.0, 400.0),
+    ],
+)
+def test_trials_computed_from_answers_and_reading_times(
+    tmp_path: Path,
+    trial_number: int,
+    is_practice: bool,
+    stimulus_name: str,
+    num_questions: int,
+    comprehension_score: float,
+    question_time_ms: float,
+    reading_time_ms: float,
+) -> None:
+    answers_dir = _write_answers(tmp_path, _ANSWERS_ROWS)
+    sess = _trial_sess(answers_dir)
+
+    with patch.object(
+        Session,
+        "sid",
+        property(lambda self: _FakeSid(answers_dir)),
+    ):
+        trials = sess.create_overview()["Trials"]
+
+    trial = next(
+        t
+        for t in trials
+        if t["trial_number"] == trial_number and t["is_practice"] == is_practice
+    )
+    assert trial["stimulus_name"] == stimulus_name
+    assert trial["num_questions"] == num_questions
+    assert trial["comprehension_score"] == comprehension_score
+    assert trial["comprehension_question_time_ms"] == question_time_ms
+    assert trial["reading_time_ms"] == reading_time_ms
+
+
+@pytest.mark.parametrize(
+    ("answers_setup",),
+    [
+        ("missing",),
+        ("unreadable",),
+    ],
+)
+def test_trials_unknown_without_usable_answers(
+    tmp_path: Path,
+    answers_setup: str,
+) -> None:
+    sess = _sess_with_validation_data()
+
+    def _patched_sid(path: Path):
+        return _FakeSid(path)
+
+    if answers_setup == "missing":
+        answers_dir = tmp_path / "nonexistent"
+    else:
+        answers_dir = tmp_path / "comp_answers" / "001_EN_UK_1_ET1"
+        answers_dir.mkdir(parents=True)
+        (answers_dir / "001_EN_UK_1_ET1_answers.csv").write_text("garbage")
+
+    def _raise(*args, **kwargs):
+        from polars.exceptions import ComputeError
+
+        raise ComputeError("cannot parse")
+
+    patches = [
+        patch.object(
+            Session,
+            "sid",
+            property(lambda self: _patched_sid(answers_dir)),
+        )
+    ]
+    if answers_setup == "unreadable":
+        patches.insert(
+            0, patch("preprocessing.data_collection.session.pl.read_csv", _raise)
+        )
+
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        trials = sess.create_overview()["Trials"]
+
+    assert trials == "unknown"


### PR DESCRIPTION
## Summary
Adds a proper `Trial` data class and a per-trial `Trials` section to the session overview YAML, replacing the broken stub in `trial.py`.

## Changes
`trial.py`
- Rewrote the `Trial` dataclass: fixed the invalid `comprehension_scores = list[int]` class attribute, removed unused fields, added a docstring
- Fields: `trial_number`, `stimulus_id`, `stimulus_name`, `is_practice`, `num_questions`, `comprehension_score`, `comprehension_question_time_ms`, `reading_time_ms`

`session.py`
- Instance-level `trials` field (was a broken class-level `trials = list[Trial]` stub!)
- `_compute_trials()`: builds per-trial metrics from the answers CSV (comprehension score, question count, question time) and per-stimulus reading spans (`reading_time_ms`)
- `_reading_time_by_trial()` helper for reading-time aggregation
- New `Trials` section in `create_overview()` between `Experiment_procedure` and `Comprehension`. set to `"unknown"` when no answers CSV exists

Tests
- Parametrized per-trial computation cases (experiment + practice trials)
- Missing-answers and unreadable-answers fallback cases

## Verification
- all tests pass

## Relates to
- #171 (main issue, partially done)
- #212 (source of session fields this builds on)
- #213 (uses the session per-type scores)

## Open ToDos
- Per-trial `data_loss_ratio` / `blink_loss_ratio` not included, depends on PR #210 (per-trial data loss), still open
- Per-trial time breakdowns (reading / questions / ratings / between-trial gaps) and `final_validation_score`, `eyelink_filters` remain
- Comprehension-by-type per trial can be derived from the answers `condition_number` column later