### PR TITLE
feat(review): sort checks

### DIFF
--- a/docs/guide/sanity_check_report.md
+++ b/docs/guide/sanity_check_report.md
@@ -43,7 +43,7 @@ line is a bullet prefixed with `✅` if the value passes, or blank if it does no
 
   *Example:* `23`
 
-  *Acceptable:* 13–30 (`ACCEPTABLE_NUM_VALIDATION`).
+  *Acceptable:* 12–30 (`ACCEPTABLE_NUM_VALIDATION`).
 
   *Problematic:* Fewer than 12 means trials ran without validation, so calibration quality cannot be
   assessed for those trials.

--- a/preprocessing/config.py
+++ b/preprocessing/config.py
@@ -493,7 +493,7 @@ class Settings:
         self.ACCEPTABLE_NUM_CALIBRATIONS = [3, 30]
 
         #: Acceptable range (min, max) for the number of validations in a session.
-        self.ACCEPTABLE_NUM_VALIDATION = (13, 30)
+        self.ACCEPTABLE_NUM_VALIDATION = (12, 30)
 
         #: Acceptable range (min, max) for average validation accuracy scores.
         self.ACCEPTABLE_AVG_VALIDATION_SCORES = (0.0, 0.8)

--- a/review_app/services/preflight.py
+++ b/review_app/services/preflight.py
@@ -48,7 +48,7 @@ def run_pipeline_preflight(dcn_name: str, *, force: bool = False) -> dict:
     _orig_output = pipe_settings.OUTPUT_DIR
     try:
         pipe_settings.DATASET_DIR = RAW_DATA_DIR / dcn_name
-        pipe_settings.OUTPUT_DIR = PREPROCESSED_DATA_DIR
+        pipe_settings.OUTPUT_DIR = PREPROCESSED_DATA_DIR / dcn_name
         result = _do_run(dcn_name)
     finally:
         pipe_settings.DATASET_DIR = _orig_dataset

--- a/review_app/templates/session/_detail_content.html
+++ b/review_app/templates/session/_detail_content.html
@@ -127,7 +127,7 @@
       <table>
         <thead><tr><th>Check</th><th>Value</th><th>Threshold</th><th>Status</th></tr></thead>
         <tbody>
-        {% for c in detail.checks %}
+        {% for c in detail.checks | sort_checks %}
         <tr>
           <td>{{ c.label }}</td>
           <td>{{ c.value }}</td>

--- a/review_app/templating.py
+++ b/review_app/templating.py
@@ -1,6 +1,7 @@
 """Shared Jinja2 templates instance for the review app."""
 
 from pathlib import Path
+from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -35,12 +36,31 @@ def lang_name(code: str) -> str:
     return code
 
 
+def sort_checks(checks: list[Any]) -> list[Any]:
+    """Sort check results for the "All Checks" table.
+
+    Order is: checks with a threshold first, then checks without a
+    threshold, and finally checks whose value is "unknown". The sort is
+    stable, so the original registry order is preserved within each group.
+
+    :param checks: List of CheckResult-like objects.
+    :returns: A sorted copy of the list.
+    """
+    return sorted(
+        checks,
+        key=lambda c: (
+            2 if str(c.value).lower() == "unknown" else (0 if c.threshold else 1)
+        ),
+    )
+
+
 env = Environment(
     loader=FileSystemLoader(str(_TEMPLATE_DIR)),
     autoescape=select_autoescape(),
 )
 
 env.globals["lang_name"] = lang_name
+env.filters["sort_checks"] = sort_checks
 
 
 def render(name: str, **context) -> str:

--- a/tests/unit/preprocessing/checks/test_quality_thresholds.py
+++ b/tests/unit/preprocessing/checks/test_quality_thresholds.py
@@ -18,7 +18,7 @@ def test_write_quality_thresholds_creates_yaml(tmp_path: Path) -> None:
         data = yaml.safe_load(f)
 
     assert data["num_calibrations"] == [3, 30]
-    assert data["num_validations"] == [13, 30]
+    assert data["num_validations"] == [12, 30]
     assert data["avg_validation_error"][1] <= 0.8
     assert data["expected_sampling_rate_hz"] == 1000
     assert data["single_validation_good_max"] == 0.305

--- a/tests/unit/review_app/test_templating.py
+++ b/tests/unit/review_app/test_templating.py
@@ -1,0 +1,52 @@
+"""Tests for shared Jinja2 template helpers."""
+
+from review_app.models import CheckResult
+from review_app.templating import lang_name, sort_checks
+
+
+def _check(check_id: str, value: object, threshold: object | None) -> CheckResult:
+    return CheckResult(
+        check_id=check_id,
+        label=check_id,
+        value=value,
+        threshold=threshold,
+        status="pass",
+    )
+
+
+def test_sort_checks_orders_threshold_first_then_none_then_unknown() -> None:
+    checks = [
+        _check("no_threshold", 5, None),
+        _check("unknown_no_threshold", "unknown", None),
+        _check("with_threshold", 5, [0, 10]),
+        _check("unknown_with_threshold", "unknown", [0, 10]),
+    ]
+    result = [c.check_id for c in sort_checks(checks)]
+    assert result == [
+        "with_threshold",
+        "no_threshold",
+        "unknown_no_threshold",
+        "unknown_with_threshold",
+    ]
+
+
+def test_sort_checks_preserves_registry_order_within_groups() -> None:
+    checks = [
+        _check("a_no_threshold", 1, None),
+        _check("b_no_threshold", 2, None),
+    ]
+    result = [c.check_id for c in sort_checks(checks)]
+    assert result == ["a_no_threshold", "b_no_threshold"]
+
+
+def test_sort_checks_returns_new_list() -> None:
+    checks = [_check("with_threshold", 5, [0, 10])]
+    result = sort_checks(checks)
+    assert result == checks
+    assert result is not checks
+
+
+def test_lang_name() -> None:
+    assert lang_name("DE") == "German"
+    assert lang_name("ZD") == "Zurich (Swiss) German"
+    assert lang_name("XX") == "XX"


### PR DESCRIPTION
Three small improvements to the review web app.

1. Sort the "All Checks" table by threshold presence
On the session detail page, the All Checks table is now sorted so checks that have a threshold appear first, checks without a threshold follow, and checks whose value is unknown are placed at the bottom. The failed-checks section is unchanged. Ordering within each group preserves the existing registry order.

2. Lower the minimum acceptable validations to 12
The accepted range for the number of validations in a session was 13-30, but the documented intent is that fewer than 12 is unacceptable. The minimum is now 12. This value propagates into the generated quality-thresholds file that the review web reads, so existing collections pick it up on their next preprocessing run.

3. Fix the web preflight wrapper output directory
The web preflight check pointed the pipeline output directory at the preprocessed-data parent folder instead of the per-DCN subfolder used by the main preprocessing run. This caused the stimulus-folder resolution to fall back to the raw-data copy, which could parse a broken metadata-form JSON and fail collection initialization with an "Invalid control character" error. The wrapper now targets the per-DCN output directory, matching the main preprocessing entry point.