### PR TITLE
fix: split per-page and per-trial data loss outputs

### DIFF
--- a/docs/guide/sanity_check_report.md
+++ b/docs/guide/sanity_check_report.md
@@ -348,6 +348,10 @@ directory:
 - `per_page_data_loss_{session}.tsv`: one row per page, with a `page_type` column
   (`reading`, `question` or `rating`).
 
+**Weighting:** each per-trial value is the time-weighted ratio within that trial, but the
+**across-trial mean uses a plain, equal-weighted mean** over trial rows — trials are not
+weighted by their recording length. Pages may be weighted by their recording duration.
+
 Columns in `per_trial_data_loss_{session}.tsv`:
 
 - `trial`, `stimulus`: trial identifiers

--- a/docs/guide/sanity_check_report.md
+++ b/docs/guide/sanity_check_report.md
@@ -339,22 +339,34 @@ warrant manual review.
 
 ## Per-trial Data Loss
 
-**Mean per-trial data loss and blink loss ratios, plus a TSV breakdown per trial.**
-The markdown section shows the mean across all trials. The full trial-level detail is written to
-`per_trial_data_loss_{session}.tsv` in the same directory.
+**Mean per-trial and per-page data loss / blink loss ratios, plus TSV breakdowns.**
+The markdown section shows the mean across all trials, followed by a per-page-type
+summary (mean data loss over the pages of each type). Two TSVs are written to the same
+directory:
 
-Columns in the TSV:
+- `per_trial_data_loss_{session}.tsv`: one row per trial.
+- `per_page_data_loss_{session}.tsv`: one row per page, with a `page_type` column
+  (`reading`, `question` or `rating`).
 
-- `trial`, `stimulus`, `page`: trial identifiers
+Columns in `per_trial_data_loss_{session}.tsv`:
+
+- `trial`, `stimulus`: trial identifiers
 - `data_loss_ratio`: fraction of missing samples per trial
 - `blink_loss_ratio`: fraction of trial time lost to blinks
 - `blink_duration_ms`: total blink duration in that trial
 - `trial_duration_ms`: trial recording duration
 
-*Acceptable:* Per-trial data loss below 10%.
+Columns in `per_page_data_loss_{session}.tsv`:
 
-*Problematic:* Individual trials exceeding 20% suggest tracking failures for that particular
-stimulus.
+- `trial`, `stimulus`, `page`: page identifiers
+- `page_type`: coarse page category (`reading`, `question`, `rating`)
+- `data_loss_ratio`: fraction of missing samples per page
+- `blink_loss_ratio`: fraction of page time lost to blinks
+- `blink_duration_ms`: total blink duration on that page
+- `page_duration_ms`: page recording duration
+
+*Problematic:* Above 2% is a warning signal. Above 10% is substantial (tracking failures for
+that particular stimulus).
 
 ---
 

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -642,6 +642,8 @@ class MultipleyeDataCollection:
             _report_to_file("## Per-trial Data Loss", report_file_path)
             per_trial_loss = self._compute_per_trial_loss_table(session_name)
             if per_trial_loss is not None and not per_trial_loss.is_empty():
+                # One row per trial. The mean over rows weights every trial equally:
+                # trials are NOT weighted by their recording length.
                 num_trials = per_trial_loss.height
                 mean_data_loss = (
                     per_trial_loss["data_loss_ratio"].mean()

--- a/preprocessing/data_collection/multipleye_data_collection.py
+++ b/preprocessing/data_collection/multipleye_data_collection.py
@@ -661,7 +661,8 @@ class MultipleyeDataCollection:
                     )
                 if mean_blink_loss is not None:
                     _report_to_file(
-                        f"- Mean per-trial blink loss: {mean_blink_loss:.3f}",
+                        f"- Mean per-trial blink loss: {mean_blink_loss:.3f} "
+                        f"(across {num_trials} trials)",
                         report_file_path,
                     )
 
