### PR TITLE
fix(docs): remove header search button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ html_theme_options = {
     "use_issues_button": True,
     "use_edit_page_button": True,
     "path_to_docs": "docs",
+    "navbar_persistent": [],
     "icon_links": [
         {
             "name": "MultiplEYE",


### PR DESCRIPTION
The newer pydata-sphinx-theme version pulled in by RTD adds a persistent "Search" button to the main header (navbar_persistent). Because sbt's .bd-header is non-sticky while the article header is sticky, scrolling to the top brings this button back in above the icon bar, pushing it down. Setting navbar_persistent: [] removes only that button. Search stays available via the sidebar button, the article-header search icon, and Ctrl+K.