### PR TITLE
Added missing output dir assignment for MeRID

### DIFF
--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -58,6 +58,7 @@ def run_preprocessing(config_path: str | None = None):
                 include_pilots=settings.INCLUDE_PILOTS,
                 excluded_sessions=settings.EXCLUDE_SESSIONS,
                 included_sessions=settings.INCLUDE_SESSIONS,
+                output_dir=settings.OUTPUT_DIR,
             )
         )
 


### PR DESCRIPTION
MeRID data collections currently fail due to having no assigned output_dir. Fixed in run_preprocessing by adding assignment