@@ -669,6 +670,22 @@ class MultipleyeDataCollection:
                     session_results / f"per_trial_data_loss_{session_name}.tsv",
                     separator="\t",
                 )
+
+                per_page_loss = self._compute_per_page_loss_table(session_name)
+                if per_page_loss is not None and not per_page_loss.is_empty():
+                    per_page_loss.write_csv(
+                        session_results / f"per_page_data_loss_{session_name}.tsv",
+                        separator="\t",
+                    )
+                    _report_to_file("Data loss by page type:", report_file_path)
+                    by_page_type = self._data_loss_by_page_type(session_name)
+                    if by_page_type is not None:
+                        for row in by_page_type.iter_rows(named=True):
+                            _report_to_file(
+                                f"- {row['page_type']}: {row['mean_data_loss']:.3f} "
+                                f"(mean over {row['num_pages']} pages)",
+                                report_file_path,
+                            )
             else:
                 _report_to_file("- No per-trial metrics available.", report_file_path)
 
@@ -1888,12 +1905,89 @@ class MultipleyeDataCollection:
         if data_loss_df is None and blink_loss_df is None:
             return None
 
-        trial_cols = ["trial", "stimulus", "page"]
+        trial_cols = ["trial", "stimulus"]
         if data_loss_df is not None and blink_loss_df is not None:
             return data_loss_df.join(blink_loss_df, on=trial_cols, how="left")
         if data_loss_df is not None:
             return data_loss_df
         return blink_loss_df
+
+    def _compute_per_page_loss_table(self, session_name: str):
+        data_loss_df = getattr(self.sessions[session_name], "_per_page_data_loss", None)
+        blink_loss_df = getattr(
+            self.sessions[session_name], "_per_page_blink_loss", None
+        )
+
+        if data_loss_df is None and blink_loss_df is None:
+            return None
+
+        page_cols = ["trial", "stimulus", "page"]
+        if data_loss_df is not None and blink_loss_df is not None:
+            table = data_loss_df.join(blink_loss_df, on=page_cols, how="left")
+        elif data_loss_df is not None:
+            table = data_loss_df
+        else:
+            table = blink_loss_df
+
+        return table.with_columns(
+            pl.col("page")
+            .map_elements(
+                self._page_type,
+                return_dtype=pl.Utf8,
+            )
+            .alias("page_type")
+        )
+
+    def _data_loss_by_page_type(self, session_name: str):
+        """Aggregate mean data-loss ratio per page type.
+
+        Parameters
+        ----------
+        session_name : str
+            The session identifier.
+
+        Returns
+        -------
+        pl.DataFrame | None
+            A DataFrame with ``page_type``, ``mean_data_loss`` and ``num_pages``
+            columns, or ``None`` if no per-page data-loss data is available.
+        """
+        per_page_loss = self._compute_per_page_loss_table(session_name)
+        if per_page_loss is None or per_page_loss.is_empty():
+            return None
+        if "data_loss_ratio" not in per_page_loss.columns:
+            return None
+        return (
+            per_page_loss.group_by("page_type")
+            .agg(
+                pl.col("data_loss_ratio").mean().alias("mean_data_loss"),
+                pl.len().alias("num_pages"),
+            )
+            .sort("page_type")
+        )
+
+    def _page_type(self, page: str) -> str:
+        """Classify a page name into a coarse page type.
+
+        Parameters
+        ----------
+        page : str
+            The page name from the gaze trial_columns.
+
+        Returns
+        -------
+        str
+            One of "reading", "question", "rating", or "other".
+        """
+        if page.startswith("page_"):
+            return "reading"
+        if page.startswith("question_"):
+            return "question"
+        if page.startswith("familiarity_rating_screen") or page == (
+            "subject_difficulty_screen"
+        ):
+            return "rating"
+        return "other"
 
     def _load_psychometric_tests(self, session_identifier: str):
         # Match the eye-tracking session to a psychometric test folder

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -16,6 +16,61 @@ from ..data_collection.stimulus import LabConfig
 from ..models.sid import Sid
 
 
+def _blink_loss_table(
+    per_group_blink: pl.DataFrame,
+    per_group_sample_count: pl.DataFrame,
+    group_cols: list[str],
+    duration_col: str,
+    sr: float,
+) -> pl.DataFrame:
+    """Build a blink-loss table grouped by a given set of columns.
+
+    Joins summed blink durations per group with the sample count per group and
+    derives the blink-loss ratio and recording duration.
+
+    Parameters
+    ----------
+    per_group_blink : pl.DataFrame
+        Blink events grouped by ``group_cols`` with a ``blink_duration_ms`` column.
+    per_group_sample_count : pl.DataFrame
+        Sample counts grouped by ``group_cols`` with a ``sample_count`` column.
+    group_cols : list of str
+        Columns used for grouping (e.g. per-page or per-trial columns).
+    duration_col : str
+        Name of the output recording-duration column.
+    sr : float
+        Sampling rate in Hz.
+
+    Returns
+    -------
+    pl.DataFrame
+        A table with ``group_cols``, ``blink_loss_ratio``, ``blink_duration_ms`` and
+        ``duration_col`` columns.
+    """
+    return (
+        per_group_blink.join(
+            per_group_sample_count,
+            on=group_cols,
+            how="right",
+        )
+        .with_columns(
+            (
+                pl.col("blink_duration_ms").fill_null(0)
+                / (pl.col("sample_count") * 1000.0 / sr)
+            ).alias("blink_loss_ratio")
+        )
+        .with_columns((pl.col("sample_count") * 1000.0 / sr).alias(duration_col))
+        .select(
+            [
+                *group_cols,
+                "blink_loss_ratio",
+                "blink_duration_ms",
+                duration_col,
+            ]
+        )
+    )
+
+
 def load_gaze_data(
     asc_file: Path,
     lab_config: LabConfig,
@@ -107,33 +162,36 @@ def load_gaze_data(
 
         blink_events = gaze.events.frame.filter(pl.col("name").str.contains("blink"))
         if not blink_events.is_empty():
-            per_trial_blink = blink_events.group_by(trial_cols).agg(
+            per_page_blink = blink_events.group_by(trial_cols).agg(
                 pl.col("duration").sum().alias("blink_duration_ms")
             )
-            per_trial_sample_count = gaze.samples.group_by(trial_cols).agg(
+            per_page_sample_count = gaze.samples.group_by(trial_cols).agg(
                 pl.len().alias("sample_count")
             )
-            gaze._per_trial_blink_loss = (
-                per_trial_blink.join(per_trial_sample_count, on=trial_cols, how="right")
-                .with_columns(
-                    (
-                        pl.col("blink_duration_ms").fill_null(0)
-                        / (pl.col("sample_count") * 1000.0 / sr)
-                    ).alias("blink_loss_ratio")
-                )
-                .with_columns(
-                    (pl.col("sample_count") * 1000.0 / sr).alias("trial_duration_ms")
-                )
-                .select(
-                    [
-                        *trial_cols,
-                        "blink_loss_ratio",
-                        "blink_duration_ms",
-                        "trial_duration_ms",
-                    ]
-                )
+            gaze._per_page_blink_loss = _blink_loss_table(
+                per_page_blink,
+                per_page_sample_count,
+                group_cols=trial_cols,
+                duration_col="page_duration_ms",
+                sr=sr,
+            )
+
+            per_trial_cols = ["trial", "stimulus"]
+            per_trial_blink = blink_events.group_by(per_trial_cols).agg(
+                pl.col("duration").sum().alias("blink_duration_ms")
+            )
+            per_trial_sample_count = gaze.samples.group_by(per_trial_cols).agg(
+                pl.len().alias("sample_count")
+            )
+            gaze._per_trial_blink_loss = _blink_loss_table(
+                per_trial_blink,
+                per_trial_sample_count,
+                group_cols=per_trial_cols,
+                duration_col="trial_duration_ms",
+                sr=sr,
             )
         else:
+            gaze._per_page_blink_loss = None
             gaze._per_trial_blink_loss = None
 
     # Clear parsed events to avoid save_raw_data crash.

--- a/preprocessing/io/load.py
+++ b/preprocessing/io/load.py
@@ -162,6 +162,7 @@ def load_gaze_data(
 
         blink_events = gaze.events.frame.filter(pl.col("name").str.contains("blink"))
         if not blink_events.is_empty():
+            # Per-page blink loss: one row per page, time-weighted within the page.
             per_page_blink = blink_events.group_by(trial_cols).agg(
                 pl.col("duration").sum().alias("blink_duration_ms")
             )
@@ -176,6 +177,9 @@ def load_gaze_data(
                 sr=sr,
             )
 
+            # Per-trial blink loss: one row per trial (time-weighted within the
+            # trial). Trials are not weighted by length against each other; the
+            # sanity report takes a plain, equal-weighted mean over trial rows.
             per_trial_cols = ["trial", "stimulus"]
             per_trial_blink = blink_events.group_by(per_trial_cols).agg(
                 pl.col("duration").sum().alias("blink_duration_ms")

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -136,10 +136,14 @@ def run_preprocessing(config_path: str | None = None):
                 pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio")
             ).item()
 
-            # Compute per-trial data loss
-            gaze._per_trial_data_loss = gaze.samples.group_by(gaze.trial_columns).agg(
+            # Compute per-page data loss (trial_columns are per-page),
+            # and per-trial data loss grouped by trial only.
+            gaze._per_page_data_loss = gaze.samples.group_by(gaze.trial_columns).agg(
                 pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio")
             )
+            gaze._per_trial_data_loss = gaze.samples.group_by(
+                ["trial", "stimulus"]
+            ).agg(pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio"))
 
             preprocessing.save_raw_data(sess.sid, gaze)
             preprocessing.save_session_metadata(sess.sid, gaze)
@@ -160,6 +164,8 @@ def run_preprocessing(config_path: str | None = None):
             "_measure_blink_loss_ratio",
             None,
         )
+        sess._per_page_data_loss = getattr(gaze, "_per_page_data_loss", None)
+        sess._per_page_blink_loss = getattr(gaze, "_per_page_blink_loss", None)
         sess._per_trial_data_loss = getattr(gaze, "_per_trial_data_loss", None)
         sess._per_trial_blink_loss = getattr(gaze, "_per_trial_blink_loss", None)
 

--- a/preprocessing/scripts/run_preprocessing.py
+++ b/preprocessing/scripts/run_preprocessing.py
@@ -136,11 +136,16 @@ def run_preprocessing(config_path: str | None = None):
                 pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio")
             ).item()
 
-            # Compute per-page data loss (trial_columns are per-page),
-            # and per-trial data loss grouped by trial only.
+            # Per-page data loss: group by trial_columns (which include "page"),
+            # so each row is one page. The ratio is time-weighted *within* the page
+            # (lost samples / expected samples over the page's time span).
             gaze._per_page_data_loss = gaze.samples.group_by(gaze.trial_columns).agg(
                 pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio")
             )
+            # Per-trial data loss: group by trial only (not page). Each trial gets one
+            # independent ratio (time-weighted within the trial). Trials are NOT
+            # weighted by their length against each other -- that is handled by the
+            # plain, equal-weighted mean across trial rows in the sanity report.
             gaze._per_trial_data_loss = gaze.samples.group_by(
                 ["trial", "stimulus"]
             ).agg(pm.measure.data_loss("pixel", sampling_rate=sr, unit="ratio"))

--- a/tests/unit/preprocessing/data_collection/test_per_trial_loss.py
+++ b/tests/unit/preprocessing/data_collection/test_per_trial_loss.py
@@ -1,17 +1,23 @@
 from pathlib import Path
 
 import polars as pl
+import pytest
 
 from preprocessing.data_collection.multipleye_data_collection import (
     MultipleyeDataCollection,
 )
 from preprocessing.data_collection.session import Session
 
+SESSION_NAME = "001_EN_UK_1_ET1"
+
+TRIAL_COLS = ["trial", "stimulus"]
+PAGE_COLS = ["trial", "stimulus", "page"]
+
 
 def _make_session():
     return Session(
         participant_id=1,
-        session_identifier="001_EN_UK_1_ET1",
+        session_identifier=SESSION_NAME,
         is_pilot=False,
         session_folder_path=Path("/tmp"),
         session_file_path=Path("/tmp/test.log"),
@@ -21,11 +27,44 @@ def _make_session():
 
 def _make_mdc(session):
     mdc = MultipleyeDataCollection.__new__(MultipleyeDataCollection)
-    mdc.sessions = {"001_EN_UK_1_ET1": session}
+    mdc.sessions = {SESSION_NAME: session}
     return mdc
 
 
-TRIAL_COLS = ["trial", "stimulus", "page"]
+def _data_loss_df(cols):
+    return pl.DataFrame(
+        {
+            **{col: ["trial_1"] for col in cols},
+            "data_loss_ratio": [0.05],
+        }
+    )
+
+
+def _blink_loss_df(cols):
+    return pl.DataFrame(
+        {
+            **{col: ["trial_1"] for col in cols},
+            "blink_loss_ratio": [0.02],
+            "blink_duration_ms": [100.0],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("page", "expected"),
+    [
+        ("page_1", "reading"),
+        ("page_12", "reading"),
+        ("question_Enc_WikiMoon_1", "question"),
+        ("familiarity_rating_screen_1", "rating"),
+        ("familiarity_rating_screen_2", "rating"),
+        ("subject_difficulty_screen", "rating"),
+        ("unknown_page", "other"),
+    ],
+)
+def test_page_type(page, expected):
+    mdc = _make_mdc(_make_session())
+    assert mdc._page_type(page) == expected
 
 
 def test_compute_per_trial_loss_table_both_available():
@@ -34,7 +73,6 @@ def test_compute_per_trial_loss_table_both_available():
         {
             "trial": ["trial_1", "trial_2"],
             "stimulus": ["Enc_WikiMoon_1", "Lit_MagicMountain_6"],
-            "page": ["page_1", "page_1"],
             "data_loss_ratio": [0.05, 0.12],
         }
     )
@@ -42,15 +80,14 @@ def test_compute_per_trial_loss_table_both_available():
         {
             "trial": ["trial_1", "trial_2"],
             "stimulus": ["Enc_WikiMoon_1", "Lit_MagicMountain_6"],
-            "page": ["page_1", "page_1"],
             "blink_loss_ratio": [0.02, 0.03],
             "blink_duration_ms": [100.0, 150.0],
-            "trial_duration_ms": [5000.0, 5000.0],
+            "trial_duration_ms": [5000.0, 7000.0],
         }
     )
 
     mdc = _make_mdc(session)
-    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+    result = mdc._compute_per_trial_loss_table(SESSION_NAME)
 
     assert result is not None
     assert result.height == 2
@@ -58,61 +95,7 @@ def test_compute_per_trial_loss_table_both_available():
     assert "blink_loss_ratio" in result.columns
     assert result["data_loss_ratio"].to_list() == [0.05, 0.12]
     assert result["blink_loss_ratio"].to_list() == [0.02, 0.03]
-
-
-def test_compute_per_trial_loss_table_data_loss_only():
-    session = _make_session()
-    session._per_trial_data_loss = pl.DataFrame(
-        {
-            "trial": ["trial_1"],
-            "stimulus": ["Enc_WikiMoon_1"],
-            "page": ["page_1"],
-            "data_loss_ratio": [0.05],
-        }
-    )
-    session._per_trial_blink_loss = None
-
-    mdc = _make_mdc(session)
-    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
-
-    assert result is not None
-    assert result.height == 1
-    assert "data_loss_ratio" in result.columns
-    assert "blink_loss_ratio" not in result.columns
-
-
-def test_compute_per_trial_loss_table_blink_loss_only():
-    session = _make_session()
-    session._per_trial_data_loss = None
-    session._per_trial_blink_loss = pl.DataFrame(
-        {
-            "trial": ["trial_1"],
-            "stimulus": ["Enc_WikiMoon_1"],
-            "page": ["page_1"],
-            "blink_loss_ratio": [0.02],
-            "blink_duration_ms": [100.0],
-            "trial_duration_ms": [5000.0],
-        }
-    )
-
-    mdc = _make_mdc(session)
-    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
-
-    assert result is not None
-    assert result.height == 1
-    assert "data_loss_ratio" not in result.columns
-    assert "blink_loss_ratio" in result.columns
-
-
-def test_compute_per_trial_loss_table_none_available():
-    session = _make_session()
-    session._per_trial_data_loss = None
-    session._per_trial_blink_loss = None
-
-    mdc = _make_mdc(session)
-    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
-
-    assert result is None
+    assert result["trial_duration_ms"].to_list() == [5000.0, 7000.0]
 
 
 def test_compute_per_trial_loss_table_handles_missing_trials():
@@ -121,7 +104,6 @@ def test_compute_per_trial_loss_table_handles_missing_trials():
         {
             "trial": ["trial_1", "trial_2"],
             "stimulus": ["Enc_WikiMoon_1", "Lit_MagicMountain_6"],
-            "page": ["page_1", "page_2"],
             "data_loss_ratio": [0.05, 0.12],
         }
     )
@@ -129,7 +111,6 @@ def test_compute_per_trial_loss_table_handles_missing_trials():
         {
             "trial": ["trial_1"],
             "stimulus": ["Enc_WikiMoon_1"],
-            "page": ["page_1"],
             "blink_loss_ratio": [0.02],
             "blink_duration_ms": [100.0],
             "trial_duration_ms": [5000.0],
@@ -137,7 +118,7 @@ def test_compute_per_trial_loss_table_handles_missing_trials():
     )
 
     mdc = _make_mdc(session)
-    result = mdc._compute_per_trial_loss_table("001_EN_UK_1_ET1")
+    result = mdc._compute_per_trial_loss_table(SESSION_NAME)
 
     assert result is not None
     assert result.height == 2
@@ -146,3 +127,114 @@ def test_compute_per_trial_loss_table_handles_missing_trials():
     blink_ratios = result["blink_loss_ratio"].to_list()
     assert blink_ratios[0] == 0.02
     assert blink_ratios[1] is None
+
+
+def test_compute_per_page_loss_table_both_available():
+    session = _make_session()
+    session._per_page_data_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_1", "trial_2"],
+            "stimulus": ["Enc_WikiMoon_1", "Enc_WikiMoon_1", "Lit_MagicMountain_6"],
+            "page": ["page_1", "question_Enc_WikiMoon_1", "subject_difficulty_screen"],
+            "data_loss_ratio": [0.05, 0.10, 0.12],
+        }
+    )
+    session._per_page_blink_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_1", "trial_2"],
+            "stimulus": ["Enc_WikiMoon_1", "Enc_WikiMoon_1", "Lit_MagicMountain_6"],
+            "page": ["page_1", "question_Enc_WikiMoon_1", "subject_difficulty_screen"],
+            "blink_loss_ratio": [0.02, 0.03, 0.04],
+            "blink_duration_ms": [100.0, 200.0, 300.0],
+            "page_duration_ms": [5000.0, 6000.0, 7000.0],
+        }
+    )
+
+    mdc = _make_mdc(session)
+    result = mdc._compute_per_page_loss_table(SESSION_NAME)
+
+    assert result is not None
+    assert result.height == 3
+    assert "page_type" in result.columns
+    assert "page_duration_ms" in result.columns
+    assert result["data_loss_ratio"].to_list() == [0.05, 0.10, 0.12]
+    assert result["blink_loss_ratio"].to_list() == [0.02, 0.03, 0.04]
+    assert result["page_type"].to_list() == ["reading", "question", "rating"]
+    assert result["page_duration_ms"].to_list() == [5000.0, 6000.0, 7000.0]
+
+
+@pytest.mark.parametrize(
+    ("table_name", "cols", "include_data", "include_blink"),
+    [
+        ("_compute_per_trial_loss_table", TRIAL_COLS, True, False),
+        ("_compute_per_trial_loss_table", TRIAL_COLS, False, True),
+        ("_compute_per_trial_loss_table", TRIAL_COLS, False, False),
+        ("_compute_per_page_loss_table", PAGE_COLS, True, False),
+        ("_compute_per_page_loss_table", PAGE_COLS, False, False),
+    ],
+)
+def test_compute_loss_table_presence(table_name, cols, include_data, include_blink):
+    prefix = "per_page" if cols is PAGE_COLS else "per_trial"
+    session = _make_session()
+    setattr(
+        session, f"_{prefix}_data_loss", _data_loss_df(cols) if include_data else None
+    )
+    setattr(
+        session,
+        f"_{prefix}_blink_loss",
+        _blink_loss_df(cols) if include_blink else None,
+    )
+
+    mdc = _make_mdc(session)
+    result = getattr(mdc, table_name)(SESSION_NAME)
+
+    if result is None:
+        assert not include_data and not include_blink
+        return
+    assert result.height == 1
+    assert ("data_loss_ratio" in result.columns) == include_data
+    assert ("blink_loss_ratio" in result.columns) == include_blink
+    if prefix == "per_page":
+        assert "page_type" in result.columns
+
+
+def test_data_loss_by_page_type():
+    session = _make_session()
+    session._per_page_data_loss = pl.DataFrame(
+        {
+            "trial": ["trial_1", "trial_1", "trial_1", "trial_2"],
+            "stimulus": [
+                "Enc_WikiMoon_1",
+                "Enc_WikiMoon_1",
+                "Enc_WikiMoon_1",
+                "Lit_MagicMountain_6",
+            ],
+            "page": [
+                "page_1",
+                "page_2",
+                "familiarity_rating_screen_1",
+                "subject_difficulty_screen",
+            ],
+            "data_loss_ratio": [0.10, 0.20, 0.30, 0.40],
+        }
+    )
+    session._per_page_blink_loss = None
+
+    mdc = _make_mdc(session)
+    result = mdc._data_loss_by_page_type(SESSION_NAME)
+
+    assert result is not None
+    rows = {row["page_type"]: row for row in result.iter_rows(named=True)}
+    assert rows["reading"]["mean_data_loss"] == pytest.approx(0.15)
+    assert rows["reading"]["num_pages"] == 2
+    assert rows["rating"]["mean_data_loss"] == pytest.approx(0.35)
+    assert rows["rating"]["num_pages"] == 2
+
+
+def test_data_loss_by_page_type_none_available():
+    session = _make_session()
+    session._per_page_data_loss = None
+    session._per_page_blink_loss = None
+
+    mdc = _make_mdc(session)
+    assert mdc._data_loss_by_page_type(SESSION_NAME) is None


### PR DESCRIPTION
Follow-up to #210. The `per_trial_data_loss_{sid}.tsv` was actually per-page by accident, because the grouping used `gaze.trial_columns = ["trial", "stimulus", "page"]` (206 pages, not trials). This splits the output and corrects the report.

- Rename the old TSV to `per_page_data_loss_{sid}.tsv`, with a derived `page_type` column (`reading` / `question` / `rating`) and `page_duration_ms`.
- Add a `per_trial_data_loss_{sid}.tsv`, grouped by trial only.
- Report: mean now across **trials**, plus a per-page-type data-loss summary in the markdown.
- Trials are weighted equally: each per-trial value is time-weighted within the trial, but the across-trial mean is a plain, equal-weighted mean over trial rows (not weighted by trial length).
- Update `run_preprocessing.py`, `load.py`, and the sanity-report docs. add tests for `_page_type`, both table builders, and page-type aggregation.